### PR TITLE
fix: remove the leading underscore (_) on route names

### DIFF
--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -95,6 +95,12 @@ def create_app() -> Sanic:
         validator = RCloneValidator()
         app.ext.dependency(validator)
 
+    @app.after_server_start
+    async def after_server_start(app: Sanic):
+        logger.info("Printing all routes by name")
+        for key in app.router.name_index.keys():
+            logger.info(f"Route: {key}")
+
     async def send_pending_events(app):
         """Send pending messages in case sending in a handler failed."""
         while True:

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -98,7 +98,7 @@ def create_app() -> Sanic:
     @app.after_server_start
     async def after_server_start(app: Sanic):
         logger.info("Printing all routes by name")
-        for key in app.router.name_index.keys():
+        for key in app.router.name_index:
             logger.info(f"Route: {key}")
 
     async def send_pending_events(app):

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -30,6 +30,11 @@ def create_app() -> Sanic:
     """Create a Sanic application."""
     config = Config.from_env()
     app = Sanic(config.app_name)
+
+    # TODO: configure this
+    app.config.PROXIES_COUNT = 2
+    app.config.REAL_IP_HEADER = "x-real-ip"
+
     if "COVERAGE_RUN" in environ:
         app.config.TOUCHUP = False
         # NOTE: in single process mode where we usually run schemathesis to get coverage the db migrations

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -30,11 +30,6 @@ def create_app() -> Sanic:
     """Create a Sanic application."""
     config = Config.from_env()
     app = Sanic(config.app_name)
-
-    # TODO: configure this
-    app.config.PROXIES_COUNT = 2
-    app.config.REAL_IP_HEADER = "x-real-ip"
-
     if "COVERAGE_RUN" in environ:
         app.config.TOUCHUP = False
         # NOTE: in single process mode where we usually run schemathesis to get coverage the db migrations
@@ -99,12 +94,6 @@ def create_app() -> Sanic:
     async def setup_rclone_validator(app, _):
         validator = RCloneValidator()
         app.ext.dependency(validator)
-
-    @app.after_server_start
-    async def after_server_start(app: Sanic):
-        logger.info("Printing all routes by name")
-        for key in app.router.name_index:
-            logger.info(f"Route: {key}")
 
     async def send_pending_events(app):
         """Send pending messages in case sending in a handler failed."""

--- a/components/renku_data_services/base_api/blueprint.py
+++ b/components/renku_data_services/base_api/blueprint.py
@@ -32,7 +32,7 @@ class CustomBlueprint:
             if name != "blueprint" and not name.startswith("_"):
                 method_factory = cast(BlueprintFactory, method)
                 url, http_methods, handler = method_factory()
-                bp.add_route(handler=handler, uri=url, methods=http_methods)
+                bp.add_route(handler=handler, uri=url, methods=http_methods, name=name)
         for req_mw in self.request_middlewares:
             bp.middleware("request")(req_mw)
         for res_mw in self.response_middlewares:

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -27,8 +27,9 @@ class OAuth2ClientsBP(CustomBlueprint):
 
         @authenticate(self.authenticator)
         async def _get_all(r: Request, user: base_models.APIUser):
