### PR TITLE
fix: properly validate quotas

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -25,7 +25,6 @@ def register_all_handlers(app: Sanic, config: Config) -> Sanic:
         rp_repo=config.rp_repo,
         authenticator=config.authenticator,
         user_repo=config.user_repo,
-        quota_repo=config.quota_repo,
     )
     classes = ClassesBP(name="classes", url_prefix=url_prefix, repo=config.rp_repo, authenticator=config.authenticator)
     quota = QuotaBP(
@@ -50,7 +49,6 @@ def register_all_handlers(app: Sanic, config: Config) -> Sanic:
         url_prefix=url_prefix,
         repo=config.user_repo,
         authenticator=config.authenticator,
-        quota_repo=config.quota_repo,
     )
     storage = StorageBP(
         name="storage",

--- a/bases/renku_data_services/data_api/config.py
+++ b/bases/renku_data_services/data_api/config.py
@@ -178,9 +178,13 @@ class Config:
         async_sqlalchemy_url = f"postgresql+asyncpg://{pg_user}:{pg_password}@{pg_host}:{pg_port}/{db_name}"
         sync_sqlalchemy_url = f"postgresql+psycopg://{pg_user}:{pg_password}@{pg_host}:{pg_port}/{db_name}"
 
-        user_repo = UserRepository(sync_sqlalchemy_url=sync_sqlalchemy_url, async_sqlalchemy_url=async_sqlalchemy_url)
+        user_repo = UserRepository(
+            sync_sqlalchemy_url=sync_sqlalchemy_url, async_sqlalchemy_url=async_sqlalchemy_url, quotas_repo=quota_repo
+        )
         rp_repo = ResourcePoolRepository(
-            sync_sqlalchemy_url=sync_sqlalchemy_url, async_sqlalchemy_url=async_sqlalchemy_url
+            sync_sqlalchemy_url=sync_sqlalchemy_url,
+            async_sqlalchemy_url=async_sqlalchemy_url,
+            quotas_repo=quota_repo,
         )
         storage_repo = StorageRepository(
             gitlab_client=gitlab_client,

--- a/components/renku_data_services/crc/blueprints.py
+++ b/components/renku_data_services/crc/blueprints.py
@@ -1,7 +1,7 @@
 """Compute resource control (CRC) app."""
 import asyncio
 from dataclasses import asdict, dataclass
-from typing import List, cast
+from typing import List
 
 from sanic import HTTPResponse, Request, json
 from sanic_ext import validate
@@ -23,7 +23,6 @@ class ResourcePoolsBP(CustomBlueprint):
     rp_repo: ResourcePoolRepository
     user_repo: UserRepository
     authenticator: base_models.Authenticator
-    quota_repo: QuotaRepository
 
     def get_all(self) -> BlueprintFactoryResponse:
         """List all resource pools."""
@@ -32,12 +31,8 @@ class ResourcePoolsBP(CustomBlueprint):
         async def _get_all(request: Request, user: base_models.APIUser):
             res_filter = ResourceClassesFilter.model_validate(dict(request.query_args))
             rps = await self.rp_repo.filter_resource_pools(api_user=user, **res_filter.dict())
-            rps_w_quota = [self.quota_repo.hydrate_resource_pool_quota(rp) for rp in rps]
             return json(
-                [
-                    apispec.ResourcePoolWithIdFiltered.model_validate(r).model_dump(exclude_none=True)
-                    for r in rps_w_quota
-                ]
+                [apispec.ResourcePoolWithIdFiltered.model_validate(r).model_dump(exclude_none=True) for r in rps]
             )
 
         return "/resource_pools", ["GET"], _get_all
@@ -50,13 +45,7 @@ class ResourcePoolsBP(CustomBlueprint):
         @validate(json=apispec.ResourcePool)
         async def _post(_: Request, body: apispec.ResourcePool, user: base_models.APIUser):
             rp = models.ResourcePool.from_dict(body.model_dump(exclude_none=True))
-            if not isinstance(rp.quota, models.Quota):
-                raise errors.ValidationError(message="The quota in the resource pool is malformed.")
-            quota_with_id = rp.quota.generate_id()
-            rp = rp.set_quota(quota_with_id)
-            self.quota_repo.create_quota(quota_with_id)
             res = await self.rp_repo.insert_resource_pool(api_user=user, resource_pool=rp)
-            res = res.set_quota(quota_with_id)
             return json(apispec.ResourcePoolWithId.model_validate(res).model_dump(exclude_none=True), 201)
 
         return "/resource_pools", ["POST"], _post
@@ -75,7 +64,6 @@ class ResourcePoolsBP(CustomBlueprint):
                     message=f"The resource pool with id {resource_pool_id} cannot be found."
                 )
             rp = rps[0]
-            rp = self.quota_repo.hydrate_resource_pool_quota(rp)
             return json(apispec.ResourcePoolWithId.model_validate(rp).model_dump(exclude_none=True))
 
         return "/resource_pools/<resource_pool_id>", ["GET"], _get_one
@@ -86,9 +74,7 @@ class ResourcePoolsBP(CustomBlueprint):
         @authenticate(self.authenticator)
         @only_admins
         async def _delete(_: Request, resource_pool_id: int, user: base_models.APIUser):
-            rp = await self.rp_repo.delete_resource_pool(api_user=user, id=resource_pool_id)
-            if rp is not None and isinstance(rp.quota, str):
-                self.quota_repo.delete_quota(rp.quota)
+            await self.rp_repo.delete_resource_pool(api_user=user, id=resource_pool_id)
             return HTTPResponse(status=204)
 
         return "/resource_pools/<resource_pool_id>", ["DELETE"], _delete
@@ -122,42 +108,11 @@ class ResourcePoolsBP(CustomBlueprint):
         body: apispec.ResourcePoolPut | apispec.ResourcePoolPatch,
     ):
         body_dict = body.model_dump(exclude_none=True)
