### PR TITLE
fix: empty connection id not serialized for repositories

### DIFF
--- a/components/renku_data_services/repositories/apispec_base.py
+++ b/components/renku_data_services/repositories/apispec_base.py
@@ -17,8 +17,10 @@ class BaseAPISpec(BaseModel):
 
     @field_validator("connection_id", mode="before", check_fields=False)
     @classmethod
-    def serialize_connection_id(cls, connection_id: str | ULID) -> str:
+    def serialize_connection_id(cls, connection_id: str | ULID | None) -> str | None:
         """Custom serializer that can handle ULIDs."""
+        if connection_id is None:
+            return None
         return str(connection_id)
 
 

--- a/test/bases/renku_data_services/data_api/test_repositories.py
+++ b/test/bases/renku_data_services/data_api/test_repositories.py
@@ -76,6 +76,23 @@ def create_oauth2_connection(oauth2_test_client: SanicASGITestClient, user_heade
 
 
 @pytest.mark.asyncio
+async def test_get_repository_without_connection(
+    oauth2_test_client: SanicASGITestClient, user_headers, create_oauth2_provider
+):
+    """Test getting internal Gitlab repository."""
+    await create_oauth2_provider("provider_1")
+    repository_url = "https://example.org/username/my_repo.git"
+
+    _, res = await oauth2_test_client.get(f"/api/data/repositories/{quote_plus(repository_url)}", headers=user_headers)
+
+    assert res.status_code == 200, res.text
+    assert res.json is not None
+    result = res.json
+    assert result.get("provider_id") == "provider_1"
+    assert "connection_id" not in result
+
+
+@pytest.mark.asyncio
 async def test_get_one_repository(oauth2_test_client: SanicASGITestClient, user_headers, create_oauth2_connection):
     connection = await create_oauth2_connection("provider_1")
     repository_url = "https://example.org/username/my_repo.git"


### PR DESCRIPTION
This caused issues for internal gitlab and also when a provider wasn't set up by a user.
