### PR TITLE
feat: sync entity changes to the solr staging table

### DIFF
--- a/bases/renku_data_services/background_jobs/config.py
+++ b/bases/renku_data_services/background_jobs/config.py
@@ -64,6 +64,7 @@ class SyncConfig:
             event_repo=event_repo,
             group_authz=Authz(authz_config),
             message_queue=message_queue,
+            search_updates_repo=search_updates_repo,
         )
         project_repo = ProjectRepository(
             session_maker=session_maker,
@@ -93,6 +94,7 @@ class SyncConfig:
             message_queue=message_queue,
             event_repo=event_repo,
             group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
             encryption_key=None,
             authz=Authz(authz_config),
         )

--- a/bases/renku_data_services/background_jobs/config.py
+++ b/bases/renku_data_services/background_jobs/config.py
@@ -17,6 +17,7 @@ from renku_data_services.message_queue.db import EventRepository
 from renku_data_services.message_queue.redis_queue import RedisQueue
 from renku_data_services.namespace.db import GroupRepository
 from renku_data_services.project.db import ProjectRepository
+from renku_data_services.search.db import SearchUpdatesRepo
 from renku_data_services.users.db import UserRepo, UsersSync
 from renku_data_services.users.kc_api import IKeycloakAPI, KeycloakAPI
 
@@ -57,6 +58,7 @@ class SyncConfig:
 
         authz_config = AuthzConfig.from_env()
         event_repo = EventRepository(session_maker=session_maker, message_queue=message_queue)
+        search_updates_repo = SearchUpdatesRepo(session_maker=session_maker)
         group_repo = GroupRepository(
             session_maker,
             event_repo=event_repo,
@@ -68,6 +70,7 @@ class SyncConfig:
             message_queue=message_queue,
             event_repo=event_repo,
             group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
             authz=Authz(authz_config),
         )
         data_connector_repo = DataConnectorRepository(

--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -345,6 +345,7 @@ class Config:
                 event_repo=self.event_repo,
                 group_authz=self.authz,
                 message_queue=self.message_queue,
+                search_updates_repo=self.search_updates_repo,
             )
         return self._group_repo
 
@@ -376,6 +377,7 @@ class Config:
                 message_queue=self.message_queue,
                 event_repo=self.event_repo,
                 group_repo=self.group_repo,
+                search_updates_repo=self.search_updates_repo,
                 encryption_key=self.encryption_key,
                 authz=self.authz,
             )

--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -308,6 +308,7 @@ class Config:
                 message_queue=self.message_queue,
                 event_repo=self.event_repo,
                 group_repo=self.group_repo,
+                search_updates_repo=self.search_updates_repo,
             )
         return self._project_repo
 

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -221,8 +221,8 @@ class ProjectRepository:
 
     @with_db_transaction
     @Authz.authz_change(AuthzOperation.create, ResourceType.project)
-    @dispatch_message(avro_schema_v2.ProjectCreated)
     @update_search_document
