### PR TITLE
kpack & Shipwright compatible k3d cluster setup

### DIFF
--- a/.devcontainer/kpack/python-builder.yaml
+++ b/.devcontainer/kpack/python-builder.yaml
@@ -4,7 +4,7 @@ metadata:
   name: python-builder
   namespace: default
 spec:
-  tag: k3d-myregistry.localhost:12345/apps/python-builder
+  tag: kpack-registry.local:5000/apps/python-builder:latest
   stack:
     name: base
     kind: ClusterStack

--- a/Makefile
+++ b/Makefile
@@ -142,11 +142,7 @@ help:  ## Display this help.
 
 .PHONY: k3d_cluster
 k3d_cluster:  ## Creates a k3d cluster for testing
-	k3d node delete k3d-myregistry.localhost
-	k3d cluster delete
-	# k3d registry delete myregistry.localhost || true
-	# k3d registry create myregistry.localhost
-	./setup-k3d-cluster.sh
+	./setup-k3d-cluster.sh --reset --install-shipwright
 
 .PHONY: install_amaltheas
 install_amaltheas:  ## Installs both version of amalthea in the. NOTE: It uses the currently active k8s context.

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ help:  ## Display this help.
 
 .PHONY: k3d_cluster
 k3d_cluster:  ## Creates a k3d cluster for testing
-	./setup-k3d-cluster.sh --reset --install-shipwright
+	./setup-k3d-cluster.sh --reset --deploy-shipwright
 
 .PHONY: install_amaltheas
 install_amaltheas:  ## Installs both version of amalthea in the. NOTE: It uses the currently active k8s context.

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ k3d_cluster:  ## Creates a k3d cluster for testing
 	k3d cluster delete
 	# k3d registry delete myregistry.localhost || true
 	# k3d registry create myregistry.localhost
-	k3d cluster create --registry-create k3d-myregistry.localhost:5000 --agents 1 --k3s-arg --disable=metrics-server@server:0 
+	./setup-k3d-cluster.sh
 
 .PHONY: install_amaltheas
 install_amaltheas:  ## Installs both version of amalthea in the. NOTE: It uses the currently active k8s context.

--- a/registries.yaml
+++ b/registries.yaml
@@ -1,0 +1,4 @@
+mirrors:
+  "kpack-registry.local:5000":
+    endpoint:
+      - http://k3d-kpack-registry.local:5000