-        quota_req = body_dict.pop("quota", None)
-        rps = await self.rp_repo.get_resource_pools(api_user, resource_pool_id)
-        if len(rps) == 0:
-            raise errors.ValidationError(message=f"The resource pool with ID {resource_pool_id} does not exist.")
-        rp = rps[0]
-        rp = self.quota_repo.hydrate_resource_pool_quota(rp)
-        match rp.quota, quota_req:
-            case _, None:
-                # No quota is specified in request
-                pass
-            case _, dict(quota_req) if not quota_req:
-                # No quota is specified in request
-                pass
-            case models.Quota(id=None), {}:
-                # The quota does not exist, create it
-                quota_req["id"] = None  # ensure that the id is None to make a new Quota
-                quota_req_model = models.Quota.from_dict(quota_req).generate_id()
-                self.quota_repo.create_quota(quota_req_model)
-                rp.set_quota(quota_req_model)
-            case models.Quota(id=_), {}:
-                # The quota exists already, update it
-                if quota_req.get("id") is not None:
-                    raise errors.ValidationError(message="Cannot update the ID of an existing quota.")
-                if not isinstance(rp.quota, models.Quota):
-                    raise errors.BaseError(message=f"Expected quota but got {type(rp.quota)}")
-                new_quota = models.Quota.from_dict({**asdict(rp.quota), **quota_req})
-                self.quota_repo.update_quota(new_quota)
-                rp.set_quota(new_quota)
         res = await self.rp_repo.update_resource_pool(
             api_user=api_user,
             id=resource_pool_id,
             **body_dict,
         )
-        if res is None:
-            raise errors.MissingResourceError(message=f"The resource pool with ID {resource_pool_id} cannot be found.")
-        res = self.quota_repo.hydrate_resource_pool_quota(res)
         return json(apispec.ResourcePoolWithId.model_validate(res).model_dump(exclude_none=True))
 
 
@@ -379,7 +334,6 @@ class QuotaBP(CustomBlueprint):
                     message=f"The resource pool with ID {resource_pool_id} cannot be found."
                 )
             rp = rps[0]
