### PR TITLE
fix: handle incorrect per_page in projects

### DIFF
--- a/components/renku_data_services/project/blueprints.py
+++ b/components/renku_data_services/project/blueprints.py
@@ -40,7 +40,11 @@ class ProjectsBP(CustomBlueprint):
                 page = int(page_parameter)
             except ValueError:
                 raise errors.ValidationError(message=f"Invalid value for parameter 'page': {page_parameter}")
-            per_page = int(args.get("per_page", default_number_of_elements_per_page))
+            per_page_parameter = args.get("per_page", default_number_of_elements_per_page)
+            try:
+                per_page = int(per_page_parameter)
+            except ValueError:
+                raise errors.ValidationError(message=f"Invalid value for parameter 'per_page': {per_page_parameter}")
 
             projects, pagination = await self.project_repo.get_projects(user=user, page=page, per_page=per_page)
             return json(

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -50,6 +50,9 @@ class ProjectRepository:
         """Get all projects from the database."""
         if page < 1:
             raise errors.ValidationError(message="Parameter 'page' must be a natural number")
+        offset = (page - 1) * per_page
+        if offset > 2**63-1:
+            raise errors.ValidationError(message="Parameter 'page' is too large")
         if per_page < 1 or per_page > 100:
             raise errors.ValidationError(message="Parameter 'per_page' must be between 1 and 100")
 
@@ -61,7 +64,7 @@ class ProjectRepository:
         async with self.session_maker() as session:
             stmt = select(schemas.ProjectORM)
             stmt = stmt.where(schemas.ProjectORM.id.in_(project_ids))
-            stmt = stmt.limit(per_page).offset((page - 1) * per_page)
+            stmt = stmt.limit(per_page).offset(offset)
             stmt = stmt.order_by(schemas.ProjectORM.creation_date.desc())
             result = await session.execute(stmt)
             projects_orm = result.scalars().all()

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -51,7 +51,7 @@ class ProjectRepository:
         if page < 1:
             raise errors.ValidationError(message="Parameter 'page' must be a natural number")
         offset = (page - 1) * per_page
-        if offset > 2**63-1:
+        if offset > 2**63 - 1:
             raise errors.ValidationError(message="Parameter 'page' is too large")
         if per_page < 1 or per_page > 100:
             raise errors.ValidationError(message="Parameter 'per_page' must be between 1 and 100")


### PR DESCRIPTION
More robust handling of the `page` and `per_page` headers in the projects blueprint.

Fixes failing schemathesis tests.

Example failing seeds:
* `--hypothesis-seed=171017779445631268920106278163870437636`
* `--hypothesis-seed=300134266653430367689664173805277011406`