### PR TITLE
fix: patching session launcher returns 500

### DIFF
--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -263,7 +263,7 @@ class SessionRepository:
             authorized = await self.project_authz.has_permission(
                 user,
                 ResourceType.project,
-                str(launcher.project_id),
+                launcher.project_id,
                 Scope.WRITE,
             )
             if not authorized:


### PR DESCRIPTION
Fixes the following error:

![image](https://github.com/user-attachments/assets/92e0c1ee-b64a-424c-b129-d5901593c789)

```
data-service [2024-09-03 14:21:17 +0000] [54] [ERROR] Exception occurred while handling uri: 'https://dev.renku.ch/api/data/session_launchers/01J2E0X0M2Y3643XQ3Z9P57MBY'
data-service Traceback (most recent call last):
data-service   File "handle_request", line 102, in handle_request
data-service     try:
data-service
data-service   File "/app/env/lib/python3.12/site-packages/renku_data_services/base_api/auth.py", line 39, in decorated_function
data-service     response = await f(request, user, *args, **kwargs)
data-service                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
data-service   File "/app/env/lib/python3.12/site-packages/sanic_ext/extras/validation/decorator.py", line 75, in decorated_function
data-service     retval = await retval
data-service              ^^^^^^^^^^^^
data-service   File "/app/env/lib/python3.12/site-packages/renku_data_services/session/blueprints.py", line 136, in _patch
data-service     launcher = await self.session_repo.update_launcher(user=user, launcher_id=launcher_id, **body_dict)
data-service                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
data-service   File "/app/env/lib/python3.12/site-packages/renku_data_services/session/db.py", line 263, in update_launcher
data-service     authorized = await self.project_authz.has_permission(
data-service                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
data-service   File "/app/env/lib/python3.12/site-packages/renku_data_services/authz/authz.py", line 327, in has_permission
data-service     res, _ = await self._has_permission(user, resource_type, resource_id, scope)
data-service              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
data-service   File "/app/env/lib/python3.12/site-packages/renku_data_services/authz/authz.py", line 310, in _has_permission
data-service     res = _AuthzConverter.to_object(resource_type, resource_id)
data-service           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
data-service   File "/app/env/lib/python3.12/site-packages/renku_data_services/authz/authz.py", line 186, in to_object
data-service     raise errors.ProgrammingError(
data-service renku_data_services.errors.errors.ProgrammingError: ProgrammingError: Unexpected or unknown resource type when checking permissions project
```

/deploy