### PR TITLE
refactor: use typed patch instance for project updates

### DIFF
--- a/components/renku_data_services/project/blueprints.py
+++ b/components/renku_data_services/project/blueprints.py
@@ -24,6 +24,7 @@ from renku_data_services.base_models.validation import validate_and_dump, valida
 from renku_data_services.errors import errors
 from renku_data_services.project import apispec
 from renku_data_services.project import models as project_models
+from renku_data_services.project.core import validate_project_patch
 from renku_data_services.project.db import ProjectMemberRepository, ProjectRepository
 from renku_data_services.users.db import UserRepo
 
@@ -136,11 +137,11 @@ class ProjectsBP(CustomBlueprint):
         async def _patch(
             _: Request, user: base_models.APIUser, project_id: str, body: apispec.ProjectPatch, etag: str
         ) -> JSONResponse:
-            body_dict = body.model_dump(exclude_none=True)
-
+            project_patch = validate_project_patch(body)
             project_update = await self.project_repo.update_project(
-                user=user, project_id=ULID.from_str(project_id), etag=etag, payload=body_dict
+                user=user, project_id=ULID.from_str(project_id), etag=etag, patch=project_patch
             )
+
             if not isinstance(project_update, project_models.ProjectUpdate):
                 raise errors.ProgrammingError(
                     message="Expected the result of a project update to be ProjectUpdate but instead "

--- a/components/renku_data_services/project/core.py
+++ b/components/renku_data_services/project/core.py
@@ -1,0 +1,17 @@
+"""Business logic for projects."""
+
+from renku_data_services.authz.models import Visibility
+from renku_data_services.project import apispec, models
+
+
+def validate_project_patch(patch: apispec.ProjectPatch) -> models.ProjectPatch:
+    """Validate the update to a project."""
+    keywords = [kw.root for kw in patch.keywords] if patch.keywords is not None else None
+    return models.ProjectPatch(
+        name=patch.name,
+        namespace=patch.namespace,
+        visibility=Visibility(patch.visibility.value) if patch.visibility is not None else None,
+        repositories=patch.repositories,
+        description=patch.description,
+        keywords=keywords,
+    )

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import functools
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import UTC, datetime
-from enum import Enum
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Concatenate, ParamSpec, TypeVar
 
 from sqlalchemy import Select, delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -216,7 +215,8 @@ class ProjectRepository:
         self,
         user: base_models.APIUser,
         project_id: ULID,
-        payload: dict[str, Any],
+        # payload: dict[str, Any],
+        patch: models.ProjectPatch,
         etag: str | None = None,
         *,
         session: AsyncSession | None = None,
@@ -232,15 +232,10 @@ class ProjectRepository:
         old_project = project.dump()
 
         required_scope = Scope.WRITE
-        new_visibility = payload.get("visibility")
-        if isinstance(new_visibility, str):
-            new_visibility = models.Visibility(new_visibility)
-        elif isinstance(new_visibility, Enum):
-            new_visibility = models.Visibility(new_visibility.value)
-        if "visibility" in payload and new_visibility != old_project.visibility:
+        if patch.visibility is not None and patch.visibility != old_project.visibility:
             # NOTE: changing the visibility requires the user to be owner which means they should have DELETE permission
             required_scope = Scope.DELETE
-        if "namespace" in payload and payload["namespace"] != old_project.namespace.slug:
+        if patch.namespace is not None and patch.namespace != old_project.namespace.slug:
             # NOTE: changing the namespace requires the user to be owner which means they should have DELETE permission
             required_scope = Scope.DELETE
         authorized = await self.authz.has_permission(user, ResourceType.project, project_id, required_scope)
@@ -253,30 +248,14 @@ class ProjectRepository:
         if etag is not None and current_etag != etag:
             raise errors.ConflictError(message=f"Current ETag is {current_etag}, not {etag}.")
 
-        if "repositories" in payload:
-            payload["repositories"] = [
-                schemas.ProjectRepositoryORM(url=r, project_id=project_id_str, project=project)
-                for r in payload["repositories"]
-            ]
-            # Trigger update for ``updated_at`` column
-            await session.execute(update(schemas.ProjectORM).where(schemas.ProjectORM.id == project_id).values())
-
-        if "keywords" in payload and not payload["keywords"]:
-            payload["keywords"] = None
-
-        for key, value in payload.items():
-            # NOTE: ``slug``, ``id``, ``created_by``, and ``creation_date`` cannot be edited or cannot
-            # be edited by setting a property on the ORM object instance.
-            if key not in ["slug", "id", "created_by", "creation_date", "namespace"]:
-                setattr(project, key, value)
-
-        if "namespace" in payload and payload["namespace"] != old_project.namespace.slug:
-            ns_slug = payload["namespace"]
+        if patch.name is not None:
+            project.name = patch.name
+        if patch.namespace is not None and patch.namespace != old_project.namespace.slug:
             ns = await session.scalar(
-                select(ns_schemas.NamespaceORM).where(ns_schemas.NamespaceORM.slug == ns_slug.lower())
+                select(ns_schemas.NamespaceORM).where(ns_schemas.NamespaceORM.slug == patch.namespace.lower())
             )
             if not ns:
-                raise errors.MissingResourceError(message=f"The namespace with slug {ns_slug} does not exist")
+                raise errors.MissingResourceError(message=f"The namespace with slug {patch.namespace} does not exist")
             if not ns.group_id and not ns.user_id:
                 raise errors.ProgrammingError(message="Found a namespace that has no group or user associated with it.")
             resource_type, resource_id = (
@@ -285,9 +264,27 @@ class ProjectRepository:
             has_permission = await self.authz.has_permission(user, resource_type, resource_id, Scope.WRITE)
             if not has_permission:
                 raise errors.ForbiddenError(
-                    message=f"The project cannot be moved because you do not have sufficient permissions with the namespace {ns_slug}"  # noqa: E501
+                    message=f"The project cannot be moved because you do not have sufficient permissions with the namespace {patch.namespace}"  # noqa: E501
                 )
             project.slug.namespace_id = ns.id
+        if patch.visibility is not None:
+            visibility_orm = (
+                project_apispec.Visibility(patch.visibility)
+                if isinstance(patch.visibility, str)
+                else project_apispec.Visibility(patch.visibility.value)
+            )
+            project.visibility = visibility_orm
+        if patch.repositories is not None:
+            project.repositories = [
+                schemas.ProjectRepositoryORM(url=r, project_id=project_id_str, project=project)
+                for r in patch.repositories
+            ]
+            # Trigger update for ``updated_at`` column
+            await session.execute(update(schemas.ProjectORM).where(schemas.ProjectORM.id == project_id).values())
+        if patch.description is not None:
+            project.description = patch.description if patch.description else None
+        if patch.keywords is not None:
+            project.keywords = patch.keywords if patch.keywords else None
 
         await session.flush()
         await session.refresh(project)

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -215,7 +215,6 @@ class ProjectRepository:
         self,
         user: base_models.APIUser,
         project_id: ULID,
-        # payload: dict[str, Any],
         patch: models.ProjectPatch,
         etag: str | None = None,
         *,

--- a/components/renku_data_services/project/models.py
+++ b/components/renku_data_services/project/models.py
@@ -50,6 +50,18 @@ class UnsavedProject(BaseProject):
     namespace: str
 
 
+@dataclass(frozen=True, eq=True, kw_only=True)
+class ProjectPatch:
+    """Model for changes requested on a project."""
+
+    name: str | None
+    namespace: str | None
+    visibility: Visibility | None
+    repositories: list[Repository] | None
+    description: str | None
+    keywords: list[str] | None
+
+
 @dataclass
 class ProjectUpdate:
     """Indicates that a project has been updated and retains the old and new values."""

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -552,6 +552,10 @@ async def test_patch_description_as_editor_and_keep_namespace_and_visibility(
     _, response = await sanic_client.patch(f"/api/data/projects/{project_id}", headers=headers, json=patch)
 
     assert response.status_code == 200, response.text
+    assert response.json is not None
+    assert response.json.get("namespace") == project["namespace"]
+    assert response.json.get("visibility") == project["visibility"]
+    assert response.json.get("description") == "Updated description"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
See #485.

Refactor the project update method to used a typed `ProjectPatch` instance. This means that the update code is now type-checked.

/deploy