### PR TITLE
fix: use default_filename for secrets in Renku 1.0

### DIFF
--- a/components/renku_data_services/secrets/core.py
+++ b/components/renku_data_services/secrets/core.py
@@ -74,7 +74,11 @@ async def create_k8s_secret(
 
             decrypted_value = decrypt_string(decryption_key, user.id, secret.encrypted_value).encode()  # type: ignore
 
-            keys = key_mapping_with_lists_only[str(secret.id)] if key_mapping_with_lists_only else [secret.name]
+            keys = (
+                key_mapping_with_lists_only[str(secret.id)]
+                if key_mapping_with_lists_only
+                else [secret.default_filename]
+            )
             for key in keys:
                 decrypted_secrets[key] = b64encode(decrypted_value).decode()
     except Exception as e:


### PR DESCRIPTION
Use `default_filename` as the secret's filename for Renku 1.0 sessions.

Forgotten edit, or rebase-yanked from session secrets.

Before, if using spaces or other characters in the secret's name:
![Screenshot 2024-12-19 at 15 25 35](https://github.com/user-attachments/assets/fa3cb7ba-b84b-4d97-a57f-e406b89cc799)

After:
![image](https://github.com/user-attachments/assets/97af0fab-8d2e-456b-9e39-202625e9d195)
![image](https://github.com/user-attachments/assets/0eae8141-a374-4b09-b2e8-cb413d63a001)


/deploy