### PR TITLE
fix: keycloak user sync

### DIFF
--- a/bases/renku_data_services/keycloak_sync/config.py
+++ b/bases/renku_data_services/keycloak_sync/config.py
@@ -3,7 +3,6 @@ import os
 from dataclasses import dataclass
 from typing import Callable
 
-from sqlalchemy import NullPool
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -36,7 +35,7 @@ class SyncConfig:
                 message="Please provide a database password in the 'DB_PASSWORD' environment variable."
             )
         async_sqlalchemy_url = f"postgresql+asyncpg://{pg_user}:{pg_password}@{pg_host}:{pg_port}/{db_name}"
-        engine = create_async_engine(async_sqlalchemy_url, poolclass=NullPool)
+        engine = create_async_engine(async_sqlalchemy_url, pool_size=2, max_overflow=0)
         session_maker: Callable[..., AsyncSession] = sessionmaker(
             engine, class_=AsyncSession, expire_on_commit=False
         )  # type: ignore[call-overload]

--- a/components/renku_data_services/users/db.py
+++ b/components/renku_data_services/users/db.py
@@ -197,6 +197,7 @@ class UsersSync:
 
             async def _do_update(raw_kc_user: Dict[str, Any]):
                 kc_user = UserInfo.from_kc_user_payload(raw_kc_user)
+                logging.info(f"Checking user with Keycloak ID {kc_user.id}")
                 db_user = await self._get_user(kc_user.id)
                 if db_user != kc_user:
                     logging.info(f"Inserting or updating user {db_user} -> {kc_user}")

--- a/components/renku_data_services/users/kc_api.py
+++ b/components/renku_data_services/users/kc_api.py
@@ -76,15 +76,17 @@ class KeycloakAPI:
             "max": self.result_per_request_limit + 1,
         }
         first = 0
-        res = self._http_client.get(url, params={**query_args, "first": first})
-        output = res.json()
-        if not isinstance(output, list):
-            raise ValueError("Received unexpected response from Keycloak for users")
-        output = cast(List[Dict[str, Any]], output)
-        yield from output
-        if len(output) < self.result_per_request_limit + 1:
-            return
-        first += self.result_per_request_limit
+        while True:
+            res = self._http_client.get(url, params={**query_args, "first": first})
+            output = res.json()
+            if not isinstance(output, list):
+                raise ValueError("Received unexpected response from Keycloak for users")
+            output = cast(List[Dict[str, Any]], output)
+            yield from output[:-1]
+            if len(output) < self.result_per_request_limit + 1:
+                yield output[-1]
+                return
+            first += self.result_per_request_limit
 
     def get_user_events(
         self, start_date: date, end_date: date | None = None, event_types: List[KeycloakEvent] | None = None
@@ -103,16 +105,17 @@ class KeycloakAPI:
         if end_date:
             query_args["dateTo"] = end_date.isoformat()
         first = 0
-        res = self._http_client.get(url, params={**query_args, "first": first})
-        output = res.json()
-        if not isinstance(output, list):
-            raise ValueError("Received unexpected response from Keycloak for events")
-        output = cast(List[Dict[str, Any]], output)
-        yield from output
-        # TODO: What happens if the output is not a list
-        if isinstance(output, list) and len(output) < self.result_per_request_limit + 1:
-            return
-        first += self.result_per_request_limit
+        while True:
+            res = self._http_client.get(url, params={**query_args, "first": first})
+            output = res.json()
+            if not isinstance(output, list):
+                raise ValueError("Received unexpected response from Keycloak for events")
+            output = cast(List[Dict[str, Any]], output)
+            yield from output[:-1]
+            if len(output) < self.result_per_request_limit + 1:
+                yield output[-1]
+                return
+            first += self.result_per_request_limit
 
     def get_admin_events(
         self, start_date: date, end_date: date | None = None, event_types: List[KeycloakAdminEvent] | None = None
@@ -133,13 +136,14 @@ class KeycloakAPI:
         if end_date:
             query_args["dateTo"] = end_date.isoformat()
         first = 0
-        res = self._http_client.get(url, params={**query_args, "first": first})
-        output = res.json()
-        if not isinstance(output, list):
-            raise ValueError("Received unexpected response from Keycloak for events")
-        output = cast(List[Dict[str, Any]], output)
-        yield from output
-        # TODO: What happens if the output is not a list
-        if isinstance(output, list) and len(output) < self.result_per_request_limit + 1:
-            return
-        first += self.result_per_request_limit
+        while True:
+            res = self._http_client.get(url, params={**query_args, "first": first})
+            output = res.json()
+            if not isinstance(output, list):
+                raise ValueError("Received unexpected response from Keycloak for events")
+            output = cast(List[Dict[str, Any]], output)
+            yield from output[:-1]
+            if len(output) < self.result_per_request_limit + 1:
+                yield output[-1]
+                return
+            first += self.result_per_request_limit


### PR DESCRIPTION
This fixes the syncing of keycloak users in the data service.

I setup iterators to do paginated requests to Keycloak and then just completely forgot to add a while loop to keep going through all possible pages. So currently only the first 20 users were imported.

I tested a job with this code on dev and it works. I use `asyncio.gather` for the user updates so if I use a nullpool then I open too many connections to postgres. That is why I added a pool with 2. I know this slows things down but this is just a job that runs periodically and it does not need to be fast. It is better for this to be slow than to nuke the db.

Once this is approved and merged. I will make a bugfix release from 0.5.0 that includes this change and then make a renku bugfix release. Currently on main in this repo we have a lot of stuff that will go out with renku 0.50.0 but this fix will be added to 0.49.x so that it can be deployed sooner than 0.50.0.

This is preventing admins from adding users to different resource pools.


