### PR TITLE
fix: adding users and showing quotas

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
   pull_request:
+    branches:
+      - 'main'
+      - 'hotfix/**'
 
 jobs:
   test:

--- a/src/k8s/clients.py
+++ b/src/k8s/clients.py
@@ -42,7 +42,7 @@ class K8sCoreClient(K8sCoreClientInterface):  # pragma:nocover
 
     def patch_namespaced_resource_quota(self, name: Any, namespace: Any, body: Any, **kwargs: Any) -> Any:
         """Update a resource quota."""
-        return self.client.delete_namespaced_resource_quota(name, namespace, body, **kwargs)
+        return self.client.patch_namespaced_resource_quota(name, namespace, body, **kwargs)
 
 
 class K8sSchedulingClient(K8sSchedudlingClientInterface):  # pragma:nocover

--- a/src/k8s/quota.py
+++ b/src/k8s/quota.py
@@ -121,3 +121,18 @@ class QuotaRepository:
         """Update a specific resource quota."""
         quota_manifest = self._quota_to_manifest(quota)
         self.core_client.patch_namespaced_resource_quota(name=quota.id, namespace=self.namespace, body=quota_manifest)
+
+    def hydrate_resource_pool_quota(self, resource_pool: models.ResourcePool) -> models.ResourcePool:
+        """Replace the resource pool quota ID with a quota model."""
+
+        if resource_pool.quota is None or isinstance(resource_pool.quota, models.Quota):
+            return resource_pool
+        if isinstance(resource_pool.quota, str):
+            quota = self._get_quota(resource_pool.quota)
+            return resource_pool.set_quota(quota)
+        else:
+            raise errors.BaseError(
+                message=f"Cannot find a quota for the resource pool with id {resource_pool.id}.",
+                detail="The quota field in the resource pool is expected to be either a string or "
+                f"`models.Quota` but we got {type(resource_pool.quota)}",
+            )

--- a/src/renku_crc/app.py
+++ b/src/renku_crc/app.py
@@ -150,6 +150,7 @@ class ResourcePoolsBP(CustomBlueprint):
         )
         if res is None:
             raise errors.MissingResourceError(message=f"The resource pool with ID {resource_pool_id} cannot be found.")
+        res = self.quota_repo.hydrate_resource_pool_quota(res)
         return json(apispec.ResourcePoolWithId.from_orm(res).dict(exclude_none=True))
 
 

--- a/src/renku_crc/blueprint.py
+++ b/src/renku_crc/blueprint.py
@@ -29,8 +29,8 @@ class CustomBlueprint:
         members = getmembers(self, ismethod)
         for name, method in members:
             if name != "blueprint" and not name.startswith("_"):
-                method = cast(BlueprintFactory, method)
-                url, http_methods, handler = method()
+                method_factory = cast(BlueprintFactory, method)
+                url, http_methods, handler = method_factory()
                 bp.add_route(handler=handler, uri=url, methods=http_methods)
         for req_mw in self.request_middlewares:
             bp.middleware("request")(req_mw)


### PR DESCRIPTION
A few issues here that @rokroskar found:
- The response from some endpoints fail because we expect to get a full quota in the response but internally in some cases the quota could also just be a string. So these cases were breaking the API. Now I have addressed this.
- Patching a resource pool was calling the method to delete the resource pool, and luckily this was failing, I have corrected this now so it should work