### PR TITLE
chore: prevent duplicate list entries on schema merge

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/jungaretti/features/make:1": {},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "procps"
+			"packages": "procps,gcc,python3-dev,curl"
 		}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ dist
 .git
 .venv
 crc_services.db
+.devcontainer

--- a/bases/renku_data_services/data_api/config.py
+++ b/bases/renku_data_services/data_api/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
-from deepmerge import always_merger
+from deepmerge import Merger
 from jwt import PyJWKClient
 from tenacity import retry, stop_after_attempt, stop_after_delay, wait_fixed
 from yaml import safe_load
@@ -30,6 +30,25 @@ from renku_data_services.users.dummy import DummyAuthenticator, DummyUserStore
 from renku_data_services.users.gitlab import GitlabAuthenticator
 from renku_data_services.users.keycloak import KcUserStore, KeycloakAuthenticator
 from renku_data_services.utils.core import get_ssl_context
+
+
+def merge_list(merger, path, base, nxt):
+    if len(nxt) > 0:
+        for x in nxt:
+            if x not in base:
+                base.append(x)
+    return base
+
+
+unique_list_merger = Merger(
+    [
+        (list, merge_list),
+        (dict, "merge"),
+        (set, "union"),
+    ],
+    ["override"],
+    ["override"],
+)
 
 
 @retry(stop=(stop_after_attempt(20) | stop_after_delay(300)), wait=wait_fixed(2), reraise=True)
@@ -95,7 +114,7 @@ class Config:
         with open(spec_file, "r") as f:
             storage_spec = safe_load(f)
 
-        self.spec = always_merger.merge(crc_spec, storage_spec)
+        self.spec = unique_list_merger.merge(crc_spec, storage_spec)
 
         if self.default_resource_pool_file is not None:
             with open(self.default_resource_pool_file, "r") as f:

--- a/bases/renku_data_services/data_api/config.py
+++ b/bases/renku_data_services/data_api/config.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
-from deepmerge import Merger
 from jwt import PyJWKClient
 from tenacity import retry, stop_after_attempt, stop_after_delay, wait_fixed
 from yaml import safe_load
@@ -29,26 +28,7 @@ from renku_data_services.storage.db import StorageRepository
 from renku_data_services.users.dummy import DummyAuthenticator, DummyUserStore
 from renku_data_services.users.gitlab import GitlabAuthenticator
 from renku_data_services.users.keycloak import KcUserStore, KeycloakAuthenticator
-from renku_data_services.utils.core import get_ssl_context
-
-
-def merge_list(merger, path, base, nxt):
-    if len(nxt) > 0:
-        for x in nxt:
-            if x not in base:
-                base.append(x)
-    return base
-
-
-unique_list_merger = Merger(
-    [
-        (list, merge_list),
-        (dict, "merge"),
-        (set, "union"),
-    ],
-    ["override"],
-    ["override"],
-)
+from renku_data_services.utils.core import get_ssl_context, merge_api_specs
 
 
 @retry(stop=(stop_after_attempt(20) | stop_after_delay(300)), wait=wait_fixed(2), reraise=True)
@@ -114,7 +94,7 @@ class Config:
         with open(spec_file, "r") as f:
             storage_spec = safe_load(f)
 
-        self.spec = unique_list_merger.merge(crc_spec, storage_spec)
+        self.spec = merge_api_specs(crc_spec, storage_spec)
 
         if self.default_resource_pool_file is not None:
             with open(self.default_resource_pool_file, "r") as f:

--- a/components/renku_data_services/crc/api.spec.yaml
+++ b/components/renku_data_services/crc/api.spec.yaml
@@ -1061,18 +1061,22 @@ components:
           memory: 250
           gpu: 10
         public: true
-        default: true
+        default: false
         classes:
           - name: "resource class 1"
             cpu: 1.5
             memory: 2
             gpu: 0
-            max_storage: 100
+            max_storage: 10
+            default_storage: 2
+            default: true
           - name: "resource class 2"
             cpu: 4.5
             memory: 10
             gpu: 2
             max_storage: 10
+            default_storage: 2
+            default: false
         name: "resource pool name"
     ResourcePoolPatch:
       type: object
@@ -1398,7 +1402,7 @@ components:
       additionalProperties: false
       description: A minimal representation of a node afinity label
       properties:
-        key: 
+        key:
           $ref: "#/components/schemas/K8sLabel"
         requiredDuringScheduling:
           type: boolean

--- a/components/renku_data_services/storage/api.spec.yaml
+++ b/components/renku_data_services/storage/api.spec.yaml
@@ -178,7 +178,7 @@ components:
         - type: string
         - type: boolean
         - type: object
-        - type: "null"
+        # - type: "null" --> type cannot be null according to the openapi spec
     CloudStorageUrl:
       allOf:
         - $ref: "#/components/schemas/GitRequest"

--- a/components/renku_data_services/utils/core.py
+++ b/components/renku_data_services/utils/core.py
@@ -2,6 +2,9 @@
 import functools
 import os
 import ssl
+from typing import Any
+
+from deepmerge import Merger
 
 
 @functools.lru_cache(1)
@@ -12,3 +15,17 @@ def get_ssl_context():
     if custom_cert_file:
         context.load_verify_locations(cafile=custom_cert_file)
     return context
+
+
+def merge_api_specs(*args):
+    """Merges API spec files into a single one."""
+    merger = Merger(
+        type_strategies=[(list, "append_unique"), (dict, "merge"), (set, "union")],
+        fallback_strategies=["override"],
+        type_conflict_strategies=["override_if_not_empty"],
+    )
+
+    merged_spec: dict[str, Any]
+    merged_spec = functools.reduce(merger.merge, args, dict())
+
+    return merged_spec


### PR DESCRIPTION
This makes sure the merged merged API schema complies with OpenAPI spec.

closes #61 

/deploy