### PR TITLE
fix: define devcontainer image tag for git tag event

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -51,6 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build devcontainer
         uses: devcontainers/ci@v0.3
+        continue-on-error: true
         with:
           push: always
           skipContainerUserIdUpdate: false

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -32,6 +32,7 @@ jobs:
           tags: |
             type=ref,event=pr,prefix=cache-pr-,priority=600
             type=ref,event=branch,prefix=cache-,priority=500
+            type=ref,event=tag,prefix=cache-,priority=500
       - name: Extract Docker image name
         id: docker_image
         env:


### PR DESCRIPTION
See failing job: https://github.com/SwissDataScienceCenter/renku-data-services/actions/runs/10159936043/job/28095202729#logs.