### PR TITLE
chore: Update avro models to current version

### DIFF
--- a/components/renku_data_services/message_queue/avro_models/io/renku/events/v2/__init__.py
+++ b/components/renku_data_services/message_queue/avro_models/io/renku/events/v2/__init__.py
@@ -11,6 +11,8 @@ from renku_data_services.message_queue.avro_models.io.renku.events.v2.project_me
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.project_member_updated import ProjectMemberUpdated
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.project_removed import ProjectRemoved
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.project_updated import ProjectUpdated
+from renku_data_services.message_queue.avro_models.io.renku.events.v2.reprovisioning_finished import ReprovisioningFinished
+from renku_data_services.message_queue.avro_models.io.renku.events.v2.reprovisioning_started import ReprovisioningStarted
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.user_added import UserAdded
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.user_removed import UserRemoved
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.user_updated import UserUpdated

--- a/components/renku_data_services/message_queue/avro_models/io/renku/events/v2/reprovisioning_finished.py
+++ b/components/renku_data_services/message_queue/avro_models/io/renku/events/v2/reprovisioning_finished.py
@@ -1,0 +1,52 @@
+from dataclasses import asdict, dataclass
+from typing import ClassVar, Dict
+
+from dataclasses_avroschema import AvroModel
+from undictify import type_checked_constructor
+
+
+@type_checked_constructor()
+@dataclass
+class ReprovisioningFinished(AvroModel):
+    """
+    Event raised when a reprovisioning of data events finished
+    """
+    id: str
+
+    #: The Avro Schema associated to this class
+    _schema: ClassVar[str] = """{
+        "type": "record",
+        "name": "ReprovisioningFinished",
+        "namespace": "io.renku.events.v2",
+        "doc": "Event raised when a reprovisioning of data events finished",
+        "fields": [
+            {
+                "name": "id",
+                "type": "string"
+            }
+        ]
+    }"""
+
+    def serialize_json(self) -> str:
+        """
+        Returns an Avro-json representation of this instance.
+        """
+        return self.serialize(serialization_type='avro-json').decode('ascii')
+
+    def to_dict(self) -> Dict:
+        """
+        Returns a dictionary version of this instance.
+        """
+        return asdict(self)
+
+    @classmethod
+    def from_dict(
+            cls,
+            the_dict: Dict
+    ) -> 'ReprovisioningFinished':
+        """
+        Returns an instance of this class from a dictionary.
+
+        :param the_dict: The dictionary from which to create an instance of this class.
+        """
+        return cls(**the_dict)

--- a/components/renku_data_services/message_queue/avro_models/io/renku/events/v2/reprovisioning_started.py
+++ b/components/renku_data_services/message_queue/avro_models/io/renku/events/v2/reprovisioning_started.py
@@ -1,0 +1,52 @@
+from dataclasses import asdict, dataclass
+from typing import ClassVar, Dict
+
+from dataclasses_avroschema import AvroModel
+from undictify import type_checked_constructor
+
+
+@type_checked_constructor()
+@dataclass
+class ReprovisioningStarted(AvroModel):
+    """
+    Event raised when a reprovisioning of data events started
+    """
+    id: str
+
+    #: The Avro Schema associated to this class
+    _schema: ClassVar[str] = """{
+        "type": "record",
+        "name": "ReprovisioningStarted",
+        "namespace": "io.renku.events.v2",
+        "doc": "Event raised when a reprovisioning of data events started",
+        "fields": [
+            {
+                "name": "id",
+                "type": "string"
+            }
+        ]
+    }"""
+
+    def serialize_json(self) -> str:
+        """
+        Returns an Avro-json representation of this instance.
+        """
+        return self.serialize(serialization_type='avro-json').decode('ascii')
+
+    def to_dict(self) -> Dict:
+        """
+        Returns a dictionary version of this instance.
+        """
+        return asdict(self)
+
+    @classmethod
+    def from_dict(
+            cls,
+            the_dict: Dict
+    ) -> 'ReprovisioningStarted':
+        """
+        Returns an instance of this class from a dictionary.
+
+        :param the_dict: The dictionary from which to create an instance of this class.
+        """
+        return cls(**the_dict)

--- a/components/renku_data_services/message_queue/schemas/v2/asyncapi.yaml
+++ b/components/renku_data_services/message_queue/schemas/v2/asyncapi.yaml
@@ -1,0 +1,46 @@
+asyncapi: 3.0.0
+info:
+  title: Search Sync Events
+  version: 0.0.1
+servers:
+  redis:
+    host: renku-redis
+    protocol: redis
+    description: Renku Redis Instance
+channels:
+  data_service.all_events:
+    messages:
+      syncEvent:
+        payload:
+          schemaFormat: "application/vnd.apache.avro;version=1.9.0"
+          oneOf:
+            - $ref: './user/events/added.avsc#/UserAdded'
+            - $ref: './user/events/created.avsc#/UserUpdated'
+            - $ref: './user/events/removed.avsc#/UserRemoved'
+            - $ref: './group/events/added.avsc#/GroupAdded'
+            - $ref: './group/events/created.avsc#/GroupUpdated'
+            - $ref: './group/events/removed.avsc#/GroupRemoved'
+            - $ref: './group/events/member_added.avsc#/GroupMemberAdded'
+            - $ref: './group/events/member_added.avsc#/GroupMemberUpdated'
+            - $ref: './group/events/member_removed.avsc#/GroupMemberRemoved'
+            - $ref: './project/events/created.avsc#/ProjectCreated'
+            - $ref: './project/events/updated.avsc#/ProjectUpdated'
+            - $ref: './project/events/removed.avsc#/ProjectRemoved'
+            - $ref: './project/events/member_added.avsc#/ProjectMemberAdded'
+            - $ref: './project/events/member_updated.avsc#/ProjectMemberUpdated'
+            - $ref: './project/events/member_removed.avsc#/ProjectMemberRemoved'
+            - $ref: './notify/events/reprovisioning_started.asvc#/ReprovisioningStarted'
+            - $ref: './notify/events/reprovisioning_finished.asvc#/ReprovisioningFinished'
+        traits:
+        - $ref: '#/components/messageTraits/headers'
+
+components:
+  messageTraits:
+    headers:
+      payload:
+        type: object
+        properties:
+          id:
+            type: string
+          headers:
+            - $ref: '../header/headers.avsc#/Header'

--- a/components/renku_data_services/message_queue/schemas/v2/notify/events/reprovisioning_finished.avsc
+++ b/components/renku_data_services/message_queue/schemas/v2/notify/events/reprovisioning_finished.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name":"ReprovisioningFinished",
+  "namespace":"io.renku.events.v2",
+  "doc":"Event raised when a reprovisioning of data events finished",
+  "fields":[
+    {
+      "name":"id",
+      "type":"string"
+    }
+  ]
+}

--- a/components/renku_data_services/message_queue/schemas/v2/notify/events/reprovisioning_started.avsc
+++ b/components/renku_data_services/message_queue/schemas/v2/notify/events/reprovisioning_started.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name":"ReprovisioningStarted",
+  "namespace":"io.renku.events.v2",
+  "doc":"Event raised when a reprovisioning of data events started",
+  "fields":[
+    {
+      "name":"id",
+      "type":"string"
+    }
+  ]
+}


### PR DESCRIPTION
Ran this build step to download the current avro schema files and generate python model classes:

```
make download_avro
python components/renku_data_services/message_queue/generate_models.py
```