### PR TITLE
fix: allow project editors to send patches with the current namespace

### DIFF
--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -237,7 +237,7 @@ class ProjectRepository:
         if "visibility" in payload and new_visibility != old_project.visibility:
             # NOTE: changing the visibility requires the user to be owner which means they should have DELETE permission
             required_scope = Scope.DELETE
-        if "namespace" in payload and payload["namespace"] != old_project.namespace:
+        if "namespace" in payload and payload["namespace"] != old_project.namespace.slug:
             # NOTE: changing the namespace requires the user to be owner which means they should have DELETE permission
             required_scope = Scope.DELETE
         authorized = await self.authz.has_permission(user, ResourceType.project, project_id, required_scope)
@@ -267,7 +267,7 @@ class ProjectRepository:
             if key not in ["slug", "id", "created_by", "creation_date", "namespace"]:
                 setattr(project, key, value)
 
-        if "namespace" in payload:
+        if "namespace" in payload and payload["namespace"] != old_project.namespace.slug:
             ns_slug = payload["namespace"]
             ns = await session.scalar(
                 select(ns_schemas.NamespaceORM).where(ns_schemas.NamespaceORM.slug == ns_slug.lower())
@@ -282,7 +282,7 @@ class ProjectRepository:
             has_permission = await self.authz.has_permission(user, resource_type, resource_id, Scope.WRITE)
             if not has_permission:
                 raise errors.ForbiddenError(
-                    message=f"The project cannot be created because you do not have sufficient permissions with the namespace {ns_slug}"  # noqa: E501
+                    message=f"The project cannot be moved because you do not have sufficient permissions with the namespace {ns_slug}"  # noqa: E501
                 )
             project.slug.namespace_id = ns.id
 

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -552,26 +552,6 @@ async def test_patch_description_as_editor_and_keep_namespace(
 
     assert response.status_code == 200, response.text
 
-    # expected_permissions = dict(
-    #     write=False,
-    #     delete=False,
-    #     change_membership=False,
-    # )
-    # if role == "editor" or role == "owner":
-    #     expected_permissions["write"] = True
-    # if role == "owner":
-    #     expected_permissions["delete"] = True
-    #     expected_permissions["change_membership"] = True
-
-    # _, response = await sanic_client.get(f"/api/data/projects/{project_id}/permissions", headers=user_headers)
-
-    # assert response.status_code == 200, response.text
-    # assert response.json is not None
-    # permissions = response.json
-    # assert permissions.get("write") == expected_permissions["write"]
-    # assert permissions.get("delete") == expected_permissions["delete"]
-    # assert permissions.get("change_membership") == expected_permissions["change_membership"]
-
 
 @pytest.mark.asyncio
 async def test_get_all_projects_for_specific_user(

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -532,6 +532,48 @@ async def test_patch_project_invalid_namespace(
 
 
 @pytest.mark.asyncio
+async def test_patch_description_as_editor_and_keep_namespace(
+    sanic_client,
+    create_project,
+    user_headers,
+    regular_user,
+) -> None:
+    project = await create_project("Project 1", admin=True, members=[{"id": regular_user.id, "role": "editor"}])
+    project_id = project["id"]
+
+    headers = merge_headers(user_headers, {"If-Match": project["etag"]})
+    patch = {
+        "namespace": project[
+            "namespace"
+        ],  # Test that we do not require DELETE permission when sending the current namepace
+        "description": "Updated description",
+    }
+    _, response = await sanic_client.patch(f"/api/data/projects/{project_id}", headers=headers, json=patch)
+
+    assert response.status_code == 200, response.text
+
+    # expected_permissions = dict(
+    #     write=False,
+    #     delete=False,
+    #     change_membership=False,
+    # )
+    # if role == "editor" or role == "owner":
+    #     expected_permissions["write"] = True
+    # if role == "owner":
+    #     expected_permissions["delete"] = True
+    #     expected_permissions["change_membership"] = True
+
+    # _, response = await sanic_client.get(f"/api/data/projects/{project_id}/permissions", headers=user_headers)
+
+    # assert response.status_code == 200, response.text
+    # assert response.json is not None
+    # permissions = response.json
+    # assert permissions.get("write") == expected_permissions["write"]
+    # assert permissions.get("delete") == expected_permissions["delete"]
+    # assert permissions.get("change_membership") == expected_permissions["change_membership"]
+
+
+@pytest.mark.asyncio
 async def test_get_all_projects_for_specific_user(
     create_project, sanic_client, user_headers, admin_headers, unauthorized_headers
 ) -> None:


### PR DESCRIPTION
With the current Renku 2.0 UI, when a user with the "editor" role tries to update a project, e.g. the description or keywords, they are not allowed to do so because the UI sends a patch containing the current namespace.

This is fixed in this PR, the added test fails prior to the fix.

Additional note: the `if "namespace" in payload and payload["namespace"] != old_project.namespace` code line was incorrect with respect to typing but this is not caught by `mypy` because the update is passed as an untyped `dict`. I will create a new PR to deprecate and replace `db.py` updates using dictionaries as they are unsafe. The correct approach can be seen in `data_connectors` where a Patch object is used so that all update-able properties are typed.

See example:
```json
{"description":"My new description, it's the only field I touched.","name":"Test Private Project","namespace":"flora-garden","visibility":"private","keywords":[]}
```
Results in 404 with `{"error":{"code":1404,"message":"Project with id '01J0R8RPMARTQG5YVBZN9Y5BE9' does not exist or you do not have access to it."}}`.

/deploy