### PR TITLE
fix: consider storage config passed in when launching sessions

### DIFF
--- a/components/renku_data_services/notebooks/api/schemas/cloud_storage.py
+++ b/components/renku_data_services/notebooks/api/schemas/cloud_storage.py
@@ -94,7 +94,7 @@ class RCloneStorage(ICloudStorageRequest):
             ) = await config.storage_validator.get_storage_by_id(
                 user, internal_gitlab_user, project_id, data["storage_id"]
             )
-            configuration = {**configuration, **(configuration or {})}
+            configuration = {**configuration, **(data.get("configuration", {}))}
             readonly = readonly
         else:
             source_path = data["source_path"]


### PR DESCRIPTION
Moving
https://github.com/SwissDataScienceCenter/renku-notebooks/pull/1912 from ntoebooks repo.