### PR TITLE
refactor: use the k8s cache for buildruns

### DIFF
--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -160,10 +160,11 @@ class BuildsConfig:
         if os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true":
             shipwright_client = None
         else:
+            # TODO: is there a reason to use a different cache URL here?
+            cache_url = os.environ["NB_AMALTHEA_V2__CACHE_URL"]
             shipwright_client = ShipwrightClient(
                 namespace=namespace,
-                # TODO: Use the k8s cache
-                cache_url=None,
+                cache_url=cache_url,
             )
 
         return cls(

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -151,20 +151,17 @@ class ShipwrightClient:
     def __init__(
         self,
         namespace: str,
-        cache_url: str | None,
+        cache_url: str,
         # NOTE: If cache skipping is enabled then when the cache fails a large number of
         # buildruns can overload the k8s API by submitting a lot of calls directly.
         skip_cache_if_unavailable: bool = False,
     ) -> None:
-        self.cache = _ShipwrightCache(url=cache_url) if cache_url else None
+        self.cache = _ShipwrightCache(url=cache_url)
         self.base_client = _ShipwrightClientBase(namespace=namespace)
         self.skip_cache_if_unavailable = skip_cache_if_unavailable
 
     async def list_build_runs(self) -> list[BuildRun]:
         """Get a list of Shipwright BuildRuns."""
-        if self.cache is None:
-            return await self.base_client.list_build_runs()
-
         try:
             return await self.cache.list_build_runs()
         except CacheError:
@@ -176,9 +173,6 @@ class ShipwrightClient:
 
     async def get_build_run(self, name: str) -> BuildRun | None:
         """Get a Shipwright BuildRun."""
-        if self.cache is None:
-            return await self.base_client.get_build_run(name)
-
         try:
             return await self.cache.get_build_run(name)
         except CacheError:


### PR DESCRIPTION
PR Stack:
* #625
  * (this) #647
    * #648
      * #657
      * #656

Related PRs:
* https://github.com/SwissDataScienceCenter/renku-notebooks/pull/2007
* https://github.com/SwissDataScienceCenter/renku/pull/3878

/deploy #notest renku=build/session-env-builders renku-ui=leafty/session-env-builders-5 renku-notebooks=leafty/shipwright-buildrun-cache extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/,dataService.imageBuilders.pushSecretName=flora-docker-secret