### PR TITLE
fix: handle spaces in provider_id for connected services

### DIFF
--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -1,7 +1,7 @@
 """Connected services blueprint."""
 
 from dataclasses import dataclass
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 from sanic import HTTPResponse, Request, json, redirect
 from sanic.log import logger
@@ -41,6 +41,7 @@ class OAuth2ClientsBP(CustomBlueprint):
 
         @authenticate(self.authenticator)
         async def _get_one(_: Request, user: base_models.APIUser, provider_id: str) -> JSONResponse:
+            provider_id = unquote(provider_id)
             client = await self.connected_services_repo.get_oauth2_client(provider_id=provider_id, user=user)
             return validated_json(apispec.Provider, client)
 
@@ -67,6 +68,7 @@ class OAuth2ClientsBP(CustomBlueprint):
         async def _patch(
             _: Request, user: base_models.APIUser, provider_id: str, body: apispec.ProviderPatch
         ) -> JSONResponse:
+            provider_id = unquote(provider_id)
             body_dict = body.model_dump(exclude_none=True)
             client = await self.connected_services_repo.update_oauth2_client(
                 user=user, provider_id=provider_id, **body_dict
@@ -81,6 +83,7 @@ class OAuth2ClientsBP(CustomBlueprint):
         @authenticate(self.authenticator)
         @only_admins
         async def _delete(_: Request, user: base_models.APIUser, provider_id: str) -> HTTPResponse:
+            provider_id = unquote(provider_id)
             await self.connected_services_repo.delete_oauth2_client(user=user, provider_id=provider_id)
             return HTTPResponse(status=204)
 
@@ -95,6 +98,7 @@ class OAuth2ClientsBP(CustomBlueprint):
         async def _authorize(
             request: Request, user: base_models.APIUser, provider_id: str, query: AuthorizeParams
         ) -> HTTPResponse:
+            provider_id = unquote(provider_id)
             callback_url = self._get_callback_url(request)
             url = await self.connected_services_repo.authorize_client(
                 provider_id=provider_id, user=user, callback_url=callback_url, next_url=query.next_url

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -13,8 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from ulid import ULID
 
-import renku_data_services.base_models as base_models
-from renku_data_services import errors
+from renku_data_services import base_models, errors
 from renku_data_services.connected_services import apispec, models
 from renku_data_services.connected_services import orm as schemas
 from renku_data_services.connected_services.apispec import ConnectionStatus
@@ -75,11 +74,12 @@ class ConnectedServicesRepository:
         if not user.is_admin:
             raise errors.ForbiddenError(message="You do not have the required permissions for this operation.")
 
+        provider_id = base_models.Slug.from_name(new_client.id).value
         encrypted_client_secret = (
             encrypt_string(self.encryption_key, user.id, new_client.client_secret) if new_client.client_secret else None
         )
         client = schemas.OAuth2ClientORM(
-            id=new_client.id,
+            id=provider_id,
             kind=new_client.kind,
             client_id=new_client.client_id,
             client_secret=encrypted_client_secret,


### PR DESCRIPTION
Fixes #437.

1. Handle spaces for the update and delete endpoints (use `unquote()`).
2. Use `Slug.from_name()` at creation time to avoid special characters in new providers.

/deploy #notest