--- a/setup-k3d-cluster.sh
+++ b/setup-k3d-cluster.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+KPACK_VERSION=0.15.0
+INTERNL_RE="host\.k3d\.internal"
+REGISTRY_NAME="kpack-registry.local"
+REGISTRY_PORT=5000
+REGISTRY_URI=$REGISTRY_NAME:$REGISTRY_PORT
+K3D_REGISTRY_NAME="k3d-$REGISTRY_NAME"
+
+function setup_registry() {
+    set +e
+    registry=$(k3d registry list | grep $REGISTRY_NAME)
+
+    set -e
+
+    if [[ "$registry" == "" ]]
+    then
+        echo "Creating registry $REGISTRY_URI"
+        k3d registry create $REGISTRY_NAME -p $REGISTRY_PORT
+    else
+        echo "Registry $REGISTRY_NAME already exist -> reusing."
+    fi
+}
+
+function setup_dns() {
+    echo "Updating the cluster DNS configuration to make the registry accessible"
+
+    # Wait for the DNS to contain the internal entry
+    internal_added=false
+
+    until [ $internal_added == true ]
+    do
+
+        configmap=$(kubectl get configmaps --namespace kube-system coredns -o yaml)
+        if [[ $configmap =~ $INTERNL_RE ]]
+        then
+            internal_added=true
+        fi
+    done
+
+    # Add entry to the DNS so that the API of the registry can be accessed
+    kubectl get configmaps --namespace kube-system coredns -o yaml | sed -e "s/\(host.k3d.internal\)/\\1 $REGISTRY_NAME/g" | kubectl apply -f -
+    # Restart the coredns pod to take into account the config change
+    coredns_pod=$(kubectl --namespace kube-system get pods | grep coredns | awk '{print $1}')
+    kubectl --namespace kube-system delete pod "$coredns_pod" --wait=true
+    # Wait for the pod to be back on track
+    coredns_pod=$(kubectl --namespace kube-system get pods | grep coredns | awk '{print $1}')
+    kubectl --namespace kube-system wait --for=condition=Ready "pod/$coredns_pod"
+}
+
+function copy_image() {
+    # copy image to registry
+    echo "Copying image from source registry to $REGISTRY_URI"
+    kubectl create job copy-image --image quay.io/skopeo/stable:latest -- skopeo copy docker://paketobuildpacks/builder-jammy-base:latest docker://$REGISTRY_URI/paketobuildpacks/builder-jammy-base:latest --dest-tls-verify=false
+    kubectl wait --for=condition=complete job/copy-image
+    kubectl delete job copy-image
+}
+
+function setup_kpack() {
+    # deploy kpack
+    kubectl apply -f https://github.com/buildpacks-community/kpack/releases/download/v$KPACK_VERSION/release-$KPACK_VERSION.yaml
+    kubectl --namespace kpack wait deployments.apps/kpack-controller --for='jsonpath={.status.conditions[?(@.type=="Available")].status}=True'
+
+    # create kpack resources
+    kubectl apply -f .devcontainer/kpack/clusterstore.yaml
+    kubectl wait --for=condition=Ready=True clusterstores.kpack.io/default
+    kubectl apply -f .devcontainer/kpack/clusterstack.yaml
+    kubectl wait --for=condition=Ready=True clusterstack.kpack.io/base
+    kubectl apply -f .devcontainer/kpack/python-builder.yaml
+
+    # Fails sometimes because it seems some things happens a bit too fast and it
+    # looks like the reconciler does not retry to reconcile the builder.
+    # Recreating it fixes the situation
+    set +e
+    kubectl wait --for=condition=Ready=True builder.kpack.io/python-builder
+    if [[ $? -eq 1 ]]
+    then
+        kubectl delete -f builder.yaml
+        kubectl apply -f builder.yaml
+    fi
+    set -e
+    kubectl wait --for=condition=Ready=True builder.kpack.io/python-builder
+}
+
+deploy_kpack=false
+create_image=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --deploy-kpack)
+            deploy_kpack=true
+            shift # past value
+            ;;
+        --create-image)
+            create_image=true
+            shift # past value
+            ;;
+        -*|--*)
+            echo "Unknown option $1"
+            exit 1
+            ;;
+    esac
+done
+
+setup_registry
+
+set -e
+k3d cluster create kpack-test --registry-use $K3D_REGISTRY_NAME:$REGISTRY_PORT --registry-config registries.yaml --agents 1 --k3s-arg --disable=metrics-server@server:0
+
+setup_dns
+copy_image
+
+if [[ $deploy_kpack == true ]]
+then
+    setup_kpack
+fi
+
+if [[ $create_image == true ]]
+then
+    kubectl apply -f image.yaml
+fi

--- a/setup-k3d-cluster.sh
+++ b/setup-k3d-cluster.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 
 KPACK_VERSION=0.15.0
+SHIPWRIGHT_VERSION=v0.14.0
 INTERNL_RE="host\.k3d\.internal"
-REGISTRY_NAME="kpack-registry.local"
+REGISTRY_NAME="dev-registry.local"
 REGISTRY_PORT=5000
 REGISTRY_URI=$REGISTRY_NAME:$REGISTRY_PORT
 K3D_REGISTRY_NAME="k3d-$REGISTRY_NAME"
