### PR TITLE
feat: define retention parameters

### DIFF
--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -13,6 +13,7 @@ import functools
 import os
 import secrets
 from dataclasses import dataclass, field
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -147,6 +148,8 @@ class BuildsConfig:
     vscodium_python_run_image: str | None = None
     build_strategy_name: str | None = None
     push_secret_name: str | None = None
+    buildrun_retention_after_failed: timedelta | None = None
+    buildrun_retention_after_succeeded: timedelta | None = None
 
     @classmethod
     def from_env(cls, prefix: str = "", namespace: str = "") -> "BuildsConfig":
@@ -156,6 +159,22 @@ class BuildsConfig:
         vscodium_python_run_image = os.environ.get(f"{prefix}BUILD_VSCODIUM_PYTHON_RUN_IMAGE")
         build_strategy_name = os.environ.get(f"{prefix}BUILD_STRATEGY_NAME")
         push_secret_name = os.environ.get(f"{prefix}BUILD_PUSH_SECRET_NAME")
+        buildrun_retention_after_failed_seconds = int(
+            os.environ.get(f"{prefix}BUILD_RUN_RETENTION_AFTER_FAILED_SECONDS") or "0"
+        )
+        buildrun_retention_after_failed = (
+            timedelta(seconds=buildrun_retention_after_failed_seconds)
+            if buildrun_retention_after_failed_seconds > 0
+            else None
+        )
+        buildrun_retention_after_succeeded_seconds = int(
+            os.environ.get(f"{prefix}BUILD_RUN_RETENTION_AFTER_SUCCEEDED_SECONDS") or "0"
+        )
+        buildrun_retention_after_succeeded = (
+            timedelta(seconds=buildrun_retention_after_succeeded_seconds)
+            if buildrun_retention_after_succeeded_seconds > 0
+            else None
+        )
 
         if os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true":
             shipwright_client = None
@@ -174,6 +193,8 @@ class BuildsConfig:
             build_strategy_name=build_strategy_name or None,
             push_secret_name=push_secret_name or None,
             shipwright_client=shipwright_client,
+            buildrun_retention_after_failed=buildrun_retention_after_failed,
+            buildrun_retention_after_succeeded=buildrun_retention_after_succeeded,
         )
 
 

--- a/components/renku_data_services/session/constants.py
+++ b/components/renku_data_services/session/constants.py
@@ -1,5 +1,6 @@
 """Constants for sessions environments, session launchers and container image builds."""
 
+from datetime import timedelta
 from typing import Final
 
 BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX: Final[str] = "harbor.dev.renku.ch/renku-builds/"
@@ -16,3 +17,9 @@ BUILD_DEFAULT_BUILD_STRATEGY_NAME: Final[str] = "renku-buildpacks"
 
 BUILD_DEFAULT_PUSH_SECRET_NAME: Final[str] = "renku-build-secret"
 """The name of the default secret to use when pushing Renku builds."""
+
+BUILD_RUN_DEFAULT_RETENTION_AFTER_FAILED: Final[timedelta] = timedelta(minutes=5)
+"""The default retention TTL for BuildRuns when in failed state."""
+
+BUILD_RUN_DEFAULT_RETENTION_AFTER_SUCCEEDED: Final[timedelta] = timedelta(minutes=5)
+"""The default retention TTL for BuildRuns when in succeeded state."""

--- a/components/renku_data_services/session/crs.py
+++ b/components/renku_data_services/session/crs.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from renku_data_services.session.cr_shipwright_buildrun import Build, Git, ParamValue, Strategy
 from renku_data_services.session.cr_shipwright_buildrun import Model as _BuildRun
 from renku_data_services.session.cr_shipwright_buildrun import Output as BuildOutput
+from renku_data_services.session.cr_shipwright_buildrun import Retention1 as Retention
 from renku_data_services.session.cr_shipwright_buildrun import Source as BuildSource
 from renku_data_services.session.cr_shipwright_buildrun import Spec as BuildRunSpec
 from renku_data_services.session.cr_shipwright_buildrun import Spec1 as BuildSpec

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -931,6 +931,14 @@ class SessionRepository:
         build_strategy_name = self.builds_config.build_strategy_name or constants.BUILD_DEFAULT_BUILD_STRATEGY_NAME
         push_secret_name = self.builds_config.push_secret_name or constants.BUILD_DEFAULT_PUSH_SECRET_NAME
 
+        retention_after_failed = (
+            self.builds_config.buildrun_retention_after_failed or constants.BUILD_RUN_DEFAULT_RETENTION_AFTER_FAILED
+        )
+        retention_after_succeeded = (
+            self.builds_config.buildrun_retention_after_succeeded
+            or constants.BUILD_RUN_DEFAULT_RETENTION_AFTER_SUCCEEDED
+        )
+
         return models.ShipwrightBuildRunParams(
             name=build.k8s_name,
             git_repository=git_repository,
@@ -938,6 +946,8 @@ class SessionRepository:
             output_image=output_image,
             build_strategy_name=build_strategy_name,
             push_secret_name=push_secret_name,
+            retention_after_failed=retention_after_failed,
+            retention_after_succeeded=retention_after_succeeded,
         )
 
     async def _get_environment_authorization(

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -1,7 +1,7 @@
 """Models for sessions."""
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import StrEnum
 from pathlib import PurePosixPath
 
@@ -237,6 +237,8 @@ class ShipwrightBuildRunParams:
     output_image: str
     build_strategy_name: str
     push_secret_name: str
+    retention_after_failed: timedelta | None = None
+    retention_after_succeeded: timedelta | None = None
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)


### PR DESCRIPTION
PR Stack:
* #625
  * #647
    * #648
      * (this) #657
      * #656

Support defining retention parameters for build runs.

Related PR: https://github.com/SwissDataScienceCenter/renku/pull/3913

/deploy #notest renku=leafty/define-buildrun-retention renku-ui=leafty/session-env-builders-5 renku-notebooks=leafty/shipwright-buildrun-cache extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=flora-docker-secret,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/