### PR TITLE
chore: set up dependabot depedency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: "pip"
+  directories:
+    - "/"
+    - "/projects/renku_data_service"
+    - "/projects/background_jobs"
+    - "/projects/secrets_storage"
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+  open-pull-requests-limit: 5
+  group:
+    poetry:
+      patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     interval: "weekly"
     day: "sunday"
   open-pull-requests-limit: 5
-  group:
+  groups:
     poetry:
       patterns:
         - "*"


### PR DESCRIPTION
note: multi-directory support is beta and not in the documentation other than https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/

this updates poetry dependencies for all pyproject.toml's grouped together, on every sunday (when CI is unlikely to be running).

We could also have separate PRs for dev and prod dependencies.