### PR TITLE
refactor: update exception logging in `CustomErrorHandler`

### DIFF
--- a/components/renku_data_services/base_api/error_handler.py
+++ b/components/renku_data_services/base_api/error_handler.py
@@ -87,7 +87,10 @@ class CustomErrorHandler(ErrorHandler):
                 if message == "" or message is None:
                     message = ", ".join([str(i) for i in exception.args])
                 formatted_exception = errors.BaseError(
-                    message=message, status_code=exception.status_code, code=1000 + exception.status_code
+                    message=message,
+                    status_code=exception.status_code,
+                    code=1000 + exception.status_code,
+                    quiet=exception.quiet or False,
                 )
             case SqliteError():
                 formatted_exception = errors.BaseError(

--- a/components/renku_data_services/base_api/error_handler.py
+++ b/components/renku_data_services/base_api/error_handler.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError as PydanticValidationError
 from sanic import HTTPResponse, Request, SanicException, json
 from sanic.errorpages import BaseRenderer, TextRenderer
 from sanic.handlers import ErrorHandler
-from sanic.log import logger
 from sanic_ext.exceptions import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -22,6 +21,7 @@ class BaseError(Protocol):
     code: int
     message: str
     detail: Optional[str]
+    quiet: bool
 
 
 class BaseErrorResponse(Protocol):
@@ -62,15 +62,9 @@ class CustomErrorHandler(ErrorHandler):
         self.api_spec = api_spec
         super().__init__(base)
 
-    def _log_unhandled_exception(self, exception: Exception) -> None:
-        if self.debug:
-            logger.exception("An unknown or unhandled exception occurred", exc_info=exception)
-        logger.error("An unknown or unhandled exception of type %s occurred", type(exception).__name__)
-
     def default(self, request: Request, exception: Exception) -> HTTPResponse:
         """Overrides the default error handler."""
         formatted_exception = errors.BaseError()
-        logger.exception("An unknown or unhandled exception occurred", exc_info=exception)
         match exception:
             case errors.BaseError():
                 formatted_exception = exception
@@ -88,8 +82,6 @@ class CustomErrorHandler(ErrorHandler):
                         ]
                         message = f"There are errors in the following fields, {', '.join(parts)}"
                         formatted_exception = errors.ValidationError(message=message)
-                    case _:
-                        self._log_unhandled_exception(exception)
             case SanicException():
                 message = exception.message
                 if message == "" or message is None:
@@ -131,8 +123,7 @@ class CustomErrorHandler(ErrorHandler):
                 formatted_exception = errors.ValidationError(
                     message="The provided input is too large to be stored in the database"
                 )
