### PR TITLE
fix: delete project when its group is deleted

### DIFF
--- a/components/renku_data_services/migrations/versions/89aa4573cfa9_cleanup_project_when_slug_is_removed.py
+++ b/components/renku_data_services/migrations/versions/89aa4573cfa9_cleanup_project_when_slug_is_removed.py
@@ -1,0 +1,48 @@
+"""cleanup project when slug is removed
+
+Revision ID: 89aa4573cfa9
+Revises: 87a439f35346
+Create Date: 2024-04-02 13:01:02.124918
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '89aa4573cfa9'
+down_revision = '87a439f35346'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Register a trigger and function to remove a project when its slug is removed.
+
+    This is necessary because we only have a foreign key on the slugs table pointing to Projects, so
+    we remove slugs when a project is removed. But we also want to remove projects when a slug is removed
+    because this can occur when you delete a group and all projects within the group should also be deleted.
+    """
+    # NOTE: There may be projects left in DB whose slugs have been removed but the projects are present,
+    # these should be cleaned up.
+    op.execute("""DELETE FROM projects.projects
+WHERE projects.id NOT IN (
+SELECT project_slugs.project_id FROM projects.project_slugs
+);""")
+    # NOTE: OLD variable holds the name of the row that is being deleted (i.e. the trigger)
+    op.execute("""CREATE OR REPLACE FUNCTION delete_project_after_slug_deletion()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    DELETE FROM projects.projects WHERE projects.id = OLD.project_id;
+    RETURN OLD;
+END;
+$$
+LANGUAGE plpgsql;""")
+    op.execute("""CREATE OR REPLACE TRIGGER delete_project_after_slug_deletion
+AFTER DELETE ON projects.project_slugs
+FOR EACH ROW
+EXECUTE FUNCTION delete_project_after_slug_deletion();""")
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS delete_project_after_slug_deletion on projects.project_slugs CASCADE;")
+    op.execute("DROP FUNCTION IF EXISTS delete_project_after_slug_deletion CASCADE;")

--- a/components/renku_data_services/namespace/db.py
+++ b/components/renku_data_services/namespace/db.py
@@ -208,6 +208,10 @@ class GroupRepository:
                     message=f"You cannot delete a group by using an old group slug {slug}.",
                     detail=f"The latest slug is {group.namespace.slug}, please use this for deletions.",
                 )
+            # NOTE: We have a stored procedure that gets triggered when a project slug is removed to remove the project.
+            # This is required because the slug has a foreign key pointing to the project, so when a project is removed
+            # the slug is removed but the converse is not true. The stored procedure in migration 89aa4573cfa9 has the
+            # trigger and procedure that does the cleanup when a slug is removed.
             stmt = delete(schemas.GroupORM).where(schemas.GroupORM.id == group.id)
             await session.execute(stmt)
 

--- a/components/renku_data_services/project/orm.py
+++ b/components/renku_data_services/project/orm.py
@@ -30,6 +30,8 @@ class ProjectORM(BaseORM):
     visibility: Mapped[Visibility]
     created_by_id: Mapped[str] = mapped_column("created_by_id", String())
     description: Mapped[Optional[str]] = mapped_column("description", String(500))
+    # NOTE: The project slugs table has a foreign key from the projects table, but there is a stored procedure
+    # triggered by the deletion of slugs to remove the project used by the slug. See migration 89aa4573cfa9.
     slug: Mapped["ProjectSlug"] = relationship(lazy="joined", init=False, repr=False, viewonly=True)
     repositories: Mapped[List["ProjectRepositoryORM"]] = relationship(
         back_populates="project",


### PR DESCRIPTION
This was not done because the project slugs table has a foreign key pointing to projects. So the foreign key delete cascade takes care of deleting slugs when a project is deleted. But when deleting a group, this deletes the project slugs that belong to the group but the project table has no foreign key to the slugs. So for this case I added a trigger and a procedure that deletes the project when its slug is deleted.

/deploy extra-values=global.gitlab.url=https://gitlab.dev.renku.ch,global.gitlab.registry.host=registry.dev.renku.ch/