### PR TITLE
chore(ci): do not start kind on devcontainer startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
 		"ghcr.io/devcontainers-contrib/features/poetry",
 		"ghcr.io/devcontainers-contrib/features/bash-command"
 	],
-	"postCreateCommand": "poetry install --with dev && make kind_cluster && make install_amaltheas",
+	"postCreateCommand": "poetry install --with dev",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ help:  ## Display this help.
 kind_cluster:  ## Creates a kind cluster for testing
 	kind delete cluster
 	docker network rm -f kind
-	docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --ipv6=false --subnet=192.168.0.0/16 kind
+	docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --ipv6=false kind
 	kind create cluster --config kind_config.yaml
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 	echo "Waiting for ingress controller to initialize"


### PR DESCRIPTION
This is currently not being used on the main branch yet and was added in support of upcoming changes.

But it slows down the ci pipelines.

We can find a different way to set things up for the automated tests. And for developing people can still call the commands in the makefile if they want the kind setup.