### PR TITLE
test: only load apispec one, don't recalculate routes on each request

### DIFF
--- a/test/bases/renku_data_services/data_api/test_connected_services.py
+++ b/test/bases/renku_data_services/data_api/test_connected_services.py
@@ -4,20 +4,23 @@ from typing import Any
 from urllib.parse import parse_qs, quote, urlparse
 
 import pytest
+import pytest_asyncio
 from sanic import Sanic
 from sanic_testing.testing import SanicASGITestClient
 
 from renku_data_services.app_config import Config
 from renku_data_services.connected_services.dummy_async_oauth2_client import DummyAsyncOAuth2Client
 from renku_data_services.data_api.app import register_all_handlers
+from test.utils import SanicReusableASGITestClient
 
 
-@pytest.fixture
-def oauth2_test_client(app_config: Config) -> SanicASGITestClient:
+@pytest_asyncio.fixture
+async def oauth2_test_client(app_config: Config) -> SanicASGITestClient:
     app_config.async_oauth2_client_class = DummyAsyncOAuth2Client
     app = Sanic(app_config.app_name)
     app = register_all_handlers(app, app_config)
-    return SanicASGITestClient(app)
+    async with SanicReusableASGITestClient(app) as client:
+        yield client
 
 
 @pytest.fixture

--- a/test/bases/renku_data_services/data_api/test_repositories.py
+++ b/test/bases/renku_data_services/data_api/test_repositories.py
@@ -4,20 +4,23 @@ from typing import Any
 from urllib.parse import parse_qs, quote, quote_plus, urlparse
 
 import pytest
+import pytest_asyncio
 from sanic import Sanic
 from sanic_testing.testing import SanicASGITestClient
 
 from renku_data_services.app_config import Config
 from renku_data_services.connected_services.dummy_async_oauth2_client import DummyAsyncOAuth2Client
 from renku_data_services.data_api.app import register_all_handlers
+from test.utils import SanicReusableASGITestClient
 
 
-@pytest.fixture
-def oauth2_test_client(app_config: Config) -> SanicASGITestClient:
+@pytest_asyncio.fixture
+async def oauth2_test_client(app_config: Config) -> SanicASGITestClient:
     app_config.async_oauth2_client_class = DummyAsyncOAuth2Client
     app = Sanic(app_config.app_name)
     app = register_all_handlers(app, app_config)
-    return SanicASGITestClient(app)
+    async with SanicReusableASGITestClient(app) as client:
+        yield client
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,6 +36,29 @@ def free_port() -> int:
         return port
 
 
+@pytest.fixture(scope="session")
+def authz_testing_server(free_port):
+    port = free_port
+    proc = subprocess.Popen(
+        [
+            "spicedb",
+            "serve-testing",
+            "--grpc-addr",
+            f":{port}",
+            "--readonly-grpc-enabled=false",
+            "--skip-release-check=true",
+            "--log-level=debug",
+        ]
+    )
+    yield port
+
+    try:
+        proc.terminate()
+    except Exception as err:
+        logging.error(f"Encountered error when shutting down Authzed DB for testing {err}")
+        proc.kill()
+
+
 @pytest.fixture
 def authz_config(monkeypatch, free_port) -> Iterator[AuthzConfig]:
     port = free_port

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,29 +36,6 @@ def free_port() -> int:
         return port
 
 
-@pytest.fixture(scope="session")
-def authz_testing_server(free_port):
-    port = free_port
-    proc = subprocess.Popen(
-        [
-            "spicedb",
-            "serve-testing",
-            "--grpc-addr",
-            f":{port}",
-            "--readonly-grpc-enabled=false",
-            "--skip-release-check=true",
-            "--log-level=debug",
-        ]
-    )
-    yield port
-
-    try:
-        proc.terminate()
-    except Exception as err:
-        logging.error(f"Encountered error when shutting down Authzed DB for testing {err}")
-        proc.kill()
-
-
 @pytest.fixture
 def authz_config(monkeypatch, free_port) -> Iterator[AuthzConfig]:
     port = free_port


### PR DESCRIPTION
looking at other open PRs right now, running (main) tests takes around 32 minutes.
With these changes, this is down to 18 minutes.

We can further improve this by around -50% if we find a way to have the sanic client be session scoped (one sanic client per worker, not one per test). This should not cause any problems, but would require a significant refactor in how we get the function-scoped database and other `Config` properties into blueprints without rerunning the `register_all_handlers` method. Like we'd need a way to swap out the database connection of repositories per test without constructing a new sanic client. I've created #477 to further investigate this.

For reference, these are the speedups i saw on my machine for main tests with two workers, in seconds:
before memoizing yaml loading: 2205
after memoizing yaml: 1434
after the reusable sanic client (plus yaml memoizing): 1304