### PR TITLE
fix: add Renku env variables to Renku 2.0 sessions

### DIFF
--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -478,6 +478,11 @@ class NotebooksNewBP(CustomBlueprint):
                         env=[
                             SessionEnvItem(name="RENKU_BASE_URL_PATH", value=base_server_path),
                             SessionEnvItem(name="RENKU_BASE_URL", value=base_server_url),
+                            SessionEnvItem(name="RENKU_MOUNT_DIR", value=storage_mount.as_posix()),
+                            SessionEnvItem(name="RENKU_SESSION", value="1"),
+                            SessionEnvItem(name="RENKU_SESSION_IP", value="0.0.0.0"),  # nosec B104
+                            SessionEnvItem(name="RENKU_SESSION_PORT", value=f"{environment.port}"),
+                            SessionEnvItem(name="RENKU_WORKING_DIR", value=work_dir.as_posix()),
                         ],
                     ),
                     ingress=Ingress(


### PR DESCRIPTION
Closes #528.

Add the following environment variables:

* RENKU_MOUNT_DIR    Folder which contains the container state between
                     hibernations

* RENKU_SESSION      Set to "1" inside a Renku user session

* RENKU_SESSION_IP   IP where the session web server should be listening

* RENKU_SESSION_PORT Port where the session web server should be listening

* RENKU_WORKING_DIR  Default current working directory of applications within the session container.

/deploy