### PR TITLE
fix: patching existing user's project role should not add extra roles

### DIFF
--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -580,16 +580,30 @@ class Authz:
                 # The existing relationships should be deleted if all goes well and added back in if we have to undo
                 existing_rel = existing_rels[0]
                 if existing_rel.relationship != rel:
-                    add_members.append(
-                        RelationshipUpdate(
-                            operation=RelationshipUpdate.OPERATION_TOUCH,
-                            relationship=rel,
-                        ),
+                    add_members.extend(
+                        [
+                            RelationshipUpdate(
+                                operation=RelationshipUpdate.OPERATION_TOUCH,
+                                relationship=rel,
+                            ),
+                            # NOTE: The old role for the user still exists and we have to remove it
+                            # if not both the old and new role for the same user will be present in the database
+                            RelationshipUpdate(
+                                operation=RelationshipUpdate.OPERATION_DELETE,
+                                relationship=existing_rel.relationship,
+                            ),
+                        ]
                     )
-                    undo.append(
-                        RelationshipUpdate(
-                            operation=RelationshipUpdate.OPERATION_TOUCH, relationship=existing_rel.relationship
-                        ),
+                    undo.extend(
+                        [
+                            RelationshipUpdate(
+                                operation=RelationshipUpdate.OPERATION_DELETE,
+                                relationship=rel,
+                            ),
+                            RelationshipUpdate(
+                                operation=RelationshipUpdate.OPERATION_TOUCH, relationship=existing_rel.relationship
+                            ),
+                        ]
                     )
                     output.append(MembershipChange(member, Change.UPDATE))
                 for rel_to_remove in existing_rels[1:]:

--- a/components/renku_data_services/message_queue/converters.py
+++ b/components/renku_data_services/message_queue/converters.py
@@ -66,6 +66,14 @@ class _ProjectEventConverter:
                             creationDate=project.creation_date,
                             keywords=project.keywords or [],
                         ),
+                    ),
+                    Event(
+                        "projectAuth.added",
+                        v1.ProjectAuthorizationAdded(
+                            projectId=project.id,
+                            userId=project.created_by,
+                            role=v1.ProjectMemberRole.OWNER,
+                        ),
                     )
                 ]
             case v1.ProjectUpdated:

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -602,6 +602,10 @@ async def test_add_project_members(
         f"/api/data/projects/{project_id}/members", headers=user_headers, json=members
     )
     assert response.status_code == 200, response.text
+    _, response = await sanic_client.get(
+        f"/api/data/projects/{project_id}/members", headers=user_headers,
+    )
+    assert len(response.json) == 3
     events = await app_config.redis.redis_connection.xrange("projectAuth.removed")
     assert len(events) == 0
     events = await app_config.redis.redis_connection.xrange("projectAuth.added")

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -10,6 +10,7 @@ from ulid import ULID
 from components.renku_data_services.message_queue.avro_models.io.renku.events import v1 as avro_schema_v1
 from components.renku_data_services.message_queue.avro_models.io.renku.events import v2 as avro_schema_v2
 from renku_data_services.app_config.config import Config
+from renku_data_services.authz.models import Role
 from renku_data_services.message_queue.redis_queue import deserialize_binary
 from renku_data_services.users.models import UserInfo
 
@@ -557,7 +558,13 @@ async def test_creator_is_added_as_owner_members(sanic_client, create_project, u
 
 @pytest.mark.asyncio
 async def test_add_project_members(
-    create_project, sanic_client, user_headers, app_config, member_1_user: UserInfo, member_2_user: UserInfo
+    create_project,
+    sanic_client,
+    regular_user,
+    user_headers,
+    app_config,
+    member_1_user: UserInfo,
+    member_2_user: UserInfo,
 ):
     project = await create_project("Project 1")
     project_id = project["id"]
@@ -573,13 +580,18 @@ async def test_add_project_members(
     events = await app_config.redis.redis_connection.xrange("projectAuth.removed")
     assert len(events) == 0
     events = await app_config.redis.redis_connection.xrange("projectAuth.added")
-    assert len(events) == 2
+    assert len(events) == 3
     event = events[0][1]
+    auth_event = deserialize_binary(event[b"payload"], avro_schema_v1.ProjectAuthorizationAdded)
+    assert auth_event.projectId == project_id
+    assert auth_event.userId == regular_user.id
+    assert auth_event.role.value.lower() == Role.OWNER.value
+    event = events[1][1]
     auth_event = deserialize_binary(event[b"payload"], avro_schema_v2.ProjectMemberAdded)
     assert auth_event.projectId == project_id
     assert auth_event.userId == members[0]["id"]
     assert auth_event.role.value.lower() == members[0]["role"]
-    event = events[1][1]
+    event = events[2][1]
     auth_event = deserialize_binary(event[b"payload"], avro_schema_v2.ProjectMemberAdded)
     assert auth_event.projectId == project_id
     assert auth_event.userId == members[1]["id"]
@@ -603,13 +615,14 @@ async def test_add_project_members(
     )
     assert response.status_code == 200, response.text
     _, response = await sanic_client.get(
-        f"/api/data/projects/{project_id}/members", headers=user_headers,
+        f"/api/data/projects/{project_id}/members",
+        headers=user_headers,
     )
     assert len(response.json) == 3
     events = await app_config.redis.redis_connection.xrange("projectAuth.removed")
     assert len(events) == 0
     events = await app_config.redis.redis_connection.xrange("projectAuth.added")
-    assert len(events) == 2  # The events from before are still there but there arent new ones
+    assert len(events) == 3  # The events from before are still there but there arent new ones
     events = await app_config.redis.redis_connection.xrange("projectAuth.updated")
     assert len(events) == 1
     event = events[0][1]


### PR DESCRIPTION
We need to replace the role of an existing user in the authz DB when a role is patched. So when the new role is added we have to explicitly remove the old role. If not the user ends up with both roles in the authorization database. Which we do not want.

Spotted by @ciyer in testing.

Deployed over at https://github.com/SwissDataScienceCenter/renku/pull/3617

This also fixes a few other problems with the message queue:
- we were always sending a v1 header if v2 messages were being sent
- we were not emitting a project member added as owner event when a project is created