-            case _:
-                self._log_unhandled_exception(exception)
+        self.log(request, formatted_exception)
         return json(
             self.api_spec.ErrorResponse(
                 error=self.api_spec.Error(

--- a/components/renku_data_services/errors/errors.py
+++ b/components/renku_data_services/errors/errors.py
@@ -12,6 +12,7 @@ class BaseError(Exception):
     status_code: int = 500
     message: str = "An unexpected error occurred"
     detail: Optional[str] = None
+    quiet: bool = False
 
     def __repr__(self) -> str:
         """String representation of the error."""
@@ -23,37 +24,12 @@ class BaseError(Exception):
 
 
 @dataclass
-class MissingResourceError(BaseError):
-    """Raised when a resource is not found."""
+class GeneralBadRequest(BaseError):
+    """Raised for a 400 status code - when the server cannot or will not process the request."""
 
-    code: int = 1404
-    status_code: int = 404
-    message: str = "The requested resource does not exist or cannot be found"
-
-
-@dataclass
-class ConfigurationError(BaseError):
-    """Raised when the server is not properly configured."""
-
-    message: str = "The server is not properly configured and cannot run"
-
-
-@dataclass
-class ValidationError(BaseError):
-    """Raised when the inputs or outputs are invalid."""
-
-    code: int = 1422
-    message: str = "The provided input is invalid"
-    status_code: int = 422
-
-
-@dataclass
-class Unauthorized(BaseError):
-    """Raised when the user does not have the required credentials."""
-
-    code: int = 1401
-    message: str = "The supplied credentials are missing or invalid."
-    status_code: int = 401
+    code: int = 1400
+    message: str = "The request is invalid, malformed or non-sensical and cannot be fulfilled."
+    status_code: int = 400
 
 
 @dataclass
@@ -66,12 +42,30 @@ class NoDefaultPoolAccessError(BaseError):
 
 
 @dataclass
-class GeneralBadRequest(BaseError):
-    """Raised for a 400 status code - when the server cannot or will not process the request."""
+class Unauthorized(BaseError):
+    """Raised when the user does not have the required credentials."""
 
-    code: int = 1400
-    message: str = "The request is invalid, malformed or non-sensical and cannot be fulfilled."
-    status_code: int = 400
+    code: int = 1401
+    message: str = "The supplied credentials are missing or invalid."
+    status_code: int = 401
+
+
+@dataclass
+class MissingResourceError(BaseError):
+    """Raised when a resource is not found."""
+
+    code: int = 1404
+    status_code: int = 404
+    message: str = "The requested resource does not exist or cannot be found"
+
+
+@dataclass
+class ConflictError(BaseError):
+    """Raised when a conflicting update occurs."""
+
+    code: int = 1409
+    message: str = "Conflicting update detected."
+    status_code: int = 409
 
 
 @dataclass
@@ -90,6 +84,31 @@ class UpdatingWithStaleContentError(BaseError):
 
 
 @dataclass
+class ValidationError(BaseError):
+    """Raised when the inputs or outputs are invalid."""
+
+    code: int = 1422
+    message: str = "The provided input is invalid"
+    status_code: int = 422
+
+
+@dataclass
+class PreconditionRequiredError(BaseError):
+    """Raised when a precondition is not met."""
+
+    code: int = 1428
+    message: str = "Conflicting update detected."
+    status_code: int = 428
+
+
+@dataclass
+class ConfigurationError(BaseError):
+    """Raised when the server is not properly configured."""
+
+    message: str = "The server is not properly configured and cannot run"
+
+
+@dataclass
 class ProgrammingError(BaseError):
     """Raised an irrecoverable programming error or bug occurs."""
 
@@ -105,24 +124,6 @@ class EventError(BaseError):
     code: int = 1501
     message: str = "An unexpected error occured when handling or generating events for the message queue."
     status_code: int = 500
-
-
-@dataclass
-class ConflictError(BaseError):
-    """Raised when a conflicting update occurs."""
-
-    code: int = 1409
-    message: str = "Conflicting update detected."
-    status_code: int = 409
-
-
-@dataclass
-class PreconditionRequiredError(BaseError):
-    """Raised when a precondition is not met."""
-
-    code: int = 1428
-    message: str = "Conflicting update detected."
-    status_code: int = 428
 
 
 @dataclass

--- a/components/renku_data_services/errors/errors.py
+++ b/components/renku_data_services/errors/errors.py
@@ -23,6 +23,9 @@ class BaseError(Exception):
         return f"{self.__class__.__qualname__}: {self.message}"
 
 
+# ! IMPORTANT: keep this list ordered by HTTP status code.
+
+
 @dataclass
 class GeneralBadRequest(BaseError):
     """Raised for a 400 status code - when the server cannot or will not process the request."""

--- a/components/renku_data_services/user_preferences/db.py
+++ b/components/renku_data_services/user_preferences/db.py
@@ -44,7 +44,7 @@ class UserPreferencesRepository(_Base):
             user_preferences = res.one_or_none()
 
             if user_preferences is None:
-                raise errors.MissingResourceError(message="Preferences not found for user.")
+                raise errors.MissingResourceError(message="Preferences not found for user.", quiet=True)
             return user_preferences.dump()
 
     async def delete_user_preferences(self, user: base_models.APIUser) -> None:
@@ -117,7 +117,7 @@ class UserPreferencesRepository(_Base):
             user_preferences = res.one_or_none()
 
             if user_preferences is None:
-                raise errors.MissingResourceError(message="Preferences not found for user.")
+                raise errors.MissingResourceError(message="Preferences not found for user.", quiet=True)
 
             project_slugs: list[str]
             project_slugs = user_preferences.pinned_projects.get("project_slugs", [])


### PR DESCRIPTION
Fixes #245.

[Sanic exceptions have a `quiet` property](https://sanic.dev/en/guide/best-practices/exceptions.html#codequietcode) which is used to suppress logging. The custom error handler is updated to use Sanic's default `log()` method and our custom error classes now also have the `quiet` attribute.

Details:
* Add `quiet` attribute to `BaseError`
* Use the default `log()` method after the `formatted_exception` has been assigned in the `default` error handler.
* Re-order exceptions to be listed by ascending HTTP status code.
* Suppress "Preferences not found for user." messages.

/deploy #notest