### PR TITLE
fix: use correct uid/gid when cloning git repos

### DIFF
--- a/components/renku_data_services/notebooks/api/amalthea_patches/git_proxy.py
+++ b/components/renku_data_services/notebooks/api/amalthea_patches/git_proxy.py
@@ -21,9 +21,6 @@ async def main_container(
     config: NotebooksConfig,
     repositories: list[Repository],
     git_providers: list[GitProvider],
-    uid: int = 1000,
-    gid: int = 1000,
-    fs_group: int = 100,
 ) -> client.V1Container | None:
     """The patch that adds the git proxy container to a session statefulset."""
     if not user.is_authenticated or not repositories or user.access_token is None or user.refresh_token is None:
@@ -70,9 +67,8 @@ async def main_container(
     container = client.V1Container(
         image=config.sessions.git_proxy.image,
         security_context={
-            "fsGroup": fs_group,
-            "runAsGroup": gid,
-            "runAsUser": uid,
+            "runAsGroup": 1000,
+            "runAsUser": 1000,
             "allowPrivilegeEscalation": False,
             "runAsNonRoot": True,
         },

--- a/components/renku_data_services/notebooks/api/amalthea_patches/git_proxy.py
+++ b/components/renku_data_services/notebooks/api/amalthea_patches/git_proxy.py
@@ -21,6 +21,9 @@ async def main_container(
     config: NotebooksConfig,
     repositories: list[Repository],
     git_providers: list[GitProvider],
+    uid: int = 1000,
+    gid: int = 1000,
+    fs_group: int = 100,
 ) -> client.V1Container | None:
     """The patch that adds the git proxy container to a session statefulset."""
     if not user.is_authenticated or not repositories or user.access_token is None or user.refresh_token is None:
@@ -67,9 +70,9 @@ async def main_container(
     container = client.V1Container(
         image=config.sessions.git_proxy.image,
         security_context={
-            "fsGroup": 100,
-            "runAsGroup": 1000,
-            "runAsUser": 1000,
+            "fsGroup": fs_group,
+            "runAsGroup": gid,
+            "runAsUser": uid,
             "allowPrivilegeEscalation": False,
             "runAsNonRoot": True,
         },

--- a/components/renku_data_services/notebooks/api/amalthea_patches/init_containers.py
+++ b/components/renku_data_services/notebooks/api/amalthea_patches/init_containers.py
@@ -29,6 +29,8 @@ async def git_clone_container_v2(
     workspace_mount_path: PurePosixPath,
     work_dir: PurePosixPath,
     lfs_auto_fetch: bool = False,
+    uid: int = 1000,
+    gid: int = 1000,
 ) -> dict[str, Any] | None:
     """Returns the specification for the container that clones the user's repositories for new operator."""
     amalthea_session_work_volume: str = "amalthea-volume"
@@ -136,9 +138,8 @@ async def git_clone_container_v2(
         },
         "securityContext": {
             "allowPrivilegeEscalation": False,
-            "fsGroup": 100,
-            "runAsGroup": 100,
-            "runAsUser": 1000,
+            "runAsGroup": gid,
+            "runAsUser": uid,
             "runAsNonRoot": True,
         },
         "volumeMounts": [
@@ -261,7 +262,6 @@ async def git_clone_container(server: "UserServer") -> dict[str, Any] | None:
         },
         "securityContext": {
             "allowPrivilegeEscalation": False,
-            "fsGroup": 100,
             "runAsGroup": 100,
             "runAsUser": 1000,
             "runAsNonRoot": True,

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -334,14 +334,22 @@ class NotebooksNewBP(CustomBlueprint):
                 storage_mount,
                 work_dir,
             )
-            extra_containers = await get_extra_containers(self.nb_config, user, repositories, git_providers)
+            extra_containers = await get_extra_containers(
+                self.nb_config,
+                user,
+                repositories,
+                git_providers,
+                uid=environment.uid,
+                gid=environment.gid,
+                fs_group=environment.gid,
+            )
             extra_volumes.extend(extra_init_volumes_dc)
             extra_init_containers.extend(extra_init_containers_dc)
 
             base_server_url = self.nb_config.sessions.ingress.base_url(server_name)
             base_server_path = self.nb_config.sessions.ingress.base_path(server_name)
             ui_path: str = (
-                f"{base_server_path.rstrip("/")}/{environment.default_url.lstrip("/")}"
+                f"{base_server_path.rstrip('/')}/{environment.default_url.lstrip('/')}"
                 if len(environment.default_url) > 0
                 else base_server_path
             )

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -333,16 +333,10 @@ class NotebooksNewBP(CustomBlueprint):
                 git_providers,
                 storage_mount,
                 work_dir,
-            )
-            extra_containers = await get_extra_containers(
-                self.nb_config,
-                user,
-                repositories,
-                git_providers,
                 uid=environment.uid,
                 gid=environment.gid,
-                fs_group=environment.gid,
             )
+            extra_containers = await get_extra_containers(self.nb_config, user, repositories, git_providers)
             extra_volumes.extend(extra_init_volumes_dc)
             extra_init_containers.extend(extra_init_containers_dc)
 


### PR DESCRIPTION
This was hardcoded for the old sessions so we just re-used the same hardcoded values from v1 sessions. But for v2 we should take this info from the environment.

closes #629 

/deploy