### PR TITLE
feat: select specific nodes for image builds

### DIFF
--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -154,7 +154,6 @@ class BuildsConfig:
     buildrun_retention_after_failed: timedelta | None = None
     buildrun_retention_after_succeeded: timedelta | None = None
     buildrun_build_timeout: timedelta | None = None
-
     node_selector: dict[str, str] | None = None
     tolerations: list[session_crs.Toleration] | None = None
 

--- a/components/renku_data_services/session/crs.py
+++ b/components/renku_data_services/session/crs.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from renku_data_services.session.cr_shipwright_buildrun import Build, Git, ParamValue, Strategy
+from renku_data_services.session.cr_shipwright_buildrun import Build, Git, ParamValue, Strategy, Toleration
 from renku_data_services.session.cr_shipwright_buildrun import Model as _BuildRun
 from renku_data_services.session.cr_shipwright_buildrun import Output as BuildOutput
 from renku_data_services.session.cr_shipwright_buildrun import Retention1 as Retention

--- a/components/renku_data_services/session/crs.py
+++ b/components/renku_data_services/session/crs.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 from renku_data_services.session.cr_shipwright_buildrun import Build, Git, ParamValue, Strategy, Toleration
 from renku_data_services.session.cr_shipwright_buildrun import Model as _BuildRun
@@ -51,3 +51,15 @@ class TaskRun(_TaskRunBase):
     """Tekton TaskRun."""
 
     metadata: Metadata
+
+
+class NodeSelector(RootModel[dict[str, str] | None]):
+    """A k8s node selector."""
+
+    root: dict[str, str] | None = None
+
+
+class Tolerations(RootModel[list[Toleration] | None]):
+    """A list of k8s tolerations."""
+
+    root: list[Toleration] | None = None

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -978,6 +978,9 @@ class SessionRepository:
         )
         build_timeout = self.builds_config.buildrun_build_timeout or constants.BUILD_RUN_DEFAULT_TIMEOUT
 
+        # TODO: Get this from the chart values
+        node_selector = {"renku.io/node-purpose": "image-build"}
+
         return models.ShipwrightBuildRunParams(
             name=build.k8s_name,
             git_repository=git_repository,
@@ -988,6 +991,7 @@ class SessionRepository:
             retention_after_failed=retention_after_failed,
             retention_after_succeeded=retention_after_succeeded,
             build_timeout=build_timeout,
+            node_selector=node_selector,
         )
 
     async def _get_environment_authorization(

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -19,7 +19,7 @@ from renku_data_services.authz.authz import Authz, ResourceType
 from renku_data_services.authz.models import Scope
 from renku_data_services.base_models.core import RESET
 from renku_data_services.crc.db import ResourcePoolRepository
-from renku_data_services.session import constants, crs, models
+from renku_data_services.session import constants, models
 from renku_data_services.session import orm as schemas
 from renku_data_services.session.k8s_client import ShipwrightClient
 
@@ -978,12 +978,6 @@ class SessionRepository:
         )
         build_timeout = self.builds_config.buildrun_build_timeout or constants.BUILD_RUN_DEFAULT_TIMEOUT
 
