### PR TITLE
fix: add GRPC integration to Sentry

### DIFF
--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -11,6 +11,7 @@ from sanic import Sanic
 from sanic.log import logger
 from sanic.worker.loader import AppLoader
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
+from sentry_sdk.integrations.grpc import GRPCIntegration
 from sentry_sdk.integrations.sanic import SanicIntegration, _context_enter, _context_exit, _set_transaction
 
 from renku_data_services.app_config import Config
@@ -89,7 +90,11 @@ def create_app() -> Sanic:
             sentry_sdk.init(
                 dsn=config.sentry.dsn,
                 environment=config.sentry.environment,
-                integrations=[AsyncioIntegration(), SanicIntegration(unsampled_statuses={404, 403, 401})],
+                integrations=[
+                    AsyncioIntegration(),
+                    SanicIntegration(unsampled_statuses={404, 403, 401}),
+                    GRPCIntegration(),
+                ],
                 enable_tracing=config.sentry.sample_rate > 0,
                 traces_sample_rate=config.sentry.sample_rate,
                 before_send=filter_error,


### PR DESCRIPTION
Add GRPC integration to Sentry, which adds more information about calls to `authzed`.

Before:
![Screenshot 2024-11-05 at 11 17 39](https://github.com/user-attachments/assets/c259392d-7408-4595-8f1f-a0a0616013cf)

After:
![Screenshot 2024-11-05 at 11 17 49](https://github.com/user-attachments/assets/579a3b7c-4a32-4791-bfa0-9c7576a9bb74)
![Screenshot 2024-11-05 at 11 20 18](https://github.com/user-attachments/assets/f21996b5-90a0-487a-a8f2-148598a5b0cb)

/deploy #notest extra-values=dataService.sentry.enabled=true,dataService.sentry.dsn=https://e47c95d665684bce89984bd4595268df@sentry.dev.renku.ch/13,dataService.sentry.environment=renku-dev-ci-ds-508,dataService.sentry.sampleRate=0.5