### PR TITLE
fix: path regex and private storage handling

### DIFF
--- a/bases/renku_data_services/data_api/server_options.py
+++ b/bases/renku_data_services/data_api/server_options.py
@@ -6,7 +6,7 @@ is added.
 """
 from typing import Any, List
 
-from pydantic import BaseModel, ByteSize, Extra, Field, validator
+from pydantic import BaseModel, ByteSize, Field, validator
 
 import renku_data_services.resource_pool_models as models
 
@@ -28,14 +28,14 @@ class ServerOptionsDefaults(BaseModel):
     class Config:
         """Configuration."""
 
-        extra = Extra.ignore
+        extra = "ignore"
 
 
 class _ServerOptionsCpu(BaseModel):
-    options: List[float] = Field(min_items=1)
+    options: List[float] = Field(min_length=1)
 
     class Config:
-        extra = Extra.ignore
+        extra = "ignore"
 
     @validator("options", pre=False, each_item=True)
     def greater_than_zero(cls, val):
@@ -43,10 +43,10 @@ class _ServerOptionsCpu(BaseModel):
 
 
 class _ServerOptionsGpu(BaseModel):
-    options: List[int] = Field(min_items=1)
+    options: List[int] = Field(min_length=1)
 
     class Config:
-        extra = Extra.ignore
+        extra = "ignore"
 
     @validator("options", pre=False, each_item=True)
     def greater_than_or_equal_to_zero(cls, v):
@@ -56,10 +56,10 @@ class _ServerOptionsGpu(BaseModel):
 
 
 class _ServerOptionsBytes(BaseModel):
-    options: List[ByteSize] = Field(min_items=1)
+    options: List[ByteSize] = Field(min_length=1)
 
     class Config:
-        extra = Extra.ignore
+        extra = "ignore"
 
     @validator("options", pre=True)
     def convert_units(cls, vals):
@@ -84,7 +84,7 @@ class ServerOptions(BaseModel):
     class Config:
         """Configuration."""
 
-        extra = Extra.ignore
+        extra = "ignore"
 
     def find_largest_attribute(self) -> str:
         """Find the attribute with the largest number of choices."""

--- a/components/renku_data_services/errors/errors.py
+++ b/components/renku_data_services/errors/errors.py
@@ -12,6 +12,14 @@ class BaseError(Exception):
     message: str = "An unexpected error occured"
     detail: Optional[str] = None
 
+    def __repr__(self):
+        """String representation of the error."""
+        return f"{self.__class__.__qualname__}: {self.message}"
+
+    def __str__(self):
+        """String representation of the error."""
+        return f"{self.__class__.__qualname__}: {self.message}"
+
 
 @dataclass
 class MissingResourceError(BaseError):

--- a/components/renku_data_services/storage_adapters/schemas.py
+++ b/components/renku_data_services/storage_adapters/schemas.py
@@ -78,7 +78,7 @@ class CloudStorageORM(BaseORM):
             project_id=self.project_id,
             name=self.name,
             storage_type=self.storage_type,
-            configuration=models.RCloneConfig(config=self.configuration),
+            configuration=models.RCloneConfig(config=self.configuration, private=self.private),
             source_path=self.source_path,
             target_path=self.target_path,
             storage_id=self.storage_id,

--- a/components/renku_data_services/storage_models/core.py
+++ b/components/renku_data_services/storage_models/core.py
@@ -15,19 +15,13 @@ class RCloneConfig(BaseModel, MutableMapping):
 
     config: dict[str, Any] = Field(exclude=True)
 
+    private: bool = Field(exclude=True)
     _validator: RCloneValidator = PrivateAttr(default=RCloneValidator())
-
-    @model_validator(mode="before")
-    def check_if_from_dict(cls, data: Any) -> Any:
-        """Check if the class was created from a plain dict or an already wrapped dict."""
-        if isinstance(data, dict) and {"config"} != data.keys():
-            data = {"config": data}
-        return data
 
     @model_validator(mode="after")
     def check_rclone_schema(self) -> "RCloneConfig":
         """Validate that the reclone config is valid."""
-        self._validator.validate(self.config)
+        self._validator.validate(self.config, private=self.private)
         return self
 
     @model_serializer
@@ -43,11 +37,11 @@ class RCloneConfig(BaseModel, MutableMapping):
 
     def __setitem__(self, key, value):
         self.config[key] = value
-        self._validator.validate(self.config)
+        self._validator.validate(self.config, private=self.private)
 
     def __delitem__(self, key):
         del self.config[key]
-        self._validator.validate(self.config)
+        self._validator.validate(self.config, private=self.private)
 
     def __iter__(self):
         return iter(self.config)
@@ -64,14 +58,14 @@ class CloudStorage(BaseModel):
 
     storage_id: str | None = Field(default=None)
 
-    source_path: str = Field(pattern=r"^((\w+/)*?\w+)$")
+    source_path: str = Field(pattern=r"^(([\w\-]+/)*?\w+)$")
     """Path inside the cloud storage.
 
     Note: Since rclone itself doesn't really know about buckets/containers (they're not in the schema),
     bucket/container/etc. has to be the first part of source path.
     """
 
-    target_path: str = Field(pattern=r"^(\w+/)*?\w+$")
+    target_path: str = Field(pattern=r"^([\w\-]+/)*?\w+$")
     """Path inside the target repository to mouhnt/clone data to."""
 
     @classmethod
@@ -92,15 +86,16 @@ class CloudStorage(BaseModel):
         if "type" not in data["configuration"]:
             raise errors.ValidationError(message="'type' not set in 'configuration'")
 
+        private = data.get("private", False)
         return cls(
             project_id=data["project_id"],
             storage_id=data.get("storage_id"),
             name=data["name"],
-            configuration=RCloneConfig(config=data["configuration"]),
+            configuration=RCloneConfig(config=data["configuration"], private=private),
             storage_type=data["configuration"]["type"],
             source_path=data["source_path"],
             target_path=data["target_path"],
-            private=data.get("private", False),
+            private=private,
         )
 
     @classmethod
@@ -170,7 +165,7 @@ class CloudStorage(BaseModel):
             project_id=project_id,
             name=name,
             storage_type="s3",
-            configuration=RCloneConfig(config=configuration),
+            configuration=RCloneConfig(config=configuration, private=private),
             source_path=source_path,
             target_path=target_path,
             private=private,
@@ -206,7 +201,7 @@ class CloudStorage(BaseModel):
             project_id=project_id,
             name=name,
             storage_type="azureblob",
-            configuration=RCloneConfig(config=configuration),
+            configuration=RCloneConfig(config=configuration, private=private),
             source_path=source_path,
             target_path=target_path,
             private=private,

--- a/components/renku_data_services/storage_models/core.py
+++ b/components/renku_data_services/storage_models/core.py
@@ -58,14 +58,14 @@ class CloudStorage(BaseModel):
 
     storage_id: str | None = Field(default=None)
 
-    source_path: str = Field(pattern=r"^(([\w\-]+/)*?\w+)$")
+    source_path: str = Field(min_length=1)
     """Path inside the cloud storage.
 
     Note: Since rclone itself doesn't really know about buckets/containers (they're not in the schema),
     bucket/container/etc. has to be the first part of source path.
     """
 
-    target_path: str = Field(pattern=r"^([\w\-]+/)*?\w+$")
+    target_path: str = Field(min_length=1)
     """Path inside the target repository to mouhnt/clone data to."""
 
     @classmethod

--- a/components/renku_data_services/storage_schemas/api.spec.yaml
+++ b/components/renku_data_services/storage_schemas/api.spec.yaml
@@ -240,6 +240,9 @@ components:
           type: string
           description: the target path relative to the repository where the storage should be mounted
           example: my/project/folder
+        private:
+          type: boolean
+          description: Whether this storage is private (i.e. requires credentials) or not
     CloudStorageWithId:
       allOf:
         - $ref: "#/components/schemas/CloudStorage"

--- a/components/renku_data_services/storage_schemas/apispec.py
+++ b/components/renku_data_services/storage_schemas/apispec.py
@@ -133,6 +133,9 @@ class CloudStoragePatch(BaseAPISpec):
         description="the target path relative to the repository where the storage should be mounted",
         example="my/project/folder",
     )
+    private: Optional[bool] = Field(
+        None, description="Whether this storage is private (i.e. requires credentials) or not"
+    )
 
 
 class CloudStorageWithId(CloudStorage):

--- a/components/renku_data_services/storage_schemas/core.py
+++ b/components/renku_data_services/storage_schemas/core.py
@@ -65,11 +65,20 @@ class RCloneValidator:
         for patch in patches:
             patch(spec)
 
-    def validate(self, configuration: Union["RCloneConfig", dict[str, Any]], keep_sensitive: bool = False):
+    def validate(
+        self, configuration: Union["RCloneConfig", dict[str, Any]], private: bool = False, keep_sensitive: bool = False
+    ):
         """Validates an RClone config."""
         provider = self.get_provider(configuration)
 
-        provider.validate_config(configuration, keep_sensitive=keep_sensitive)
+        provider.validate_config(configuration, private=private, keep_sensitive=keep_sensitive)
+
+    def remove_sensitive_options_from_config(self, configuration: Union["RCloneConfig", dict[str, Any]]):
+        """Remove sensitive fields from a config, e.g. when turning a private storage public."""
+
+        provider = self.get_provider(configuration)
+
+        provider.remove_sensitive_options_from_config(configuration)
 
     def get_provider(self, configuration: Union["RCloneConfig", dict[str, Any]]) -> "RCloneProviderSchema":
         """Get a provider for configuration."""
@@ -137,6 +146,11 @@ class RCloneOption(BaseModel):
     value_str: str = Field(alias="ValueStr")
     type: str = Field(alias="Type")
 
+    @property
+    def is_sensitive(self):
+        """Whether this options is sensitive (e.g. credentials) or not."""
+        return self.sensitive or self.is_password
+
     def matches_provider(self, provider: str | None) -> bool:
         """Check if this option applies for a provider.
 