-            for h in r.headers:
-                logger.info(f"Header: {h} = {r.headers.get_all(h)}")
+            logger.info(f"scheme = {r.scheme}")
+            # for h in r.headers:
+            #     logger.info(f"Header: {h} = {r.headers.get_all(h)}")
 
             clients = await self.connected_services_repo.get_oauth2_clients(user=user)
             return json(

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -1,7 +1,7 @@
 """Connected services blueprint."""
 
 from dataclasses import dataclass
-from urllib.parse import urlunparse
+from urllib.parse import urlparse, urlunparse
 
 from sanic import HTTPResponse, Request, json, redirect
 from sanic.log import logger
@@ -27,7 +27,8 @@ class OAuth2ClientsBP(CustomBlueprint):
 
         @authenticate(self.authenticator)
         async def _get_all(r: Request, user: base_models.APIUser):
-            test_url = r.url_for(f"{self.name}.get_all")
+            test_url = r.url_for(f"{self.name}.{self.authorize_callback.__name__}")
+            test_url = urlunparse(urlparse(test_url)._replace(scheme="https"))
             logger.info(f"test_url = {test_url}")
 
             clients = await self.connected_services_repo.get_oauth2_clients(user=user)
@@ -118,7 +119,8 @@ class OAuth2ClientsBP(CustomBlueprint):
         return "/oauth2/callback", ["GET"], _callback
 
     def _get_callback_url(self, request: Request) -> str:
-        test_url = request.url_for(f"{self.name}.authorize_callback", _scheme="https")
+        test_url = request.url_for(f"{self.name}.{self.authorize_callback.__name__}")
+        test_url = urlunparse(urlparse(test_url)._replace(scheme="https"))
         logger.info(f"test_url = {test_url}")
 
         callback_path = "/api/data/oauth2/callback"

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -5,7 +5,7 @@ from urllib.parse import urlunparse
 
 from sanic import HTTPResponse, Request, json, redirect
 from sanic_ext import validate
-
+from sanic.log import logger
 import renku_data_services.base_models as base_models
 from renku_data_services.base_api.auth import authenticate, only_admins, only_authenticated
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
@@ -115,6 +115,9 @@ class OAuth2ClientsBP(CustomBlueprint):
 
     @staticmethod
     def _get_callback_url(request: Request) -> str:
+        test_url = request.url_for("renku_data_services.oauth2_clients.authorize_callback")
+        logger.info(f"test_url = {test_url}")
+
         callback_path = "/api/data/oauth2/callback"
         return urlunparse(("https", request.host, callback_path, None, None, None))
 

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -27,9 +27,8 @@ class OAuth2ClientsBP(CustomBlueprint):
 
         @authenticate(self.authenticator)
         async def _get_all(r: Request, user: base_models.APIUser):
-            test_url = r.url_for(f"{self.name}.{self.authorize_callback.__name__}")
-            test_url = urlunparse(urlparse(test_url)._replace(scheme="https"))
-            logger.info(f"test_url = {test_url}")
+            for h in r.headers:
+                logger.info(f"Header: {h} = {r.headers.get_all(h)}")
 
             clients = await self.connected_services_repo.get_oauth2_clients(user=user)
             return json(
@@ -119,17 +118,8 @@ class OAuth2ClientsBP(CustomBlueprint):
         return "/oauth2/callback", ["GET"], _callback
 
     def _get_callback_url(self, request: Request) -> str:
-        test_url = request.url_for(f"{self.name}.{self.authorize_callback.__name__}")
-        test_url = urlunparse(urlparse(test_url)._replace(scheme="https"))
-        logger.info(f"test_url = {test_url}")
-
-        callback_path = "/api/data/oauth2/callback"
-        ref_url = urlunparse(("https", request.host, callback_path, None, None, None))
-        logger.info(f"ref_url = {ref_url}")
-
-        logger.info(f"Check test_url = {test_url == ref_url}")
-
-        return ref_url
+        callback_url = request.url_for(f"{self.name}.{self.authorize_callback.__name__}")
+        return urlunparse(urlparse(callback_url)._replace(scheme="https"))
 
 
 @dataclass(kw_only=True)

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -118,13 +118,16 @@ class OAuth2ClientsBP(CustomBlueprint):
         return "/oauth2/callback", ["GET"], _callback
 
     def _get_callback_url(self, request: Request) -> str:
-        # test_url = request.url_for("renku_data_services.oauth2_clients.authorize_callback")
-        # logger.info(f"test_url = {test_url}")
-        test_url = request.url_for(f"{self.name}.authorize_callback")
+        test_url = request.url_for(f"{self.name}.authorize_callback", _scheme="https")
         logger.info(f"test_url = {test_url}")
 
         callback_path = "/api/data/oauth2/callback"
-        return urlunparse(("https", request.host, callback_path, None, None, None))
+        ref_url = urlunparse(("https", request.host, callback_path, None, None, None))
+        logger.info(f"ref_url = {ref_url}")
+
+        logger.info(f"Check test_url = {test_url == ref_url}")
+
+        return ref_url
 
 
 @dataclass(kw_only=True)

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass
 from urllib.parse import urlunparse
 
 from sanic import HTTPResponse, Request, json, redirect
-from sanic_ext import validate
 from sanic.log import logger
+from sanic_ext import validate
+
 import renku_data_services.base_models as base_models
 from renku_data_services.base_api.auth import authenticate, only_admins, only_authenticated
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
@@ -25,7 +26,10 @@ class OAuth2ClientsBP(CustomBlueprint):
         """List all OAuth2 Clients."""
 
         @authenticate(self.authenticator)
-        async def _get_all(_: Request, user: base_models.APIUser):
+        async def _get_all(r: Request, user: base_models.APIUser):
+            test_url = r.url_for(f"{self.name}.get_all")
+            logger.info(f"test_url = {test_url}")
+
             clients = await self.connected_services_repo.get_oauth2_clients(user=user)
             return json(
                 [apispec.Provider.model_validate(c).model_dump(exclude_none=True, mode="json") for c in clients]
@@ -113,9 +117,10 @@ class OAuth2ClientsBP(CustomBlueprint):
 
         return "/oauth2/callback", ["GET"], _callback
 
-    @staticmethod
-    def _get_callback_url(request: Request) -> str:
-        test_url = request.url_for("renku_data_services.oauth2_clients.authorize_callback")
+    def _get_callback_url(self, request: Request) -> str:
+        # test_url = request.url_for("renku_data_services.oauth2_clients.authorize_callback")
+        # logger.info(f"test_url = {test_url}")
+        test_url = request.url_for(f"{self.name}.authorize_callback")
         logger.info(f"test_url = {test_url}")
 
         callback_path = "/api/data/oauth2/callback"


### PR DESCRIPTION
WIP

Before:
```
[2024-05-24 12:53:46 +0000] [25940] [INFO] Route: renku_data_services.resource_pool_users._get_all
[2024-05-24 12:53:46 +0000] [25940] [INFO] Route: renku_data_services.resource_pool_users._get
[2024-05-24 12:53:46 +0000] [25940] [INFO] Route: renku_data_services.resource_pool_users._delete
[2024-05-24 12:53:46 +0000] [25940] [INFO] Route: renku_data_services.resource_pool_users._put
[2024-05-24 12:53:46 +0000] [25940] [INFO] Route: renku_data_services.resource_pool_users._post
```

After:
```
[2024-05-24 12:58:29 +0000] [26730] [INFO] Route: renku_data_services.resource_pool_users.get
[2024-05-24 12:58:29 +0000] [26730] [INFO] Route: renku_data_services.resource_pool_users.get_all
[2024-05-24 12:58:29 +0000] [26730] [INFO] Route: renku_data_services.resource_pool_users.put
[2024-05-24 12:58:29 +0000] [26730] [INFO] Route: renku_data_services.resource_pool_users.delete
[2024-05-24 12:58:29 +0000] [26730] [INFO] Route: renku_data_services.resource_pool_users.post
```

/deploy #notest renku=release-0.52.x