+    @dispatch_message(avro_schema_v2.ProjectCreated)
     async def insert_project(
         self,
         user: base_models.APIUser,

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -221,6 +221,7 @@ class ProjectRepository:
 
     @with_db_transaction
     @Authz.authz_change(AuthzOperation.create, ResourceType.project)
+    @dispatch_message(avro_schema_v2.ProjectCreated)
     @update_search_document
     async def insert_project(
         self,
@@ -293,6 +294,7 @@ class ProjectRepository:
     @with_db_transaction
     @Authz.authz_change(AuthzOperation.update, ResourceType.project)
     @dispatch_message(avro_schema_v2.ProjectUpdated)
+    @update_search_document
     async def update_project(
         self,
         user: base_models.APIUser,
@@ -406,6 +408,7 @@ class ProjectRepository:
     @with_db_transaction
     @Authz.authz_change(AuthzOperation.delete, ResourceType.project)
     @dispatch_message(avro_schema_v2.ProjectRemoved)
+    @update_search_document
     async def delete_project(
         self, user: base_models.APIUser, project_id: ULID, *, session: AsyncSession | None = None
     ) -> models.DeletedProject | None:

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -34,6 +34,8 @@ from renku_data_services.namespace.db import GroupRepository
 from renku_data_services.project import apispec as project_apispec
 from renku_data_services.project import constants, models
 from renku_data_services.project import orm as schemas
+from renku_data_services.search.db import SearchUpdatesRepo
+from renku_data_services.search.decorators import update_search_document
 from renku_data_services.secrets import orm as secrets_schemas
 from renku_data_services.secrets.core import encrypt_user_secret
 from renku_data_services.secrets.models import SecretKind
@@ -52,12 +54,14 @@ class ProjectRepository:
         message_queue: IMessageQueue,
         event_repo: EventRepository,
         group_repo: GroupRepository,
+        search_updates_repo: SearchUpdatesRepo,
         authz: Authz,
     ) -> None:
         self.session_maker = session_maker
         self.message_queue: IMessageQueue = message_queue
         self.event_repo: EventRepository = event_repo
         self.group_repo: GroupRepository = group_repo
+        self.search_updates_repo: SearchUpdatesRepo = search_updates_repo
         self.authz = authz
 
     async def get_projects(
@@ -217,7 +221,7 @@ class ProjectRepository:
 
     @with_db_transaction
     @Authz.authz_change(AuthzOperation.create, ResourceType.project)
-    @dispatch_message(avro_schema_v2.ProjectCreated)
+    @update_search_document
     async def insert_project(
         self,
         user: base_models.APIUser,

--- a/components/renku_data_services/search/core.py
+++ b/components/renku_data_services/search/core.py
@@ -88,6 +88,8 @@ async def update_solr(search_updates_repo: SearchUpdatesRepo, solr_client: SolrC
             else:
                 counter = counter + len(entries)
                 await search_updates_repo.mark_processed(ids)
+
+            await solr_client.delete("deleted:true")
         except Exception as e:
             logger.error(f"Error while updating solr with entities {ids}", exc_info=e)
             try:

--- a/components/renku_data_services/search/core.py
+++ b/components/renku_data_services/search/core.py
@@ -9,6 +9,7 @@ from renku_data_services.message_queue.models import Reprovisioning
 from renku_data_services.namespace.db import GroupRepository
 from renku_data_services.project.db import ProjectRepository
 from renku_data_services.search.db import SearchUpdatesRepo
+from renku_data_services.search.models import DeleteDoc
 from renku_data_services.solr.solr_client import (
     DefaultSolrClient,
     RawDocument,
@@ -89,7 +90,15 @@ async def update_solr(search_updates_repo: SearchUpdatesRepo, solr_client: SolrC
                 counter = counter + len(entries)
                 await search_updates_repo.mark_processed(ids)
 
-            await solr_client.delete("deleted:true")
+            try:
+                # In the above upsert, documents could get
+                # "soft-deleted". This would finally remove them. As
+                # the success of this is not production critical,
+                # errors are only logged
+                await solr_client.delete(DeleteDoc.solr_query())
+            except Exception as de:
+                logger.error("Error when removing soft-deleted documents", exc_info=de)
+
         except Exception as e:
             logger.error(f"Error while updating solr with entities {ids}", exc_info=e)
             try:

--- a/components/renku_data_services/search/db.py
+++ b/components/renku_data_services/search/db.py
@@ -91,7 +91,7 @@ class SearchUpdatesRepo:
                     "payload": json.dumps(dp.to_dict()),
                 }
 
-    async def upsert(self, entity: UserInfo | Group | Project, started_at: datetime | None) -> ULID:
+    async def upsert(self, entity: UserInfo | Group | Project, started_at: datetime | None = None) -> ULID:
         """Add entity documents to the staging table.
 
         If a user already exists, it is updated.

--- a/components/renku_data_services/search/db.py
+++ b/components/renku_data_services/search/db.py
@@ -93,10 +93,10 @@ class SearchUpdatesRepo:
                 }
             case DeleteDoc() as d:
                 return {
-                    "entity_id": d.doc_id,
+                    "entity_id": d.id,
                     "entity_type": d.entity_type,
                     "created_at": started,
-                    "payload": json.dumps({"id": d.doc_id, "deleted": True}),
+                    "payload": json.dumps(d.to_dict()),
                 }
 
     async def upsert(self, entity: Entity, started_at: datetime | None = None) -> ULID:

--- a/components/renku_data_services/search/decorators.py
+++ b/components/renku_data_services/search/decorators.py
@@ -1,0 +1,62 @@
+"""Message queue implementation for redis streams."""
+
+import functools
+from collections.abc import Awaitable, Callable
+from typing import Concatenate, ParamSpec, Protocol, TypeVar
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from renku_data_services.errors import errors
+from renku_data_services.namespace.models import Group
+from renku_data_services.project.models import Project
+from renku_data_services.search.db import SearchUpdatesRepo
+from renku_data_services.users.models import UserInfo
+
+
+class WithSearchUpdateRepo(Protocol):
+    """The protocol required for a class to send messages to a message queue."""
+
+    @property
+    def search_updates_repo(self) -> SearchUpdatesRepo:
+        """Returns the repository for updating search documents."""
+        ...
+
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+_WithSearchUpdateRepo = TypeVar("_WithSearchUpdateRepo", bound=WithSearchUpdateRepo)
+
+
+def update_search_document(
+    f: Callable[Concatenate[_WithSearchUpdateRepo, _P], Awaitable[_T]],
+) -> Callable[Concatenate[_WithSearchUpdateRepo, _P], Awaitable[_T]]:
+    """Initializes a transaction and commits it on successful exit of the wrapped function."""
+
+    @functools.wraps(f)
+    async def func_wrapper(self: _WithSearchUpdateRepo, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        session = kwargs.get("session")
+        if not isinstance(session, AsyncSession):
+            raise errors.ProgrammingError(
+                message="The decorator that populates the message queue expects a valid database session "
+                f"in the keyword arguments instead it got {type(session)}."
+            )
+        result = await f(self, *args, **kwargs)
+        if result is None:
+            return result
+
+        match result:
+            case Project() as p:
+                await self.search_updates_repo.upsert(p)
+
+            case UserInfo() as u:
+                await self.search_updates_repo.upsert(u)
+
+            case Group() as g:
+                await self.search_updates_repo.upsert(g)
+
+            case _:
+                pass
+
+        return result
+
+    return func_wrapper

--- a/components/renku_data_services/search/decorators.py
+++ b/components/renku_data_services/search/decorators.py
@@ -10,6 +10,7 @@ from renku_data_services.errors import errors
 from renku_data_services.namespace.models import DeletedGroup, Group
 from renku_data_services.project.models import DeletedProject, Project, ProjectUpdate
 from renku_data_services.search.db import SearchUpdatesRepo
+from renku_data_services.search.models import DeleteDoc
 from renku_data_services.users.models import DeletedUser, UserInfo, UserInfoUpdate
 
 
@@ -52,7 +53,8 @@ def update_search_document(
                 await self.search_updates_repo.upsert(p.new)
 
             case DeletedProject() as p:
-                pass  # todo: oops, forgot that case 😅
+                record = DeleteDoc.project(p.id)
+                await self.search_updates_repo.upsert(record)
 
             case UserInfo() as u:
                 await self.search_updates_repo.upsert(u)
@@ -61,13 +63,15 @@ def update_search_document(
                 await self.search_updates_repo.upsert(u.new)
 
             case DeletedUser() as u:
-                pass  # todo: oops, forgot that case 😅
+                record = DeleteDoc.user(u.id)
+                await self.search_updates_repo.upsert(record)
 
             case Group() as g:
                 await self.search_updates_repo.upsert(g)
 
             case DeletedGroup() as g:
-                pass  # todo: oops, forgot that case 😅
+                record = DeleteDoc.group(g.id)
+                await self.search_updates_repo.upsert(record)
 
             case list():
                 match result:

--- a/components/renku_data_services/search/decorators.py
+++ b/components/renku_data_services/search/decorators.py
@@ -2,7 +2,7 @@
 
 import functools
 from collections.abc import Awaitable, Callable
-from typing import Concatenate, ParamSpec, Protocol, TypeVar
+from typing import Concatenate, ParamSpec, Protocol, TypeVar, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -69,12 +69,12 @@ def update_search_document(
             case DeletedGroup() as g:
                 pass  # todo: oops, forgot that case 😅
 
-            case _:
-                if isinstance(result, list):
-                    for element in result:
-                        match element:
-                            case UserInfo() as u:
-                                await self.search_updates_repo.upsert(u)
+            case list():
+                match result:
+                    case [UserInfo(), *_] as els:
+                        users = cast(list[UserInfo], els)
+                        for u in users:
+                            await self.search_updates_repo.upsert(u)
 
         return result
 

--- a/components/renku_data_services/search/decorators.py
+++ b/components/renku_data_services/search/decorators.py
@@ -1,4 +1,4 @@
-"""Message queue implementation for redis streams."""
+"""Decorators to support search integration."""
 
 import functools
 from collections.abc import Awaitable, Callable

--- a/components/renku_data_services/search/models.py
+++ b/components/renku_data_services/search/models.py
@@ -1,5 +1,7 @@
 """Model classes for search."""
 
+from typing import Any
+
 from pydantic import BaseModel
 from ulid import ULID
 
@@ -11,23 +13,32 @@ from renku_data_services.users.models import UserInfo
 class DeleteDoc(BaseModel):
     """A special payload for the staging table indicating to delete a document in solr."""
 
-    doc_id: str
+    id: str
     entity_type: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the dict representation."""
+        return {"id": self.id, "deleted": True}
+
+    @classmethod
+    def solr_query(cls) -> str:
+        """Returns the solr query that would select all documents of this type."""
+        return "deleted:true"
 
     @classmethod
     def group(cls, id: ULID) -> "DeleteDoc":
         """For deleting a group."""
-        return DeleteDoc(doc_id=str(id), entity_type="Group")
+        return DeleteDoc(id=str(id), entity_type="Group")
 
     @classmethod
     def project(cls, id: ULID) -> "DeleteDoc":
         """For deleting a project."""
-        return DeleteDoc(doc_id=str(id), entity_type="Project")
+        return DeleteDoc(id=str(id), entity_type="Project")
 
     @classmethod
     def user(cls, id: str) -> "DeleteDoc":
         """For deleting a user."""
-        return DeleteDoc(doc_id=id, entity_type="User")
+        return DeleteDoc(id=id, entity_type="User")
 
 
 Entity = UserInfo | Group | Project | DeleteDoc

--- a/components/renku_data_services/search/models.py
+++ b/components/renku_data_services/search/models.py
@@ -1,0 +1,33 @@
+"""Model classes for search."""
+
+from pydantic import BaseModel
+from ulid import ULID
+
+from renku_data_services.namespace.models import Group
+from renku_data_services.project.models import Project
+from renku_data_services.users.models import UserInfo
+
+
+class DeleteDoc(BaseModel):
+    """A special payload for the staging table indicating to delete a document in solr."""
+
+    doc_id: str
+    entity_type: str
+
+    @classmethod
+    def group(cls, id: ULID) -> "DeleteDoc":
+        """For deleting a group."""
+        return DeleteDoc(doc_id=str(id), entity_type="Group")
+
+    @classmethod
+    def project(cls, id: ULID) -> "DeleteDoc":
+        """For deleting a project."""
+        return DeleteDoc(doc_id=str(id), entity_type="Project")
+
+    @classmethod
+    def user(cls, id: str) -> "DeleteDoc":
+        """For deleting a user."""
+        return DeleteDoc(doc_id=id, entity_type="User")
+
+
+Entity = UserInfo | Group | Project | DeleteDoc

--- a/components/renku_data_services/users/db.py
+++ b/components/renku_data_services/users/db.py
@@ -209,7 +209,6 @@ class UsersSync:
         self.authz = authz
         self.search_updates_repo = user_repo.search_updates_repo
 
-
     async def _get_user(self, id: str) -> UserInfo | None:
         """Get a specific user."""
         async with self.session_maker() as session, session.begin():

--- a/components/renku_data_services/users/db.py
+++ b/components/renku_data_services/users/db.py
@@ -207,11 +207,8 @@ class UsersSync:
         self.group_repo = group_repo
         self.user_repo = user_repo
         self.authz = authz
+        self.search_updates_repo = user_repo.search_updates_repo
 
-    @property
-    def search_updates_repo(self) -> SearchUpdatesRepo:
-        """Return the SearchUpdatesRepo to fulfill the decorator requirements."""
-        return self.search_updates_repo
 
     async def _get_user(self, id: str) -> UserInfo | None:
         """Get a specific user."""
@@ -223,8 +220,8 @@ class UsersSync:
 
     @with_db_transaction
     @Authz.authz_change(AuthzOperation.update_or_insert, ResourceType.user)
-    @dispatch_message(events.UpdateOrInsertUser)
     @update_search_document
+    @dispatch_message(events.UpdateOrInsertUser)
     async def update_or_insert_user(
         self, user: UnsavedUserInfo, *, session: AsyncSession | None = None
     ) -> UserInfoUpdate:

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,10 @@
         python312
         basedpyright
         rclone
+        (writeShellScriptBin "pyfix" ''
+          poetry run ruff check --fix
+          poetry run ruff format
+        '')
       ];
     in {
       formatter = pkgs.alejandra;

--- a/test/bases/renku_data_services/background_jobs/test_sync.py
+++ b/test/bases/renku_data_services/background_jobs/test_sync.py
@@ -50,6 +50,7 @@ from renku_data_services.namespace.models import Namespace, NamespaceKind
 from renku_data_services.namespace.orm import NamespaceORM
 from renku_data_services.project.db import ProjectRepository
 from renku_data_services.project.models import UnsavedProject
+from renku_data_services.search.db import SearchUpdatesRepo
 from renku_data_services.storage.models import UnsavedCloudStorage
 from renku_data_services.storage.orm import CloudStorageORM
 from renku_data_services.users.db import UserRepo, UsersSync
@@ -69,11 +70,13 @@ def get_app_configs(db_instance: DBConfig, authz_instance: AuthzConfig):
         redis = RedisConfig.fake()
         message_queue = RedisQueue(redis)
         event_repo = EventRepository(db_instance.async_session_maker, message_queue=message_queue)
+        search_updates_repo = SearchUpdatesRepo(db_instance.async_session_maker)
         group_repo = GroupRepository(
             session_maker=db_instance.async_session_maker,
             event_repo=event_repo,
             group_authz=Authz(authz_instance),
             message_queue=message_queue,
+            search_updates_repo=search_updates_repo,
         )
         project_repo = ProjectRepository(
             session_maker=db_instance.async_session_maker,
@@ -81,6 +84,7 @@ def get_app_configs(db_instance: DBConfig, authz_instance: AuthzConfig):
             event_repo=event_repo,
             group_repo=group_repo,
             authz=Authz(authz_instance),
+            search_updates_repo=search_updates_repo,
         )
         data_connector_repo = DataConnectorRepository(
             session_maker=db_instance.async_session_maker,
@@ -104,6 +108,7 @@ def get_app_configs(db_instance: DBConfig, authz_instance: AuthzConfig):
             group_repo=group_repo,
             encryption_key=secrets.token_bytes(32),
             authz=Authz(authz_instance),
+            search_updates_repo=search_updates_repo,
         )
         users_sync = UsersSync(
             db_instance.async_session_maker,


### PR DESCRIPTION
- Add a decorator that intercepts db calls to additionally update the search staging table

/deploy renku=build/search-migration-part1