+CLUSTER_NAME="devel"
+
+function delete_all() {
+    k3d cluster delete $CLUSTER_NAME
+    k3d registry delete $REGISTRY_NAME
+}
 
 function setup_registry() {
     set +e
@@ -19,6 +26,21 @@ function setup_registry() {
         k3d registry create $REGISTRY_NAME -p $REGISTRY_PORT
     else
         echo "Registry $REGISTRY_NAME already exist -> reusing."
+    fi
+}
+
+function setup_cluster() {
+    set +e
+    cluster=$(k3d cluster list | grep $CLUSTER_NAME)
+
+    set -e
+
+    if [[ "$cluster" == "" ]]
+    then
+        echo "Creating cluster $CLUSTER_NAME"
+        k3d cluster create $CLUSTER_NAME --registry-use $K3D_REGISTRY_NAME:$REGISTRY_PORT --registry-config registries.yaml --agents 1 --k3s-arg --disable=metrics-server@server:0
+    else
+        echo "Cluster $CLUSTER_NAME already exist -> reusing."
     fi
 }
 
@@ -82,17 +104,76 @@ function setup_kpack() {
     kubectl wait --for=condition=Ready=True builder.kpack.io/python-builder
 }
 
+function setup_shipwright() {
+    # Setup tekton
+    curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/$SHIPWRIGHT_VERSION/hack/install-tekton.sh | bash
+
+    # Setup Shipwright
+    kubectl apply --filename https://github.com/shipwright-io/build/releases/download/$SHIPWRIGHT_VERSION/release.yaml --server-side
+    curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/$SHIPWRIGHT_VERSION/hack/setup-webhook-cert.sh | bash
+    curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
+
+    # Install Shipwright strategies
+    kubectl apply --filename https://github.com/shipwright-io/build/releases/download/$SHIPWRIGHT_VERSION/sample-strategies.yaml --server-side
+
+    set -x
+}
+
+function test_shipwright_build() {
+    cat <<EOF | kubectl apply -f -
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildpack-nodejs-build
+spec:
+  source:
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build
+  strategy:
+    name: buildpacks-v3
+    kind: ClusterBuildStrategy
+  output:
+    image: ${REGISTRY_URI}/sample-nodejs:latest
+EOF
+    cat <<EOF | kubectl create -f -
+    apiVersion: shipwright.io/v1beta1
+    kind: BuildRun
+    metadata:
+      generateName: buildpack-nodejs-buildrun-
+    spec:
+      build:
+        name: buildpack-nodejs-build
+EOF
+}
+
+reset=false
 deploy_kpack=false
+deploy_shipwright=false
 create_image=false
+test_build=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --reset)
+            reset=true
+            shift # past value
+            ;;
         --deploy-kpack)
             deploy_kpack=true
             shift # past value
             ;;
+        --deploy-shipwright)
+            deploy_shipwright=true
+            shift # past value
+            ;;
         --create-image)
             create_image=true
+            shift # past value
+            ;;
+        --test-build)
+            test_build=true
             shift # past value
             ;;
         -*|--*)
@@ -102,20 +183,33 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-setup_registry
+if [[ $reset == true ]]
+then
+    delete_all
+fi
 
-set -e
-k3d cluster create kpack-test --registry-use $K3D_REGISTRY_NAME:$REGISTRY_PORT --registry-config registries.yaml --agents 1 --k3s-arg --disable=metrics-server@server:0
+setup_registry
+setup_cluster
 
 setup_dns
-copy_image
 
 if [[ $deploy_kpack == true ]]
 then
+    copy_image
     setup_kpack
+fi
+
+if [[ $deploy_shipwright == true ]]
+then
+    setup_shipwright
 fi
 
 if [[ $create_image == true ]]
 then
     kubectl apply -f image.yaml
+fi
+
+if [[ $test_build == true ]]
+then
+    test_shipwright_build
 fi


### PR DESCRIPTION
## Describe your changes

This PR adds a script that allows to setup a k3d cluster in such a way that kpack and Shipwright can use it.

A k3d registry is created externally so it can be re-used if the cluster must be re-created without incurring the time required to populate it.

kpack and Shipwright can be optionally (and independently) deployed.

In the context of kpack, the image required for the builder is copied to the registry using a Kubernetes job.