@@ -163,7 +177,7 @@ class RCloneOption(BaseModel):
         Sensitive values are replaced with '<sensitive>' placeholders that clients are expected to handle.
         The placeholders indicate that a value should be there without storing the value.
         """
-        if not keep_sensitive and (self.sensitive or self.is_password):
+        if not keep_sensitive and self.is_sensitive:
             return "<sensitive>"
         match self.type:
             case "int" | "Duration" | "SizeSuffix" | "MultiEncoder":
@@ -209,7 +223,7 @@ class RCloneProviderSchema(BaseModel):
     @property
     def sensitive_options(self) -> list[RCloneOption]:
         """Returns all sensitive options for this provider."""
-        return [o for o in self.options if o.sensitive or o.is_password]
+        return [o for o in self.options if o.is_sensitive]
 
     def get_option_for_provider(self, name: str, provider: str | None) -> RCloneOption | None:
         """Get an RClone option matching a provider."""
@@ -221,7 +235,9 @@ class RCloneProviderSchema(BaseModel):
 
         return None
 
-    def validate_config(self, configuration: Union["RCloneConfig", dict[str, Any]], keep_sensitive: bool = False):
+    def validate_config(
+        self, configuration: Union["RCloneConfig", dict[str, Any]], private: bool = False, keep_sensitive: bool = False
+    ):
         """Validate an RClone config."""
         keys = set(configuration.keys()) - {"type"}
         provider: str | None = configuration.get("provider")  # type: ignore
@@ -242,6 +258,14 @@ class RCloneProviderSchema(BaseModel):
             missing_str = "\n".join(missing)
             raise errors.ValidationError(message=f"The following fields are required but missing:\n{missing_str}")
 
+        if not private:
+            for sensitive in self.sensitive_options:
+                if sensitive.name in configuration:
+                    raise errors.ValidationError(
+                        message=f"Setting value for field '{sensitive.name}', which is sensitive, is not allowed for"
+                        " public storage"
+                    )
+
         for key in keys:
             value = configuration[key]
 
@@ -260,6 +284,12 @@ class RCloneProviderSchema(BaseModel):
 
             configuration[key] = option.validate_config(value, provider=provider, keep_sensitive=keep_sensitive)
 
+    def remove_sensitive_options_from_config(self, configuration: Union["RCloneConfig", dict[str, Any]]):
+        """Remove sensitive options from configuration."""
+        for sensitive in self.sensitive_options:
+            if sensitive.name in configuration:
+                del configuration[sensitive.name]
+
     def get_private_fields(
         self, configuration: Union["RCloneConfig", dict[str, Any]]
     ) -> Generator[RCloneOption, None, None]:
@@ -267,7 +297,7 @@ class RCloneProviderSchema(BaseModel):
         provider: str | None = configuration.get("provider")  # type: ignore
 
         for option in self.options:
-            if not option.sensitive and not option.is_password:
+            if not option.is_sensitive:
                 continue
             if option.advanced:
                 continue

--- a/test/bases/renku_data_services/data_api/test_storage.py
+++ b/test/bases/renku_data_services/data_api/test_storage.py
@@ -155,6 +155,23 @@ def storage_test_client(
                 },
                 "source_path": "bucket/myfolder",
                 "target_path": "my/target",
+                "private": False,
+            },
+            422,
+            "",
+        ),
+        (
+            {
+                "project_id": "123456",
+                "name": "mystorage",
+                "configuration": {
+                    "type": "s3",
+                    "provider": "AWS",
+                    "secret_access_key": "1234567",  # passing in secret
+                },
+                "source_path": "bucket/myfolder",
+                "target_path": "my/target",
+                "private": True,
             },
             201,
             "s3",
@@ -225,8 +242,8 @@ def storage_test_client(
                     "provider": "AWS",
                     "region": "us-east-1",
                 },
-                "source_path": "bucket/myfolder",
-                "target_path": "my/target",
+                "source_path": "bucket/my-folder",
+                "target_path": "my/my-target",
             },
             422,
             "",
@@ -416,11 +433,49 @@ async def test_storage_put(storage_test_client, valid_storage_payload):
                 "configuration": {"type": "azureblob"},
                 "source_path": "bucket/myfolder",
                 "target_path": "my/target",
+                "private": True,
             }
         ),
     )
     assert res.status_code == 200
     assert res.json["storage_type"] == "azureblob"
+    assert res.json["private"]
+
+
+@pytest.mark.asyncio
+async def test_storage_patch_make_public(storage_test_client):
+    payload = {
+        "project_id": "123456",
+        "name": "mystorage",
+        "configuration": {"type": "s3", "provider": "AWS", "region": "us-east-1", "access_key_id": "my-secret"},
+        "source_path": "bucket/myfolder",
+        "target_path": "my/target",
+        "private": "true",
+    }
+    storage_test_client, _ = storage_test_client
+    _, res = await storage_test_client.post(
+        "/api/data/storage",
+        headers={"Authorization": "bearer test"},
+        data=json.dumps(payload),
+    )
+    assert res.status_code == 201
+    assert res.json["storage_type"] == "s3"
+    assert res.json["private"]
+    assert "access_key_id" in res.json["configuration"]
+    storage_id = res.json["storage_id"]
+
+    _, res = await storage_test_client.patch(
+        f"/api/data/storage/{storage_id}",
+        headers={"Authorization": "bearer test"},
+        data=json.dumps(
+            {
+                "private": False,
+            }
+        ),
+    )
+    assert res.status_code == 200
+    assert not res.json["private"]
+    assert "access_key_id" not in res.json["configuration"]
 
 
 @pytest.mark.asyncio

--- a/test/bases/renku_data_services/data_api/test_storage.py
+++ b/test/bases/renku_data_services/data_api/test_storage.py
@@ -267,9 +267,9 @@ async def test_storage_creation(
     assert res.status_code == expected_status_code
     assert res.json
     if res.status_code < 300:
-        assert res.json["storage_type"] == expected_storage_type
-        assert res.json["name"] == payload["name"]
-        assert res.json["target_path"] == payload["target_path"]
+        assert res.json["storage"]["storage_type"] == expected_storage_type
+        assert res.json["storage"]["name"] == payload["name"]
+        assert res.json["storage"]["target_path"] == payload["target_path"]
 
 
 @pytest.mark.asyncio
@@ -281,7 +281,7 @@ async def test_create_storage_duplicate_name(storage_test_client, valid_storage_
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
+    assert res.json["storage"]["storage_type"] == "s3"
 
     _, res = await storage_test_client.post(
         "/api/data/storage",
@@ -300,9 +300,9 @@ async def test_get_storage(storage_test_client, valid_storage_payload):
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
+    assert res.json["storage"]["storage_type"] == "s3"
 
-    project_id = res.json["project_id"]
+    project_id = res.json["storage"]["project_id"]
     _, res = await storage_test_client.get(
         f"/api/data/storage?project_id={project_id}",
         headers={"Authorization": "bearer test"},
@@ -325,9 +325,9 @@ async def test_get_storage_unauthorized(storage_test_client, valid_storage_paylo
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
+    assert res.json["storage"]["storage_type"] == "s3"
 
-    project_id = res.json["project_id"]
+    project_id = res.json["storage"]["project_id"]
     gl_auth.project_id = "9999999"
     _, res = await storage_test_client.get(
         f"/api/data/storage?project_id={project_id}",
@@ -347,9 +347,9 @@ async def test_get_storage_private(storage_test_client, valid_storage_payload):
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
+    assert res.json["storage"]["storage_type"] == "s3"
 
-    project_id = res.json["project_id"]
+    project_id = res.json["storage"]["project_id"]
     _, res = await storage_test_client.get(
         f"/api/data/storage?project_id={project_id}",
         headers={"Authorization": "bearer test"},
@@ -375,8 +375,8 @@ async def test_storage_deletion(storage_test_client, valid_storage_payload):
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
-    storage_id = res.json["storage_id"]
+    assert res.json["storage"]["storage_type"] == "s3"
+    storage_id = res.json["storage"]["storage_id"]
 
     _, res = await storage_test_client.delete(
         f"/api/data/storage/{storage_id}",
@@ -401,8 +401,8 @@ async def test_storage_deletion_unauthorized(storage_test_client, valid_storage_
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
-    storage_id = res.json["storage_id"]
+    assert res.json["storage"]["storage_type"] == "s3"
+    storage_id = res.json["storage"]["storage_id"]
     gl_auth.project_id = "999999"
     _, res = await storage_test_client.delete(
         f"/api/data/storage/{storage_id}",
@@ -420,8 +420,8 @@ async def test_storage_put(storage_test_client, valid_storage_payload):
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
-    storage_id = res.json["storage_id"]
+    assert res.json["storage"]["storage_type"] == "s3"
+    storage_id = res.json["storage"]["storage_id"]
 
     _, res = await storage_test_client.put(
         f"/api/data/storage/{storage_id}",
@@ -438,8 +438,8 @@ async def test_storage_put(storage_test_client, valid_storage_payload):
         ),
     )
     assert res.status_code == 200
-    assert res.json["storage_type"] == "azureblob"
-    assert res.json["private"]
+    assert res.json["storage"]["storage_type"] == "azureblob"
+    assert res.json["storage"]["private"]
 
 
 @pytest.mark.asyncio
@@ -459,10 +459,10 @@ async def test_storage_patch_make_public(storage_test_client):
         data=json.dumps(payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
-    assert res.json["private"]
-    assert "access_key_id" in res.json["configuration"]
-    storage_id = res.json["storage_id"]
+    assert res.json["storage"]["storage_type"] == "s3"
+    assert res.json["storage"]["private"]
+    assert "access_key_id" in res.json["storage"]["configuration"]
+    storage_id = res.json["storage"]["storage_id"]
 
     _, res = await storage_test_client.patch(
         f"/api/data/storage/{storage_id}",
@@ -474,8 +474,8 @@ async def test_storage_patch_make_public(storage_test_client):
         ),
     )
     assert res.status_code == 200
-    assert not res.json["private"]
-    assert "access_key_id" not in res.json["configuration"]
+    assert not res.json["storage"]["private"]
+    assert "access_key_id" not in res.json["storage"]["configuration"]
 
 
 @pytest.mark.asyncio
@@ -487,8 +487,8 @@ async def test_storage_put_unauthorized(storage_test_client, valid_storage_paylo
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
-    storage_id = res.json["storage_id"]
+    assert res.json["storage"]["storage_type"] == "s3"
+    storage_id = res.json["storage"]["storage_id"]
     gl_auth.project_id = "999999"
     _, res = await storage_test_client.put(
         f"/api/data/storage/{storage_id}",
@@ -515,8 +515,8 @@ async def test_storage_patch(storage_test_client, valid_storage_payload):
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
-    storage_id = res.json["storage_id"]
+    assert res.json["storage"]["storage_type"] == "s3"
+    storage_id = res.json["storage"]["storage_id"]
 
     _, res = await storage_test_client.patch(
         f"/api/data/storage/{storage_id}",
@@ -529,9 +529,9 @@ async def test_storage_patch(storage_test_client, valid_storage_payload):
         ),
     )
     assert res.status_code == 200
-    assert res.json["storage_type"] == "azureblob"
-    assert res.json["source_path"] == "bucket/myotherfolder"
-    assert "region" not in res.json["configuration"]
+    assert res.json["storage"]["storage_type"] == "azureblob"
+    assert res.json["storage"]["source_path"] == "bucket/myotherfolder"
+    assert "region" not in res.json["storage"]["configuration"]
 
 
 @pytest.mark.asyncio
@@ -543,8 +543,8 @@ async def test_storage_patch_unauthorized(storage_test_client, valid_storage_pay
         data=json.dumps(valid_storage_payload),
     )
     assert res.status_code == 201
-    assert res.json["storage_type"] == "s3"
-    storage_id = res.json["storage_id"]
+    assert res.json["storage"]["storage_type"] == "s3"
+    storage_id = res.json["storage"]["storage_id"]
     gl_auth.project_id = "999999"
     _, res = await storage_test_client.patch(
         f"/api/data/storage/{storage_id}",


### PR DESCRIPTION
Paths now allow everything

Validation logic for private/public is a bit more advanced now:
- Sending a private field for storage marked public results in an error
- Sending a private field for storage marked private replaces the private values with `<sensitive>`
- Changing (PATCH) storage from private to public removes the `<sensitive>` entries

All endpoints that return a cloud storage return `sensitive_fields` now