### PR TITLE
feat: use the feature gate for image builds

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -129,11 +129,15 @@ def register_all_handlers(app: Sanic, config: Config) -> Sanic:
         session_repo=config.session_repo,
         authenticator=config.authenticator,
     )
-    builds = BuildsBP(
-        name="builds",
-        url_prefix=url_prefix,
-        session_repo=config.session_repo,
-        authenticator=config.authenticator,
+    builds = (
+        BuildsBP(
+            name="builds",
+            url_prefix=url_prefix,
+            session_repo=config.session_repo,
+            authenticator=config.authenticator,
+        )
+        if config.builds_config.enabled
+        else None
     )
     oauth2_clients = OAuth2ClientsBP(
         name="oauth2_clients",
@@ -225,7 +229,6 @@ def register_all_handlers(app: Sanic, config: Config) -> Sanic:
             group.blueprint(),
             session_environments.blueprint(),
             session_launchers.blueprint(),
-            builds.blueprint(),
             oauth2_clients.blueprint(),
             oauth2_connections.blueprint(),
             repositories.blueprint(),
@@ -236,6 +239,8 @@ def register_all_handlers(app: Sanic, config: Config) -> Sanic:
             data_connectors.blueprint(),
         ]
     )
+    if builds is not None:
+        app.blueprint(builds.blueprint())
 
     app.error_handler = CustomErrorHandler(apispec)
     app.config.OAS = False

--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -186,7 +186,10 @@ class BuildsConfig:
             timedelta(seconds=buildrun_build_timeout_seconds) if buildrun_build_timeout_seconds > 0 else None
         )
 
-        if os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true" or not enabled:
+        if os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true":
+            shipwright_client = None
+            enabled = True  # Enable image builds when running tests
+        elif not enabled:
             shipwright_client = None
         else:
             # TODO: is there a reason to use a different cache URL here?

--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -186,7 +186,7 @@ class BuildsConfig:
             timedelta(seconds=buildrun_build_timeout_seconds) if buildrun_build_timeout_seconds > 0 else None
         )
 
-        if os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true":
+        if (not enabled) or (os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true"):
             shipwright_client = None
         else:
             # TODO: is there a reason to use a different cache URL here?

--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -186,7 +186,7 @@ class BuildsConfig:
             timedelta(seconds=buildrun_build_timeout_seconds) if buildrun_build_timeout_seconds > 0 else None
         )
 
-        if (not enabled) or (os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true"):
+        if os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true" or not enabled:
             shipwright_client = None
         else:
             # TODO: is there a reason to use a different cache URL here?

--- a/components/renku_data_services/session/blueprints.py
+++ b/components/renku_data_services/session/blueprints.py
@@ -126,7 +126,7 @@ class SessionLaunchersBP(CustomBlueprint):
         @only_authenticated
         @validate(json=apispec.SessionLauncherPost)
         async def _post(_: Request, user: base_models.APIUser, body: apispec.SessionLauncherPost) -> JSONResponse:
-            new_launcher = validate_unsaved_session_launcher(body)
+            new_launcher = validate_unsaved_session_launcher(body, builds_config=self.session_repo.builds_config)
             launcher = await self.session_repo.insert_launcher(user=user, launcher=new_launcher)
             return validated_json(apispec.SessionLauncher, launcher, status=201)
 
@@ -153,7 +153,9 @@ class SessionLaunchersBP(CustomBlueprint):
                         message="There are errors in the following fields, id: Input should be a valid string"
                     )
 
-                launcher_patch = validate_session_launcher_patch(body, current_launcher)
+                launcher_patch = validate_session_launcher_patch(
+                    body, current_launcher, builds_config=self.session_repo.builds_config
+                )
                 launcher = await self.session_repo.update_launcher(
                     user=user, launcher_id=launcher_id, patch=launcher_patch, session=session
                 )


### PR DESCRIPTION
Configure `renku-data-services` for session image builds based on the helm chart values.

* If `IMAGE_BUILDERS_ENABLED is True` then the new session environments and image builds are available.
* If `IMAGE_BUILDERS_ENABLED is False` then users do not have access to he new session environments and image builds.
  * The API will not validate `POST` or `PATCH` requests which configure image builds.
  * The API will not answer calls to the `/builds` endpoints.

Deployments:
* Feature enabled -> https://renku-ci-ui-3511.dev.renku.ch/
* Feature disabled -> https://renku-ci-ui-3538.dev.renku.ch/