### PR TITLE
build: fix devcontainer cache build for release CI

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -33,6 +33,8 @@ jobs:
             type=ref,event=pr,prefix=cache-pr-,priority=600
             type=ref,event=branch,prefix=cache-,priority=500
             type=ref,event=tag,prefix=cache-,priority=500
+          flavor: |
+            latest=false
       - name: Extract Docker image name
         id: docker_image
         env:


### PR DESCRIPTION
without this the action creates two tags separated by a newline which causes all kinds of trouble