### PR TITLE
chore: Send all search synchronisation events to a single queue

### DIFF
--- a/components/renku_data_services/message_queue/converters.py
+++ b/components/renku_data_services/message_queue/converters.py
@@ -13,7 +13,7 @@ from renku_data_services.namespace import models as group_models
 from renku_data_services.project import models as project_models
 from renku_data_services.users import models as user_models
 
-QUEUE_NAME: Final[str] = "search.sync"
+QUEUE_NAME: Final[str] = "data_service.all_events"
 
 
 def _make_event(message_type: str, payload: AvroModel) -> Event:

--- a/components/renku_data_services/message_queue/orm.py
+++ b/components/renku_data_services/message_queue/orm.py
@@ -1,6 +1,7 @@
 """SQLAlchemy schemas for the CRC database."""
 
 import base64
+import json
 from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
@@ -54,9 +55,15 @@ class EventORM(BaseORM):
         now_utc = datetime.now(UTC).replace(tzinfo=None)
         return cls(timestamp_utc=now_utc, queue=event.queue, payload=message)
 
-    def dump(self) -> Event[dict[str, Any]]:
+    def dump(self) -> Event:
         """Create an event from the ORM object."""
         message = deepcopy(self.payload)
         if "payload" in message and isinstance(message["payload"], str):
             message["payload"] = base64.b64decode(message["payload"])
         return Event(self.queue, message)
+
+    def get_message_type(self) -> str:
+        """Return the message_type from the payload."""
+        headers = self.payload.get("headers", "{}")
+        headers_json = json.loads(headers)
+        return str(headers_json.get("type", ""))

--- a/components/renku_data_services/message_queue/orm.py
+++ b/components/renku_data_services/message_queue/orm.py
@@ -4,7 +4,7 @@ import base64
 import json
 from copy import deepcopy
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Optional
 
 from sqlalchemy import JSON, DateTime, MetaData, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -62,8 +62,12 @@ class EventORM(BaseORM):
             message["payload"] = base64.b64decode(message["payload"])
         return Event(self.queue, message)
 
-    def get_message_type(self) -> str:
+    def get_message_type(self) -> Optional[str]:
         """Return the message_type from the payload."""
         headers = self.payload.get("headers", "{}")
         headers_json = json.loads(headers)
-        return str(headers_json.get("type", ""))
+        message_type = str(headers_json.get("type", ""))
+        if message_type == "":
+            return None
+        else:
+            return message_type

