### PR TITLE
chore: remove validate_path_project_id

### DIFF
--- a/components/renku_data_services/base_api/auth.py
+++ b/components/renku_data_services/base_api/auth.py
@@ -44,30 +44,6 @@ def authenticate(
     return decorator
 
 
-def validate_path_project_id(
-    f: Callable[Concatenate[Request, _P], Awaitable[_T]],
-) -> Callable[Concatenate[Request, _P], Awaitable[_T]]:
-    """Decorator for a Sanic handler that validates the project_id path parameter."""
-    _path_project_id_regex = re.compile(r"^[A-Za-z0-9]{26}$")
-
-    @wraps(f)
-    async def decorated_function(request: Request, *args: _P.args, **kwargs: _P.kwargs) -> _T:
-        project_id = cast(str | None, kwargs.get("project_id"))
-        if not project_id:
-            raise errors.ProgrammingError(
-                message="Could not find 'project_id' in the keyword arguments for the handler in order to validate it."
-            )
-        if not _path_project_id_regex.match(project_id):
-            raise errors.ValidationError(
-                message=f"The 'project_id' path parameter {project_id} does not match the required "
-                f"regex {_path_project_id_regex}"
-            )
-
-        return await f(request, *args, **kwargs)
-
-    return decorated_function
-
-
 def validate_path_user_id(
     f: Callable[Concatenate[Request, _P], Awaitable[_T]],
 ) -> Callable[Concatenate[Request, _P], Awaitable[_T]]:

--- a/components/renku_data_services/session/blueprints.py
+++ b/components/renku_data_services/session/blueprints.py
@@ -8,7 +8,7 @@ from sanic_ext import validate
 from ulid import ULID
 
 import renku_data_services.base_models as base_models
-from renku_data_services.base_api.auth import authenticate, validate_path_project_id
+from renku_data_services.base_api.auth import authenticate
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
 from renku_data_services.session import apispec
 from renku_data_services.session.db import SessionRepository
@@ -152,8 +152,7 @@ class SessionLaunchersBP(CustomBlueprint):
         """Get all launchers belonging to a project."""
 
         @authenticate(self.authenticator)
-        @validate_path_project_id
-        async def _get_launcher(_: Request, user: base_models.APIUser, project_id: str) -> JSONResponse:
+        async def _get_launcher(_: Request, user: base_models.APIUser, project_id: ULID) -> JSONResponse:
             launchers = await self.session_repo.get_project_launchers(user=user, project_id=project_id)
             return json(
                 [
@@ -162,4 +161,4 @@ class SessionLaunchersBP(CustomBlueprint):
                 ]
             )
 
-        return "/projects/<project_id>/session_launchers", ["GET"], _get_launcher
+        return "/projects/<project_id:ulid>/session_launchers", ["GET"], _get_launcher

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -131,11 +131,9 @@ class SessionRepository:
             launcher = res.all()
             return [item.dump() for item in launcher]
 
-    async def get_project_launchers(self, user: base_models.APIUser, project_id: str) -> list[models.SessionLauncher]:
+    async def get_project_launchers(self, user: base_models.APIUser, project_id: ULID) -> list[models.SessionLauncher]:
         """Get all session launchers in a project from the database."""
-        authorized = await self.project_authz.has_permission(
-            user, ResourceType.project, ULID.from_str(project_id), Scope.READ
-        )
+        authorized = await self.project_authz.has_permission(user, ResourceType.project, project_id, Scope.READ)
         if not authorized:
             raise errors.MissingResourceError(
                 message=f"Project with id '{project_id}' does not exist or you do not have access to it."


### PR DESCRIPTION
This is not needed because we have a custom validator for the type ulid in sanic that we added at some point. So just annotating the path segment as type <project_id:ulid> will work the same.

Here is where the format is registered with Sanic: https://github.com/SwissDataScienceCenter/renku-data-services/blob/main/bases/renku_data_services/data_api/app.py#L31