### PR TITLE
chore: set up concurrency limit for tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -11,7 +11,7 @@ on:
       - closed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -8,7 +8,9 @@ on:
       - "v*"
   pull_request:
     branches:
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 env:
   DEVCONTAINER_REGISTRY: ghcr.io
   DEVCONTAINER_IMAGE_NAME: ${{ github.repository }}/devcontainer


### PR DESCRIPTION
this PR sets concurrency for the main tests, so old runs get properly cancelled if there's a new push.

I also changes it from `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` to `group: ${{ github.workflow }}-${{ github.ref || github.run_id }}`. The former is I think just copied from a stack overflow answer, but using `github.ref` makes more sense, as `github.ref` is already `refs/pull/<pr_number>/merge`, so unique per PR. `run_id` is used as a safety fallback for things that aren't PRs where we don't want concurrency.