-        # TODO: Get this from the chart values
-        node_selector = {"renku.io/node-purpose": "image-build"}
-        tolerations: list[crs.Toleration] = [
-            crs.Toleration(key="renku.io/dedicated", operator="Equal", effect="NoSchedule", value="image-build")
-        ]
-
         return models.ShipwrightBuildRunParams(
             name=build.k8s_name,
             git_repository=git_repository,
@@ -994,8 +988,8 @@ class SessionRepository:
             retention_after_failed=retention_after_failed,
             retention_after_succeeded=retention_after_succeeded,
             build_timeout=build_timeout,
-            node_selector=node_selector,
-            tolerations=tolerations,
+            node_selector=self.builds_config.node_selector,
+            tolerations=self.builds_config.tolerations,
         )
 
     async def _get_environment_authorization(

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -19,7 +19,7 @@ from renku_data_services.authz.authz import Authz, ResourceType
 from renku_data_services.authz.models import Scope
 from renku_data_services.base_models.core import RESET
 from renku_data_services.crc.db import ResourcePoolRepository
-from renku_data_services.session import constants, models
+from renku_data_services.session import constants, crs, models
 from renku_data_services.session import orm as schemas
 from renku_data_services.session.k8s_client import ShipwrightClient
 
@@ -980,6 +980,9 @@ class SessionRepository:
 
         # TODO: Get this from the chart values
         node_selector = {"renku.io/node-purpose": "image-build"}
+        tolerations: list[crs.Toleration] = [
+            crs.Toleration(key="renku.io/dedicated", operator="Equal", effect="NoSchedule", value="image-build")
+        ]
 
         return models.ShipwrightBuildRunParams(
             name=build.k8s_name,
@@ -992,6 +995,7 @@ class SessionRepository:
             retention_after_succeeded=retention_after_succeeded,
             build_timeout=build_timeout,
             node_selector=node_selector,
+            tolerations=tolerations,
         )
 
     async def _get_environment_authorization(

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -299,7 +299,7 @@ class ShipwrightClient:
                         ),
                         timeout=f"{params.build_timeout.total_seconds()}s" if params.build_timeout else None,
                         nodeSelector=params.node_selector,
-                        tolerations=[],
+                        tolerations=params.tolerations,
                     )
                 ),
                 retention=retention,

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -301,6 +301,8 @@ class ShipwrightClient:
                     )
                 ),
                 retention=retention,
+                nodeSelector=params.node_selector,
+                # tolerations=???
             ),
         )
         await self.create_build_run(build_run)

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -298,11 +298,11 @@ class ShipwrightClient:
                             pushSecret=params.push_secret_name,
                         ),
                         timeout=f"{params.build_timeout.total_seconds()}s" if params.build_timeout else None,
+                        nodeSelector=params.node_selector,
+                        tolerations=[],
                     )
                 ),
                 retention=retention,
-                nodeSelector=params.node_selector,
-                # tolerations=???
             ),
         )
         await self.create_build_run(build_run)

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -241,7 +241,6 @@ class ShipwrightBuildRunParams:
     retention_after_failed: timedelta | None = None
     retention_after_succeeded: timedelta | None = None
     build_timeout: timedelta | None = None
-
     node_selector: dict[str, str] | None = None
     tolerations: list[crs.Toleration] | None = None
 

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -9,6 +9,7 @@ from ulid import ULID
 
 from renku_data_services import errors
 from renku_data_services.base_models.core import ResetType
+from renku_data_services.session import crs
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)
@@ -241,9 +242,8 @@ class ShipwrightBuildRunParams:
     retention_after_succeeded: timedelta | None = None
     build_timeout: timedelta | None = None
 
-    # node selector
     node_selector: dict[str, str] | None = None
-    # tolerations: list[Toleration] | None = None
+    tolerations: list[crs.Toleration] | None = None
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -241,6 +241,10 @@ class ShipwrightBuildRunParams:
     retention_after_succeeded: timedelta | None = None
     build_timeout: timedelta | None = None
 
+    # node selector
+    node_selector: dict[str, str] | None = None
+    # tolerations: list[Toleration] | None = None
+
 
 @dataclass(frozen=True, eq=True, kw_only=True)
 class ShipwrightBuildStatusUpdateContent:


### PR DESCRIPTION
Add support for configuring node selector and tolerations for container image builds.

The node selector and tolerations are added to the Shipwright BuildRun object which in turn are added to the Pod running the image build.

Related PR: https://github.com/SwissDataScienceCenter/renku/pull/3920

Note: as tests are not running against k8s for now, there is no test added for this PR.

The values in the deploy string below correspond to:
```yaml
nodeSelector:
  renku.io/node-purpose: image-build
tolerations:
  - effect: NoSchedule
    key: renku.io/dedicated
    operator: Equal
    value: image-build
```

/deploy #notest renku=leafty/node-selection renku-notebooks=leafty/shipwright-buildrun-cache renku-ui=build/session-env-builders extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=flora-docker-secret,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.nodeSelector.renku\.io/node-purpose=image-build,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].value=image-build,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/