### PR TITLE
fix: allow project editors to send patches with the current visibility

### DIFF
--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import UTC, datetime
+from enum import Enum
 from typing import Any, Concatenate, ParamSpec, TypeVar
 
 from sqlalchemy import Select, delete, func, select, update
@@ -234,6 +235,8 @@ class ProjectRepository:
         new_visibility = payload.get("visibility")
         if isinstance(new_visibility, str):
             new_visibility = models.Visibility(new_visibility)
+        elif isinstance(new_visibility, Enum):
+            new_visibility = models.Visibility(new_visibility.value)
         if "visibility" in payload and new_visibility != old_project.visibility:
             # NOTE: changing the visibility requires the user to be owner which means they should have DELETE permission
             required_scope = Scope.DELETE

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -532,6 +532,29 @@ async def test_patch_project_invalid_namespace(
 
 
 @pytest.mark.asyncio
+async def test_patch_description_as_editor_and_keep_namespace_and_visibility(
+    sanic_client,
+    create_project,
+    user_headers,
+    regular_user,
+) -> None:
+    project = await create_project("Project 1", admin=True, members=[{"id": regular_user.id, "role": "editor"}])
+    project_id = project["id"]
+
+    headers = merge_headers(user_headers, {"If-Match": project["etag"]})
+    patch = {
+        # Test that we do not require DELETE permission when sending the current namepace
+        "namespace": project["namespace"],
+        # Test that we do not require DELETE permission when sending the current visibility
+        "visibility": project["visibility"],
+        "description": "Updated description",
+    }
+    _, response = await sanic_client.patch(f"/api/data/projects/{project_id}", headers=headers, json=patch)
+
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
 async def test_get_all_projects_for_specific_user(
     create_project, sanic_client, user_headers, admin_headers, unauthorized_headers
 ) -> None:


### PR DESCRIPTION
Follow up from #483: the issue also appears for the `visibility` field.

/deploy