### PR TITLE
chore: set in app include so sentry detects our application code

### DIFF
--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -93,6 +93,7 @@ def create_app() -> Sanic:
                 enable_tracing=config.sentry.sample_rate > 0,
                 traces_sample_rate=config.sentry.sample_rate,
                 before_send=filter_error,
+                in_app_include=["renku_data_services"],
             )
 
         # we manually need to set the signals because sentry sanic integration doesn't work with using


### PR DESCRIPTION
Sentry currently detects stack traces for renku code as "system" instead of in-app. This also means it doesn't link to github source code and treats errors as 3rd party library errors.

/deploy #notest extra-values=dataService.sentry.enabled=true,dataService.sentry.dsn=https://e47c95d665684bce89984bd4595268df@sentry.dev.renku.ch/13,dataService.sentry.environment=ci-renku-3548,dataService.sentry.sampleRate=0.5