### PR TITLE
fix: update data connectors migrations

### DIFF
--- a/components/renku_data_services/migrations/versions/3cf2adf9896b_add_data_connectors.py
+++ b/components/renku_data_services/migrations/versions/3cf2adf9896b_add_data_connectors.py
@@ -73,6 +73,12 @@ def upgrade() -> None:
         referent_schema="storage",
         ondelete="CASCADE",
     )
+    op.create_check_constraint(
+        "either_project_id_or_data_connector_id_is_set",
+        "entity_slugs",
+        "CAST (project_id IS NOT NULL AS int) + CAST (data_connector_id IS NOT NULL AS int) BETWEEN 0 AND 1",
+        schema="common",
+    )
     op.create_table(
         "data_connector_secrets",
         sa.Column("user_id", sa.String(length=36), nullable=False),
@@ -135,6 +141,8 @@ def downgrade() -> None:
         schema="storage",
     )
     op.drop_table("data_connector_secrets", schema="storage")
+    op.drop_constraint("either_project_id_or_data_connector_id_is_set", "entity_slugs", schema="common", type_="check")
+    op.execute("""DELETE FROM common.entity_slugs WHERE entity_slugs.data_connector_id IS NOT NULL""")
     op.drop_constraint("entity_slugs_data_connector_id_fk", "entity_slugs", schema="common", type_="foreignkey")
     op.drop_index(op.f("ix_common_entity_slugs_data_connector_id"), table_name="entity_slugs", schema="common")
     op.alter_column("entity_slugs", "project_id", existing_type=sa.String(length=26), nullable=False, schema="common")

--- a/components/renku_data_services/migrations/versions/3cf2adf9896b_add_data_connectors.py
+++ b/components/renku_data_services/migrations/versions/3cf2adf9896b_add_data_connectors.py
@@ -142,7 +142,7 @@ def downgrade() -> None:
     )
     op.drop_table("data_connector_secrets", schema="storage")
     op.drop_constraint("either_project_id_or_data_connector_id_is_set", "entity_slugs", schema="common", type_="check")
-    op.execute("""DELETE FROM common.entity_slugs WHERE entity_slugs.data_connector_id IS NOT NULL""")
+    op.execute("DELETE FROM common.entity_slugs WHERE entity_slugs.data_connector_id IS NOT NULL")
     op.drop_constraint("entity_slugs_data_connector_id_fk", "entity_slugs", schema="common", type_="foreignkey")
     op.drop_index(op.f("ix_common_entity_slugs_data_connector_id"), table_name="entity_slugs", schema="common")
     op.alter_column("entity_slugs", "project_id", existing_type=sa.String(length=26), nullable=False, schema="common")

--- a/components/renku_data_services/namespace/orm.py
+++ b/components/renku_data_services/namespace/orm.py
@@ -233,38 +233,6 @@ class EntitySlugORM(BaseORM):
         )
 
 
-class EntitySlugORM_COPY(BaseORM):
-    """Entity slugs."""
-
-    __tablename__ = "entity_slugs_copy"
-    __table_args__ = (
-        Index("entity_slugs_copy_unique_slugs", "namespace_id", "slug", unique=True),
-        # CheckConstraint(
-        #     "CAST (project_id IS NOT NULL AS int) + CAST (data_connector_id IS NOT NULL AS int) BETWEEN 0 AND 1",
-        #     name="either_project_id_or_data_connector_id_is_set",
-        # ),
-    )
-
-    id: Mapped[int] = mapped_column(primary_key=True, init=False)
-    slug: Mapped[str] = mapped_column(String(99), index=True, nullable=False)
-    project_id: Mapped[ULID | None] = mapped_column(
-        ForeignKey(ProjectORM.id, ondelete="CASCADE", name="entity_slugs_project_id_fk_copy"), index=True, nullable=True
-    )
-    project: Mapped[ProjectORM | None] = relationship(lazy="joined", init=False, repr=False, back_populates="slug")
-    data_connector_id: Mapped[ULID | None] = mapped_column(
-        ForeignKey(DataConnectorORM.id, ondelete="CASCADE", name="entity_slugs_data_connector_id_fk_copy"),
-        index=True,
-        nullable=True,
-    )
-    data_connector: Mapped[DataConnectorORM | None] = relationship(
-        lazy="joined", init=False, repr=False, back_populates="slug"
-    )
-    namespace_id: Mapped[ULID] = mapped_column(
-        ForeignKey(NamespaceORM.id, ondelete="CASCADE", name="entity_slugs_namespace_id_fk_copy"), index=True
-    )
-    namespace: Mapped[NamespaceORM] = relationship(lazy="joined", init=False, repr=False, viewonly=True)
-
-
 class EntitySlugOldORM(BaseORM):
     """Entity slugs history."""
 

--- a/components/renku_data_services/namespace/orm.py
+++ b/components/renku_data_services/namespace/orm.py
@@ -233,6 +233,38 @@ class EntitySlugORM(BaseORM):
         )
 
 
+class EntitySlugORM_COPY(BaseORM):
+    """Entity slugs."""
+
+    __tablename__ = "entity_slugs_copy"
+    __table_args__ = (
+        Index("entity_slugs_copy_unique_slugs", "namespace_id", "slug", unique=True),
+        # CheckConstraint(
+        #     "CAST (project_id IS NOT NULL AS int) + CAST (data_connector_id IS NOT NULL AS int) BETWEEN 0 AND 1",
+        #     name="either_project_id_or_data_connector_id_is_set",
+        # ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    slug: Mapped[str] = mapped_column(String(99), index=True, nullable=False)
+    project_id: Mapped[ULID | None] = mapped_column(
+        ForeignKey(ProjectORM.id, ondelete="CASCADE", name="entity_slugs_project_id_fk_copy"), index=True, nullable=True
+    )
+    project: Mapped[ProjectORM | None] = relationship(lazy="joined", init=False, repr=False, back_populates="slug")
+    data_connector_id: Mapped[ULID | None] = mapped_column(
+        ForeignKey(DataConnectorORM.id, ondelete="CASCADE", name="entity_slugs_data_connector_id_fk_copy"),
+        index=True,
+        nullable=True,
+    )
+    data_connector: Mapped[DataConnectorORM | None] = relationship(
+        lazy="joined", init=False, repr=False, back_populates="slug"
+    )
+    namespace_id: Mapped[ULID] = mapped_column(
+        ForeignKey(NamespaceORM.id, ondelete="CASCADE", name="entity_slugs_namespace_id_fk_copy"), index=True
+    )
+    namespace: Mapped[NamespaceORM] = relationship(lazy="joined", init=False, repr=False, viewonly=True)
+
+
 class EntitySlugOldORM(BaseORM):
     """Entity slugs history."""
 


### PR DESCRIPTION
Fixes two issues with the migrations for data connectors:
1.  The migrations cannot be rolled back after creating a data connector. This was caused by leftover entries in the `entity_slugs` table.
2. The entity slug constraint was not created. The change was not picked up by Alembic; it seems Alembic can only handle `CheckConstraint` creation together with table creation, but not new constraints on an existing table, updates to them, or removing them from a table.

Manually tested:
1. Create data connectors with the deployment at `HEAD`
2. Connect to a `data-service` pod and run
    ```bash
    /app/env/bin/python3 -m alembic -c /app/env/lib/python3.12/site-packages/renku_data_services/migrations/alembic.ini --name common downgrade 726d5d0e1f28
    ```
3. Check that the current revision is `726d5d0e1f28`, that is before data connectors
4. Re-apply migrations

Note that this series of actions would fail prior to this fix.

/deploy #notest
