### PR TITLE
Add a development setup using nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,11 @@ target/
 # docker compose
 docker-compose.override.yml
 .devcontainer/.poetry_cache
+
+# direnv
+.direnv/
+.envrc
+
+# nix
+result
+*.qcow2

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ details.
 
 1. `poetry install`
 2. `pre-commit install` to install pre commit hooks
-3. `DUMMY_STORES=true poetry run python bases/renku_data_services/data_api/main.py --debug --dev --fast`
+3. `make run` to run the server
 
 ## Developing
 
@@ -35,6 +35,31 @@ The container image can be built to be used as a local development service (for 
 `docker build -f projects/renku_data_services/Dockerfile . --build-arg DEV_BUILD=true -t renku-data-service`
 
 It can then be run as daemon: `docker run -d -e DUMMY_STORES=true --name renku-crc renku-data-service`
+
+### Developing with nix
+
+When using [nix](https://nixos.org/explore/), a development
+environment can be created:
+
+1. Run `nix develop` in the source root to drop into the development
+   environment.
+2. In another terminal, run `vm-run` (headless) to start a vm running
+   necessary external services, like the postgresql database.
+3. Potentially run `poetry-fix-cfg` to alter the `pyvenv.cfg` so that
+   poetry will use the env built by nix
+
+Then `make run`, `make tests` etc can be used as usual.
+
+The environment also contains other useful tools, like ruff-lsp,
+pyright and more. Instead of a vm, a development environment using
+NixOS containers is also available.
+
+The first invocation will take a while for the first run, as the
+python environment is being built. Subsequent calls are then instant.
+
+It will run a bash shell, check out [direnv](https://direnv.net/) and
+the [use flake](https://direnv.net/man/direnv-stdlib.1.html#codeuse-flake-ltinstallablegtcode)
+function if you prefer to keep your favorite shell.
 
 ## Migrations
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,258 @@
+{
+  "nodes": {
+    "devshell-tools": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1724320658,
+        "narHash": "sha256-YTgT2yHf936sxRHZiggOf5g+wcfxnlz9fAbRSKh5ukI=",
+        "owner": "eikek",
+        "repo": "devshell-tools",
+        "rev": "8f2b96bb183d647ca84a8538305f2b0529527b18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "eikek",
+        "repo": "devshell-tools",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721548954,
+        "narHash": "sha256-7cCC8+Tdq1+3OPyc3+gVo9dzUNkNIQfwSDJ2HSi2u3o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63d37ccd2d178d54e7fb691d7ec76000740ea24a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1724224171,
+        "narHash": "sha256-zyKHydkh5PPQiDPKsgpUmtHGAjR5sNcCKAe56+3W4K0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aea6e7b3614e103cdab310050a9046a4985886d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1719763542,
+        "narHash": "sha256-mXkOj9sJ0f69Nkc2dGGOWtof9d1YNY8Le/Hia3RN+8Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cdd8a11b26b4d60593733106042141756b54a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": "nixpkgs_3",
+        "systems": "systems_4",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1724208502,
+        "narHash": "sha256-TCRcEPSfgAw/t7kClmlr23s591N06mQCrhzlAO7cyFw=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "884b66152b0c625b8220b570a31dc7acc36749a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell-tools": "devshell-tools",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
+        "poetry2nix": "poetry2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719749022,
+        "narHash": "sha256-ddPKHcqaKCIFSFc/cvxS14goUhCOAwsM1PbMr0ZtHMg=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,202 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    devshell-tools.url = "github:eikek/devshell-tools";
+    poetry2nix.url = "github:nix-community/poetry2nix";
+  };
+
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    flake-utils,
+    devshell-tools,
+    poetry2nix,
+  }:
+    {
+      nixosConfigurations = let
+        services = {
+          services.dev-postgres = {
+            enable = true;
+            databases = ["renku"];
+            pgweb = {
+              enable = true;
+              database = "renku";
+            };
+          };
+          services.dev-spicedb = {
+            enable = true;
+          };
+          services.openapi-docs = {
+            enable = true;
+            openapi-spec = "http://localhost:8000/api/data/spec.json";
+          };
+        };
+      in {
+        rdsdev-vm = devshell-tools.lib.mkVm {
+          system = flake-utils.lib.system.x86_64-linux;
+          modules = [
+            {
+              virtualisation.memorySize = 2048;
+              networking.hostName = "rdsdev";
+            }
+            services
+          ];
+        };
+        rsdevcnt = devshell-tools.lib.mkContainer {
+          system = flake-utils.lib.system.x86_64-linux;
+          modules = [
+            services
+          ];
+        };
+      };
+    }
+    // flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      devshellToolsPkgs = devshell-tools.packages.${system};
+
+      poetryLib = poetry2nix.lib.mkPoetry2Nix {inherit pkgs;};
+      p2n-args = {
+        projectDir = ./.;
+        python = pkgs.python312;
+        editablePackageSources = {
+          bases = ./bases;
+          components = ./components;
+        };
+        extraPackages = p: [
+          p.ruff-lsp
+        ];
+        overrides = let
+          add-setuptools = name: final: prev:
+            prev.${name}.overridePythonAttrs (old: {buildInputs = (old.buildInputs or []) ++ [prev.setuptools];});
+          add-poetry = name: final: prev:
+            prev.${name}.overridePythonAttrs (old: {buildInputs = (old.buildInputs or []) ++ [prev.poetry];});
+        in
+          poetryLib.defaultPoetryOverrides.extend
+          (final: prev: {
+            appier = add-setuptools "appier" final prev;
+            inflector = add-setuptools "inflector" final prev;
+            google-api = add-setuptools "google-api" final prev;
+            sanic-ext = add-setuptools "sanic-ext" final prev;
+            undictify = add-setuptools "undictify" final prev;
+            types-cffi = add-setuptools "types-cffi" final prev;
+            avro-preprocessor = add-setuptools "avro-preprocessor" final prev;
+            authzed = add-poetry "authzed" final prev;
+            dataclasses-avroschema = add-poetry "dataclasses-avroschema" final prev;
+            datamodel-code-generator = add-poetry "datamodel-code-generator" final prev;
+            kubernetes-asyncio = add-setuptools "kubernetes-asyncio" final prev;
+            prometheus-sanic =
+              prev.prometheus-sanic.overridePythonAttrs
+              (
+                old: {
+                  buildInputs = (old.buildInputs or []) ++ [prev.poetry prev.poetry-core];
+                  # fix the wrong dependency
+                  # see https://github.com/nix-community/poetry2nix/issues/1694
+                  postPatch = ''
+                    substituteInPlace pyproject.toml --replace "poetry.masonry" "poetry.core.masonry"
+                  '';
+                }
+              );
+          });
+      };
+
+      projectEnv = poetryLib.mkPoetryEnv p2n-args;
+
+      devSettings = {
+        CORS_ALLOW_ALL_ORIGINS = "true";
+        DB_USER = "dev";
+        DB_NAME = "renku";
+        DB_PASSWORD = "dev";
+        AUTHZ_DB_KEY = "dev";
+        AUTHZ_DB_NO_TLS_CONNECTION = "true";
+        AUTHZ_DB_GRPC_PORT = "50051";
+        ALEMBIC_CONFIG = "./components/renku_data_services/migrations/alembic.ini";
+
+        # necessary for poetry run … as it might need to compile stuff
+        # ONLY WHEN NOT using python from nix dev environment
+        #LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON = "true";
+        POETRY_VIRTUALENVS_OPTIONS_SYSTEM_SITE_PACKAGES = "true";
+      };
+
+      fix-poetry-cfg = pkgs.writeShellScriptBin "poetry-fix-cfg" ''
+        python_exec="$(which python)"
+        python_bin="$(dirname "$python_exec")"
+        python_env="$(dirname "$python_bin")"
+
+        env_path="$(poetry env info -p)"
+        if [ -z "$env_path" ]; then
+          poetry env use "$python_exec"
+          env_path="$(poetry env info -p)"
+        fi
+        env_cfg="$env_path/pyvenv.cfg"
+
+        if [ ! -r "$env_path/pyvenv.cfg.bak" ]; then
+          cp "$env_path/pyvenv.cfg" "$env_path/pyvenv.cfg.bak"
+        fi
+
+        echo "Fix paths in: $env_cfg"
+        ${pkgs.gnused}/bin/sed -i -E "s,home = (.*)$,home = $python_bin,g" "$env_cfg"
+        ${pkgs.gnused}/bin/sed -i -E "s,base-prefix = (.*)$,base-prefix = $python_env,g" "$env_cfg"
+        ${pkgs.gnused}/bin/sed -i -E "s,base-exec-prefix = (.*)$,base-exec-prefix = $python_env,g" "$env_cfg"
+        ${pkgs.gnused}/bin/sed -i -E "s,base-executable = (.*)$,base-executable = $python_exec,g" "$env_cfg"
+      '';
+      commonPackages = with pkgs; [
+        redis
+        postgresql
+        jq
+        devshellToolsPkgs.openapi-docs
+        spicedb
+        spicedb-zed
+        ruff
+        ruff-lsp
+        poetry
+        pyright
+        mypy
+        rclone
+        fix-poetry-cfg
+      ];
+    in {
+      formatter = pkgs.alejandra;
+
+      devShells = rec {
+        default = vm;
+        vm = projectEnv.env.overrideAttrs (oldAttrs:
+          devSettings
+          // {
+            buildInputs =
+              commonPackages
+              ++ (builtins.attrValues devshell-tools.legacyPackages.${system}.vm-scripts);
+
+            DEV_VM = "rdsdev-vm";
+            VM_SSH_PORT = "10022";
+
+            DB_HOST = "localhost";
+            DB_PORT = "15432";
+            AUTHZ_DB_HOST = "localhost";
+          });
+
+        cnt = let
+          # authzed-py doesn't allow to connect via non-localhost, so this must
+          # be run (in the background) to forward localhost:50051 to the container
+          forward-auth = pkgs.writeShellScriptBin "authzed-forward-localhost" ''
+            ${pkgs.socat}/bin/socat TCP-LISTEN:50051,fork TCP:rsdevcnt:50051
+          '';
+        in
+          projectEnv.env.overrideAttrs (oldAttrs:
+            devSettings
+            // {
+              buildInputs =
+                commonPackages
+                ++ [forward-auth]
+                ++ (builtins.attrValues devshell-tools.legacyPackages.${system}.cnt-scripts);
+
+              DEV_CONTAINER = "rsdevcnt";
+
+              DB_HOST = "rsdevcnt";
+              DB_PORT = "5432";
+              AUTHZ_DB_HOST = "localhost";
+            });
+      };
+    });
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,17 +65,13 @@ def authz_config(monkeypatch, free_port) -> Iterator[AuthzConfig]:
 @pytest.fixture
 def db_config(monkeypatch, worker_id, authz_config) -> Iterator[DBConfig]:
     db_name = str(ULID()).lower() + "_" + worker_id
-    user = "renku"
-    host = "127.0.0.1"
-    port = 5432
-    password = "renku"  # nosec: B105
+    user = os.getenv("DB_USER", "renku")
+    host = os.getenv("DB_HOST", "127.0.0.1")
+    port = os.getenv("DB_PORT", "5432")
+    password = os.getenv("DB_PASSWORD", "renku")  # nosec: B105
 
     monkeypatch.setenv("DUMMY_STORES", "true")
     monkeypatch.setenv("DB_NAME", db_name)
-    monkeypatch.setenv("DB_USER", user)
-    monkeypatch.setenv("DB_PASSWORD", password)
-    monkeypatch.setenv("DB_HOST", host)
-    monkeypatch.setenv("DB_PORT", port)
     with DatabaseJanitor(
         user=user,
         host=host,


### PR DESCRIPTION
Adds a `flake.nix` file containing a development setup, building the python environment and adding some useful tools. External services can be started by a vm or a NixOS container (based on systemd-nspawn).

The test config has been slightly changed to obtain the db connection information from the environment.