### PR TITLE
chore: add CI job to publish keycloak sync images

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Docker meta
+      - name: Docker meta data services
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -83,7 +83,7 @@ jobs:
         with:
           username: ${{ secrets.RENKU_DOCKER_USERNAME }}
           password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
-      - name: Build and push
+      - name: Build and push data services
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -94,3 +94,28 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=renku/renku-data-service:buildcache
           cache-to: type=registry,ref=renku/renku-data-service:buildcache,mode=max
+      - name: Docker meta keycloak sync
+        id: meta-keycloak-sync
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            renku/keycloak-sync
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      - name: Build and push keycloak sync
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./projects/keycloak_sync/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-keycloak-sync.outputs.tags }}
+          labels: ${{ steps.meta-keycloak-sync.outputs.labels }}
+          cache-from: type=registry,ref=renku/keycloak-sync:buildcache
+          cache-to: type=registry,ref=renku/keycloak-sync:buildcache,mode=max

--- a/projects/keycloak_sync/Dockerfile
+++ b/projects/keycloak_sync/Dockerfile
@@ -22,7 +22,7 @@ RUN if $DEV_BUILD ; then \
 RUN /home/renku/.local/bin/poetry build-project -f wheel -C projects/keycloak_sync
 RUN env/bin/pip --no-cache-dir install projects/keycloak_sync/dist/*.whl
 
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN apt-get update && apt-get install -y \

--- a/projects/renku_data_service/Dockerfile
+++ b/projects/renku_data_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bullseye as builder
+FROM python:3.11-bookworm as builder
 ARG DEV_BUILD=false
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -23,7 +23,7 @@ RUN if $DEV_BUILD ; then \
 RUN /home/renku/.local/bin/poetry build-project -f wheel -C projects/renku_data_service
 RUN env/bin/pip --no-cache-dir install projects/renku_data_service/dist/*.whl
 
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ENV PROMETHEUS_MULTIPROC_DIR=/prometheus


### PR DESCRIPTION
We were missing this step for a few releases.