-            rp = self.quota_repo.hydrate_resource_pool_quota(rp)
             if rp.quota is None:
                 raise errors.MissingResourceError(
                     message=f"The resource pool with ID {resource_pool_id} does not have a quota."
@@ -413,19 +367,23 @@ class QuotaBP(CustomBlueprint):
     async def _put_patch(
         self, resource_pool_id: int, body: apispec.QuotaPatch | apispec.QuotaWithId, api_user: base_models.APIUser
     ):
+        # TODO: Check whether the quota is compatible with all the resource classes
         rps = await self.rp_repo.get_resource_pools(api_user=api_user, id=resource_pool_id)
         if len(rps) < 1:
             raise errors.MissingResourceError(message=f"Cannot find the resource pool with ID {resource_pool_id}.")
         rp = rps[0]
-        rp = self.quota_repo.hydrate_resource_pool_quota(rp)
         if rp.quota is None:
             raise errors.MissingResourceError(
                 message=f"The resource pool with ID {resource_pool_id} does not have a quota."
             )
         old_quota = rp.quota
-        old_quota = cast(models.Quota, old_quota)
         new_quota = models.Quota.from_dict({**asdict(old_quota), **body.model_dump(exclude_none=True)})
-        self.quota_repo.update_quota(new_quota)
+        for rc in rp.classes:
+            if not new_quota.is_resource_class_compatible(rc):
+                raise errors.ValidationError(
+                    message=f"The quota {new_quota} is not compatible with the resource class {rc}."
+                )
+        new_quota = self.quota_repo.update_quota(new_quota)
         return json(apispec.QuotaWithId.model_validate(new_quota).model_dump(exclude_none=True))
 
 
@@ -499,7 +457,6 @@ class UserResourcePoolsBP(CustomBlueprint):
     """Handlers for dealing with the resource pools of a specific user."""
 
     repo: UserRepository
-    quota_repo: QuotaRepository
     authenticator: base_models.Authenticator
 
     def get(self) -> BlueprintFactoryResponse:
@@ -509,7 +466,6 @@ class UserResourcePoolsBP(CustomBlueprint):
         @only_admins
         async def _get(_: Request, user_id: str, user: base_models.APIUser):
             rps = await self.repo.get_user_resource_pools(keycloak_id=user_id, api_user=user)
-            rps = [self.quota_repo.hydrate_resource_pool_quota(rp) for rp in rps]
             return json([apispec.ResourcePoolWithId.model_validate(rp).model_dump(exclude_none=True) for rp in rps])
 
         return "/users/<user_id>/resource_pools", ["GET"], _get
@@ -542,5 +498,4 @@ class UserResourcePoolsBP(CustomBlueprint):
         rps = await self.repo.update_user_resource_pools(
             keycloak_id=user_id, resource_pool_ids=resource_pool_ids.root, append=post, api_user=api_user
         )
-        rps = [self.quota_repo.hydrate_resource_pool_quota(rp) for rp in rps]
         return json([apispec.ResourcePoolWithId.model_validate(rp).model_dump(exclude_none=True) for rp in rps])

--- a/components/renku_data_services/git/gitlab.py
+++ b/components/renku_data_services/git/gitlab.py
@@ -114,7 +114,11 @@ class GitlabAPI:
 
 @dataclass(kw_only=True)
 class DummyGitlabAPI:
-    """Dummy gitlab API where the user with name John Doe has admin access to project 123456 and member access to 999999."""
+    """
+    Dummy gitlab API.
+
+    The user with name John Doe has admin access to project 123456 and member access to 999999.
+    """
 
     _store = {
         "John Doe": {

--- a/components/renku_data_services/users/dummy.py
+++ b/components/renku_data_services/users/dummy.py
@@ -46,7 +46,7 @@ class DummyAuthenticator:
         user_props = {}
         try:
             user_props = json.loads(access_token)
-        except:
+        except:  # noqa: E722 # nosec B110
             pass
         return base_models.APIUser(
             is_admin=self.admin,

--- a/poetry.lock
+++ b/poetry.lock
@@ -983,13 +983,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "hypothesis"
-version = "6.87.0"
+version = "6.88.1"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "hypothesis-6.87.0-py3-none-any.whl", hash = "sha256:a3fcf9e56fecfa1cc0c8e05eda18a76bdc1bbaf84784cce4aff0a5661dc7b11d"},
-    {file = "hypothesis-6.87.0.tar.gz", hash = "sha256:2cc23c9bb1ee38f64ee19dda9acc6be9a1be947f6bd841d5efb9793a7ecf1415"},
+    {file = "hypothesis-6.88.1-py3-none-any.whl", hash = "sha256:b45b8a651dfe4ce26f900ce6ccbce997d4fbec39ba03dd243516bf81fea8c0b8"},
+    {file = "hypothesis-6.88.1.tar.gz", hash = "sha256:f4c2c004b9ec3e0e25332ad2cb6b91eba477a855557a7b5c6e79068809ff8b51"},
 ]
 
 [package.dependencies]
@@ -2856,6 +2856,14 @@ files = [
     {file = "SQLAlchemy-2.0.21-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b69f1f754d92eb1cc6b50938359dead36b96a1dcf11a8670bff65fd9b21a4b09"},
     {file = "SQLAlchemy-2.0.21-cp311-cp311-win32.whl", hash = "sha256:af520a730d523eab77d754f5cf44cc7dd7ad2d54907adeb3233177eeb22f271b"},
     {file = "SQLAlchemy-2.0.21-cp311-cp311-win_amd64.whl", hash = "sha256:141675dae56522126986fa4ca713739d00ed3a6f08f3c2eb92c39c6dfec463ce"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:56628ca27aa17b5890391ded4e385bf0480209726f198799b7e980c6bd473bd7"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db726be58837fe5ac39859e0fa40baafe54c6d54c02aba1d47d25536170b690f"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7421c1bfdbb7214313919472307be650bd45c4dc2fcb317d64d078993de045b"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:632784f7a6f12cfa0e84bf2a5003b07660addccf5563c132cd23b7cc1d7371a9"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f6f7276cf26145a888f2182a98f204541b519d9ea358a65d82095d9c9e22f917"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2a1f7ffac934bc0ea717fa1596f938483fb8c402233f9b26679b4f7b38d6ab6e"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-win32.whl", hash = "sha256:bfece2f7cec502ec5f759bbc09ce711445372deeac3628f6fa1c16b7fb45b682"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-win_amd64.whl", hash = "sha256:526b869a0f4f000d8d8ee3409d0becca30ae73f494cbb48801da0129601f72c6"},
     {file = "SQLAlchemy-2.0.21-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7614f1eab4336df7dd6bee05bc974f2b02c38d3d0c78060c5faa4cd1ca2af3b8"},
     {file = "SQLAlchemy-2.0.21-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d59cb9e20d79686aa473e0302e4a82882d7118744d30bb1dfb62d3c47141b3ec"},
     {file = "SQLAlchemy-2.0.21-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a95aa0672e3065d43c8aa80080cdd5cc40fe92dc873749e6c1cf23914c4b83af"},

--- a/test/bases/renku_data_services/data_api/test_resource_pools.py
+++ b/test/bases/renku_data_services/data_api/test_resource_pools.py
@@ -6,13 +6,8 @@ import pytest
 from sanic import Sanic
 from sanic_testing.testing import SanicASGITestClient
 
-from renku_data_services.crc.db import ResourcePoolRepository, UserRepository
 from renku_data_services.data_api.app import register_all_handlers
 from renku_data_services.data_api.config import Config
-from renku_data_services.k8s.clients import DummyCoreClient, DummySchedulingClient
-from renku_data_services.k8s.quota import QuotaRepository
-from renku_data_services.storage.db import StorageRepository
-from renku_data_services.users.dummy import DummyAuthenticator, DummyUserStore
 
 _valid_resource_pool_payload: Dict[str, Any] = {
     "name": "test-name",
@@ -41,21 +36,9 @@ def valid_resource_pool_payload() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def test_client(
-    pool_repo: ResourcePoolRepository, user_repo: UserRepository, storage_repo: StorageRepository
-) -> SanicASGITestClient:
-    config = Config(
-        rp_repo=pool_repo,
-        user_repo=user_repo,
-        user_store=DummyUserStore(),
-        storage_repo=storage_repo,
-        authenticator=DummyAuthenticator(admin=True),
-        gitlab_authenticator=DummyAuthenticator(admin=True),
-        quota_repo=QuotaRepository(DummyCoreClient({}), DummySchedulingClient({})),
-    )
-
-    app = Sanic(config.app_name)
-    app = register_all_handlers(app, config)
+def test_client(app_config: Config) -> SanicASGITestClient:
+    app = Sanic(app_config.app_name)
+    app = register_all_handlers(app, app_config)
     return SanicASGITestClient(app)
 
 

--- a/test/bases/renku_data_services/data_api/test_smoke.py
+++ b/test/bases/renku_data_services/data_api/test_smoke.py
@@ -2,28 +2,14 @@ import pytest
 from sanic import Sanic
 from sanic_testing.testing import SanicASGITestClient
 
-from renku_data_services.crc.db import ResourcePoolRepository, UserRepository
 from renku_data_services.data_api.app import register_all_handlers
 from renku_data_services.data_api.config import Config
-from renku_data_services.k8s.clients import DummyCoreClient, DummySchedulingClient
-from renku_data_services.k8s.quota import QuotaRepository
-from renku_data_services.storage.db import StorageRepository
-from renku_data_services.users.dummy import DummyAuthenticator, DummyUserStore
 
 
 @pytest.mark.asyncio
-async def test_smoke(pool_repo: ResourcePoolRepository, user_repo: UserRepository, storage_repo: StorageRepository):
-    config = Config(
-        rp_repo=pool_repo,
-        user_repo=user_repo,
-        storage_repo=storage_repo,
-        user_store=DummyUserStore(),
-        authenticator=DummyAuthenticator(admin=True),
-        gitlab_authenticator=DummyAuthenticator(admin=True),
-        quota_repo=QuotaRepository(DummyCoreClient({}), DummySchedulingClient({})),
-    )
-    app = Sanic(config.app_name)
-    app = register_all_handlers(app, config)
+async def test_smoke(app_config: Config):
+    app = Sanic(app_config.app_name)
+    app = register_all_handlers(app, app_config)
     test_client = SanicASGITestClient(app)
     _, res = await test_client.get("/api/data/version")
     assert res.status_code == 200

--- a/test/components/renku_data_services/crc_models/hypothesis.py
+++ b/test/components/renku_data_services/crc_models/hypothesis.py
@@ -75,11 +75,12 @@ def rc_default_strat(draw):
 
 
 quota_strat = st.builds(models.Quota, cpu=a_quota_cpu, gpu=a_quota_gpu, memory=a_quota_memory)
+quota_strat_w_id = st.builds(models.Quota, cpu=a_quota_cpu, gpu=a_quota_gpu, memory=a_quota_memory, id=a_uuid_string)
 
 
 @st.composite
 def rp_strat(draw):
-    quota = draw(a_uuid_string)
+    quota = draw(quota_strat)
     classes = draw(st.lists(rc_non_default_strat(), min_size=1, max_size=5))
     classes.append(draw(rc_default_strat()))
     default = False

--- a/test/components/renku_data_services/db/test_sqlalchemy_storage_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_storage_repo.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 
 from renku_data_services import errors
 from renku_data_services.base_models.core import APIUser
-from renku_data_services.storage.db import StorageRepository
+from renku_data_services.data_api.config import Config
 
 
 def get_user(storage, valid=True):
@@ -42,7 +42,8 @@ def get_user(storage, valid=True):
 @given(storage=storage_strat())
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
 @pytest.mark.asyncio
-async def test_storage_insert_get(storage: dict[str, Any], storage_repo: StorageRepository):
+async def test_storage_insert_get(storage: dict[str, Any], app_config: Config):
+    storage_repo = app_config.storage_repo
     try:
         await create_storage(storage, storage_repo, user=get_user(storage))
     except (ValidationError, errors.ValidationError):
@@ -53,8 +54,9 @@ async def test_storage_insert_get(storage: dict[str, Any], storage_repo: Storage
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
 @pytest.mark.asyncio
 async def test_storage_update_path(
-    storage: dict[str, Any], new_source_path: str, new_target_path: str, storage_repo: StorageRepository
+    storage: dict[str, Any], new_source_path: str, new_target_path: str, app_config: Config
 ):
+    storage_repo = app_config.storage_repo
     try:
         user = user = get_user(storage)
         inserted_storage = await create_storage(storage, storage_repo, user)
@@ -73,9 +75,8 @@ async def test_storage_update_path(
 @given(storage=storage_strat(), new_config=st.one_of(s3_configuration(), azure_configuration()))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
 @pytest.mark.asyncio
-async def test_storage_update_config(
-    storage: dict[str, Any], new_config: dict[str, Any], storage_repo: StorageRepository
-):
+async def test_storage_update_config(storage: dict[str, Any], new_config: dict[str, Any], app_config: Config):
+    storage_repo = app_config.storage_repo
     try:
         user = user = get_user(storage)
         inserted_storage = await create_storage(storage, storage_repo, user)
@@ -93,7 +94,8 @@ async def test_storage_update_config(
 @given(storage=storage_strat())
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
 @pytest.mark.asyncio
-async def test_storage_delete(storage: dict[str, Any], storage_repo: StorageRepository):
+async def test_storage_delete(storage: dict[str, Any], app_config: Config):
+    storage_repo = app_config.storage_repo
     try:
         user = user = get_user(storage)
         inserted_storage = await create_storage(storage, storage_repo, user)

--- a/test/components/renku_data_services/k8s/test_k8s_adapter.py
+++ b/test/components/renku_data_services/k8s/test_k8s_adapter.py
@@ -44,18 +44,15 @@ def test_get_insert_quota(quota: models.Quota):
     core_client = DummyCoreClient({})
     scheduling_client = DummySchedulingClient({})
     quota_repo = QuotaRepository(core_client, scheduling_client)
-    quota = quota.generate_id()
-    assert quota.id is not None
     quotas = quota_repo.get_quotas()
     assert len(quotas) == 0
     assert len(scheduling_client.pcs) == 0
-    assert quota
     quota_repo.create_quota(quota)
     quotas = quota_repo.get_quotas()
     assert len(quotas) == 1
+    inserted_quota = quotas[0]
     assert len(scheduling_client.pcs) == 1
-    assert scheduling_client.pcs[quota.id].metadata.name == quota.id
-    assert quotas[0] == quota
+    assert scheduling_client.pcs[inserted_quota.id].metadata.name == inserted_quota.id
     specific_quota_list = quota_repo.get_quotas(quota.id)
     assert len(specific_quota_list) == 1
     specific_quota = specific_quota_list[0]
@@ -68,13 +65,11 @@ def test_delete_quota(quota: models.Quota):
     core_client = DummyCoreClient({})
     scheduling_client = DummySchedulingClient({})
     quota_repo = QuotaRepository(core_client, scheduling_client)
-    quota = quota.generate_id()
-    assert quota.id is not None
     quota_repo.create_quota(quota)
     quotas = quota_repo.get_quotas()
     assert len(quotas) == 1
     assert len(scheduling_client.pcs) == 1
-    quota_repo.delete_quota(quota.id)
+    quota_repo.delete_quota(quotas[0].id)
     quotas = quota_repo.get_quotas()
     assert len(quotas) == 0
     assert len(scheduling_client.pcs) == 0
@@ -86,9 +81,7 @@ def test_update_quota(old_quota: models.Quota, new_quota: models.Quota):
         core_client = DummyCoreClient({})
         scheduling_client = DummySchedulingClient({})
         quota_repo = QuotaRepository(core_client, scheduling_client)
-        old_quota = old_quota.generate_id()
-        assert old_quota.id is not None
-        quota_repo.create_quota(old_quota)
+        old_quota = quota_repo.create_quota(old_quota)
         quotas = quota_repo.get_quotas()
         assert len(scheduling_client.pcs) == 1
         assert len(quotas) == 1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for testing."""
 
 import os
+from typing import Iterator
 
 import pytest
 from hypothesis import settings
@@ -67,29 +68,11 @@ postgresql = factories.postgresql("postgresql_in_docker")
 
 
 @pytest.fixture
-def user_repo(postgresql, monkeypatch):
+def app_config(postgresql, monkeypatch) -> Iterator[DataConfig]:
     monkeypatch.setenv("DUMMY_STORES", "true")
     monkeypatch.setenv("DB_NAME", postgresql.info.dbname)
     config = DataConfig.from_env()
-    yield config.user_repo
-    monkeypatch.delenv("DUMMY_STORES", raising=False)
-
-
-@pytest.fixture
-def pool_repo(postgresql, monkeypatch):
-    monkeypatch.setenv("DUMMY_STORES", "true")
-    monkeypatch.setenv("DB_NAME", postgresql.info.dbname)
-    config = DataConfig.from_env()
-    yield config.rp_repo
-    monkeypatch.delenv("DUMMY_STORES", raising=False)
-
-
-@pytest.fixture
-def storage_repo(postgresql, monkeypatch):
-    monkeypatch.setenv("DUMMY_STORES", "true")
-    monkeypatch.setenv("DB_NAME", postgresql.info.dbname)
-    config = DataConfig.from_env()
-    yield config.storage_repo
+    yield config
     monkeypatch.delenv("DUMMY_STORES", raising=False)
 
 


### PR DESCRIPTION
This fixes several instances in the code where:
- a quota can be added in the db even if it is not compatible with existing resource classes
- a class can be added if it is not compatible with an existing quota
- the quota field in the ResourcePool dataclass has be either of type Quota or None, prior to this it could also be a string that represented the name of the quota in k8s, but that complicates the code quite a bit - the Quota type contains the k8s name as its id
- fixes to the tests to work with the new changes
- changes to the tests so that the config is used when certain things that it initializes are needed - prior to this we initialized certain db adapeters or clients separately but the config type can do these even for a test scenario

/deploy