### PR TITLE
fix: do not create new quota on update

### DIFF
--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -75,6 +75,7 @@ async def test_resource_pool_update_quota(rp: models.ResourcePool, app_config: C
         assert updated_rp.id == inserted_rp.id
         assert updated_rp.quota is not None
         assert inserted_rp.quota != updated_rp.quota
+        assert inserted_rp.quota.id == updated_rp.quota.id
         assert updated_rp.quota.cpu == 999
         assert updated_rp.quota.memory == 999
         assert updated_rp.quota.gpu == 999


### PR DESCRIPTION
At the moment, on every quota update via the API, a new quota is created in k8s. This changes the logic so a quota is only updated, as expected. 

/deploy