### PR TITLE
fix: run sanic in single process

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ../..:/workspaces:cached
 
     # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity
+    entrypoint: sleep infinity
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -24,13 +24,14 @@ jobs:
       renku-gateway: ${{ steps.deploy-comment.outputs.renku-gateway}}
       renku-graph: ${{ steps.deploy-comment.outputs.renku-graph}}
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
+      renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services }}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       test-cypress-enabled: ${{ steps.deploy-comment.outputs.test-cypress-enabled}}
       persist: ${{ steps.deploy-comment.outputs.persist}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.5.2
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.8.4
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -60,7 +61,7 @@ jobs:
           body: |
             You can access the deployment of this PR at https://renku-ci-ds-${{ github.event.number }}.dev.renku.ch
       - name: Build and deploy
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.5.2
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.8.4
         env:
           RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
@@ -82,6 +83,7 @@ jobs:
           renku_gateway: "${{ needs.check-deploy.outputs.renku-gateway }}"
           renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
           renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
+          renku_data_services: "${{ needs.check-deploy.outputs.renku-data-services }}"
           extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
 
   selenium-acceptance-tests:
@@ -89,7 +91,7 @@ jobs:
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.5.2
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.8.4
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: renku-ci-ds-${{ github.event.number }}
@@ -116,7 +118,7 @@ jobs:
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.5.2
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.8.4
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ env.RENKU_REFERENCE }}
@@ -144,7 +146,7 @@ jobs:
           body: |
             Tearing down the temporary RenkuLab deplyoment for this PR.
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.5.2
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.8.4
         env:
           HELM_RELEASE_REGEX: "^renku-ci-ds-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -24,7 +24,6 @@ jobs:
       renku-gateway: ${{ steps.deploy-comment.outputs.renku-gateway}}
       renku-graph: ${{ steps.deploy-comment.outputs.renku-graph}}
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
-      renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services }}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       test-cypress-enabled: ${{ steps.deploy-comment.outputs.test-cypress-enabled}}
       persist: ${{ steps.deploy-comment.outputs.persist}}
@@ -70,7 +69,7 @@ jobs:
           KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
           RENKU_RELEASE: renku-ci-ds-${{ github.event.number }}
           RENKU_VALUES_FILE: ${{ github.workspace }}/values.yaml
-          RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
+          RENKU_VALUES: ${{ secrets.COMBINED_CHARTS_CI_RENKU_VALUES }}
           RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
           RANCHER_DEV_API_ENDPOINT: ${{ secrets.RANCHER_DEV_API_ENDPOINT }}
@@ -83,7 +82,7 @@ jobs:
           renku_gateway: "${{ needs.check-deploy.outputs.renku-gateway }}"
           renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
           renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
-          renku_data_services: "${{ needs.check-deploy.outputs.renku-data-services }}"
+          renku_data_services: "@${{ github.head_ref }}"
           extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
 
   selenium-acceptance-tests:

--- a/projects/renku_data_service/Dockerfile
+++ b/projects/renku_data_service/Dockerfile
@@ -33,5 +33,5 @@ RUN apt-get update && apt-get install -y \
 USER $USER_UID:$USER_GID
 WORKDIR /app
 COPY --from=builder /app/env ./env
-ENTRYPOINT ["tini", "-g", "--"]
-CMD ["tini", "-g", "--", "env/bin/python", "-m", "renku_data_services.data_api.main", "--fast"]
+ENTRYPOINT ["tini", "-g", "--", "env/bin/python", "-m", "renku_data_services.data_api.main"]
+CMD ["--single-process"]

--- a/projects/renku_data_service/Dockerfile
+++ b/projects/renku_data_service/Dockerfile
@@ -34,4 +34,3 @@ USER $USER_UID:$USER_GID
 WORKDIR /app
 COPY --from=builder /app/env ./env
 ENTRYPOINT ["tini", "-g", "--", "env/bin/python", "-m", "renku_data_services.data_api.main"]
-CMD ["--single-process"]


### PR DESCRIPTION
The defaults we had before were weird. also we were running with `--fast` which takes up way too many replicas of itself because it decides this based on the total number of cpus and when it runs on k8s it sees the total cpus on the node not the total cpus allocated to the pod.