--- a/test/bases/renku_data_services/data_api/test_groups.py
+++ b/test/bases/renku_data_services/data_api/test_groups.py
@@ -41,7 +41,7 @@ async def test_group_creation_basic(
 
     events = await app_config.event_repo._get_pending_events()
 
-    group_events = [e for e in events if e.queue == "group.added"]
+    group_events = [e for e in events if e.get_message_type() == "group.added"]
     assert len(group_events) == 1
     group_event = deserialize_binary(b64decode(group_events[0].payload["payload"]), GroupAdded)
     assert group_event.id == group["id"]
@@ -49,7 +49,7 @@ async def test_group_creation_basic(
     assert group_event.description == group["description"]
     assert group_event.namespace == group["slug"]
 
-    group_events = [e for e in events if e.queue == "memberGroup.added"]
+    group_events = [e for e in events if e.get_message_type() == "memberGroup.added"]
     assert len(group_events) == 1
     group_event = deserialize_binary(b64decode(group_events[0].payload["payload"]), GroupMemberAdded)
     assert group_event.userId == "user"
@@ -139,7 +139,7 @@ async def test_group_patch_delete(
 
     events = await app_config.event_repo._get_pending_events()
 
-    group_events = [e for e in events if e.queue == "group.updated"]
+    group_events = [e for e in events if e.get_message_type() == "group.updated"]
     assert len(group_events) == 1
     group_event = deserialize_binary(b64decode(group_events[0].payload["payload"]), GroupUpdated)
     assert group_event.id == group["id"]
@@ -156,7 +156,7 @@ async def test_group_patch_delete(
 
     events = await app_config.event_repo._get_pending_events()
 
-    group_events = [e for e in events if e.queue == "group.removed"]
+    group_events = [e for e in events if e.get_message_type() == "group.removed"]
     assert len(group_events) == 1
     group_event = deserialize_binary(b64decode(group_events[0].payload["payload"]), GroupRemoved)
     assert group_event.id == group["id"]
@@ -196,7 +196,7 @@ async def test_group_members(
 
     events = await app_config.event_repo._get_pending_events()
 
-    group_events = sorted([e for e in events if e.queue == "memberGroup.added"], key=lambda e: e.id)
+    group_events = sorted([e for e in events if e.get_message_type() == "memberGroup.added"], key=lambda e: e.id)
     assert len(group_events) == 2
     group_event = deserialize_binary(b64decode(group_events[1].payload["payload"]), GroupMemberAdded)
     assert group_event.userId == member_1["id"]
@@ -243,7 +243,7 @@ async def test_removing_single_group_owner_not_allowed(
 
     events = await app_config.event_repo._get_pending_events()
 
-    group_events = [e for e in events if e.queue == "memberGroup.updated"]
+    group_events = [e for e in events if e.get_message_type() == "memberGroup.updated"]
     assert len(group_events) == 1
     group_event = deserialize_binary(b64decode(group_events[0].payload["payload"]), GroupMemberUpdated)
     assert group_event.userId == "member-1"
@@ -256,7 +256,7 @@ async def test_removing_single_group_owner_not_allowed(
 
     events = await app_config.event_repo._get_pending_events()
 
-    group_events = [e for e in events if e.queue == "memberGroup.removed"]
+    group_events = [e for e in events if e.get_message_type() == "memberGroup.removed"]
     assert len(group_events) == 1
     group_event = deserialize_binary(b64decode(group_events[0].payload["payload"]), GroupMemberRemoved)
     assert group_event.userId == "user"

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -73,7 +73,7 @@ async def test_project_creation(sanic_client, user_headers, regular_user, app_co
 
     events = await app_config.event_repo._get_pending_events()
     assert len(events) == 6
-    project_created_event = next((e for e in events if e.queue == "project.created"), None)
+    project_created_event = next((e for e in events if e.get_message_type() == "project.created"), None)
     assert project_created_event
     created_event = deserialize_binary(
         b64decode(project_created_event.payload["payload"]), avro_schema_v2.ProjectCreated
@@ -81,7 +81,7 @@ async def test_project_creation(sanic_client, user_headers, regular_user, app_co
     assert created_event.name == payload["name"]
     assert created_event.slug == payload["slug"]
     assert created_event.repositories == payload["repositories"]
-    project_auth_added = next((e for e in events if e.queue == "projectAuth.added"), None)
+    project_auth_added = next((e for e in events if e.get_message_type() == "projectAuth.added"), None)
     assert project_auth_added
     auth_event = deserialize_binary(b64decode(project_auth_added.payload["payload"]), avro_schema_v2.ProjectMemberAdded)
     assert auth_event.userId == "user"
@@ -301,7 +301,7 @@ async def test_delete_project(create_project, sanic_client, user_headers, app_co
 
     events = await app_config.event_repo._get_pending_events()
     assert len(events) == 15
-    project_removed_event = next((e for e in events if e.queue == "project.removed"), None)
+    project_removed_event = next((e for e in events if e.get_message_type() == "project.removed"), None)
     assert project_removed_event
     removed_event = deserialize_binary(
         b64decode(project_removed_event.payload["payload"]), avro_schema_v2.ProjectRemoved
@@ -338,7 +338,7 @@ async def test_patch_project(create_project, get_project, sanic_client, user_hea
 
     events = await app_config.event_repo._get_pending_events()
     assert len(events) == 11
-    project_updated_event = next((e for e in events if e.queue == "project.updated"), None)
+    project_updated_event = next((e for e in events if e.get_message_type() == "project.updated"), None)
     assert project_updated_event
     updated_event = deserialize_binary(
         b64decode(project_updated_event.payload["payload"]), avro_schema_v2.ProjectUpdated

--- a/test/components/renku_data_services/message_queue/test_EventORM.py
+++ b/test/components/renku_data_services/message_queue/test_EventORM.py
@@ -2,6 +2,7 @@
 
 import json
 
+from renku_data_services.message_queue.converters import QUEUE_NAME
 from renku_data_services.message_queue.models import Event
 from renku_data_services.message_queue.orm import EventORM
 
@@ -11,7 +12,17 @@ def test_message_type_getter(app_config) -> None:
     raw_message = json.loads(
         '{"id":"1","headers":"{\\"source\\":\\"renku-data-services\\",\\"type\\":\\"project.created\\",\\"dataContentType\\":\\"application/avro+binary\\",\\"schemaVersion\\":\\"2\\",\\"time\\":1,\\"requestId\\": \\"0\\"}","payload": ""}'  # noqa: E501
     )
-    event = Event("search.sync", raw_message)
+    event = Event(QUEUE_NAME, raw_message)
     event_orm = EventORM.load(event)
     mt = event_orm.get_message_type()
     assert mt == "project.created"
+
+
+def test_message_type_getter_none(app_config) -> None:
+    raw_message = json.loads(
+        '{"id":"1","headers":"{\\"source\\":\\"renku-data-services\\",\\"dataContentType\\":\\"application/avro+binary\\",\\"schemaVersion\\":\\"2\\",\\"time\\":1,\\"requestId\\": \\"0\\"}","payload": ""}'  # noqa: E501
+    )
+    event = Event(QUEUE_NAME, raw_message)
+    event_orm = EventORM.load(event)
+    mt = event_orm.get_message_type()
+    assert mt is None

--- a/test/components/renku_data_services/message_queue/test_EventORM.py
+++ b/test/components/renku_data_services/message_queue/test_EventORM.py
@@ -1,0 +1,17 @@
+"""Tests for the EventORM class"""
+
+import json
+
+from renku_data_services.message_queue.models import Event
+from renku_data_services.message_queue.orm import EventORM
+
+
+def test_message_type_getter(app_config) -> None:
+    # the messages are stored in the database, where `headers` is a stringifyied dict
+    raw_message = json.loads(
+        '{"id":"1","headers":"{\\"source\\":\\"renku-data-services\\",\\"type\\":\\"project.created\\",\\"dataContentType\\":\\"application/avro+binary\\",\\"schemaVersion\\":\\"2\\",\\"time\\":1,\\"requestId\\": \\"0\\"}","payload": ""}'  # noqa: E501
+    )
+    event = Event("search.sync", raw_message)
+    event_orm = EventORM.load(event)
+    mt = event_orm.get_message_type()
+    assert mt == "project.created"

--- a/test/components/renku_data_services/message_queue/test_queue.py
+++ b/test/components/renku_data_services/message_queue/test_queue.py
@@ -4,6 +4,7 @@ import pytest
 
 from renku_data_services.authz.models import Visibility
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.project_removed import ProjectRemoved
+from renku_data_services.message_queue.converters import QUEUE_NAME
 from renku_data_services.message_queue.redis_queue import dispatch_message
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.namespace.models import Namespace, NamespaceKind
@@ -42,21 +43,21 @@ async def test_queue_send(app_config, monkeypatch) -> None:
     fakerepo = FakeRepo()
     await fakerepo.fake_db_method(some_arg="test")
 
-    events = await app_config.redis.redis_connection.xrange("search.sync")
+    events = await app_config.redis.redis_connection.xrange(QUEUE_NAME)
     assert len(events) == 0
     pending_events = await app_config.event_repo._get_pending_events()
     assert len(pending_events) == 1
 
     await app_config.event_repo.send_pending_events()
 
-    events = await app_config.redis.redis_connection.xrange("search.sync")
+    events = await app_config.redis.redis_connection.xrange(QUEUE_NAME)
     assert len(events) == 1
     pending_events = await app_config.event_repo._get_pending_events()
     assert len(pending_events) == 0
 
     await app_config.event_repo.send_pending_events()
 
-    events = await app_config.redis.redis_connection.xrange("search.sync")
+    events = await app_config.redis.redis_connection.xrange(QUEUE_NAME)
     assert len(events) == 1
     pending_events = await app_config.event_repo._get_pending_events()
     assert len(pending_events) == 0

--- a/test/components/renku_data_services/message_queue/test_queue.py
+++ b/test/components/renku_data_services/message_queue/test_queue.py
@@ -42,21 +42,21 @@ async def test_queue_send(app_config, monkeypatch) -> None:
     fakerepo = FakeRepo()
     await fakerepo.fake_db_method(some_arg="test")
 
-    events = await app_config.redis.redis_connection.xrange("project.removed")
+    events = await app_config.redis.redis_connection.xrange("search.sync")
     assert len(events) == 0
     pending_events = await app_config.event_repo._get_pending_events()
     assert len(pending_events) == 1
 
     await app_config.event_repo.send_pending_events()
 
-    events = await app_config.redis.redis_connection.xrange("project.removed")
+    events = await app_config.redis.redis_connection.xrange("search.sync")
     assert len(events) == 1
     pending_events = await app_config.event_repo._get_pending_events()
     assert len(pending_events) == 0
 
     await app_config.event_repo.send_pending_events()
 
-    events = await app_config.redis.redis_connection.xrange("project.removed")
+    events = await app_config.redis.redis_connection.xrange("search.sync")
     assert len(events) == 1
     pending_events = await app_config.event_repo._get_pending_events()
     assert len(pending_events) == 0


### PR DESCRIPTION
Instead of using multiple queues/streams all the events are now sent to a single stream `search.sync`. They are only intended to synchronize data between data-services and search-service.

This requires a change to the `Event.queue` field. It was used for two things: the redis qeue/stream name and the message type. Now these two are different now and so the event must carry both separately. Events are first stored to the postgres database as single value (its avro payload) and the qeue name is stored alongside. When re-creating the event object from the database, we don't have the `(header, payload)` tuple, but only a `dict[str, Any]` (the raw message). This is different to when creating the event from a `message-type` and structured avro object. Since we never need to read the structured avro object of an event, the `Event` class is now simplified to only carry the raw message. This makes the generic type param obsolete and removes the early return in the `serialize` method which checked the payloads runtime type (as when read from the db).

The `serialize` method is still there to keep the interface, allowing perhaps later to add more structure to the class.

Additional to the canonical constructor of the event, there is a second one, `create`, for creating an event from a structured avro object and message type.