### PR TITLE
feat: allow configuring buildrun build timeout

### DIFF
--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -150,6 +150,7 @@ class BuildsConfig:
     push_secret_name: str | None = None
     buildrun_retention_after_failed: timedelta | None = None
     buildrun_retention_after_succeeded: timedelta | None = None
+    buildrun_build_timeout: timedelta | None = None
 
     @classmethod
     def from_env(cls, prefix: str = "", namespace: str = "") -> "BuildsConfig":
@@ -175,6 +176,10 @@ class BuildsConfig:
             if buildrun_retention_after_succeeded_seconds > 0
             else None
         )
+        buildrun_build_timeout_seconds = int(os.environ.get(f"{prefix}BUILD_RUN_BUILD_TIMEOUT") or "0")
+        buildrun_build_timeout = (
+            timedelta(seconds=buildrun_build_timeout_seconds) if buildrun_build_timeout_seconds > 0 else None
+        )
 
         if os.environ.get(f"{prefix}DUMMY_STORES", "false").lower() == "true":
             shipwright_client = None
@@ -195,6 +200,7 @@ class BuildsConfig:
             shipwright_client=shipwright_client,
             buildrun_retention_after_failed=buildrun_retention_after_failed,
             buildrun_retention_after_succeeded=buildrun_retention_after_succeeded,
+            buildrun_build_timeout=buildrun_build_timeout,
         )
 
 

--- a/components/renku_data_services/session/constants.py
+++ b/components/renku_data_services/session/constants.py
@@ -24,5 +24,5 @@ BUILD_RUN_DEFAULT_RETENTION_AFTER_FAILED: Final[timedelta] = timedelta(minutes=5
 BUILD_RUN_DEFAULT_RETENTION_AFTER_SUCCEEDED: Final[timedelta] = timedelta(minutes=5)
 """The default retention TTL for BuildRuns when in succeeded state."""
 
-BUILD_RUN_BUILD_TIMEOUT: Final[timedelta] = timedelta(hours=1)
+BUILD_RUN_DEFAULT_TIMEOUT: Final[timedelta] = timedelta(hours=1)
 """The default timeout for build after which they get cancelled."""

--- a/components/renku_data_services/session/constants.py
+++ b/components/renku_data_services/session/constants.py
@@ -23,3 +23,6 @@ BUILD_RUN_DEFAULT_RETENTION_AFTER_FAILED: Final[timedelta] = timedelta(minutes=5
 
 BUILD_RUN_DEFAULT_RETENTION_AFTER_SUCCEEDED: Final[timedelta] = timedelta(minutes=5)
 """The default retention TTL for BuildRuns when in succeeded state."""
+
+BUILD_RUN_BUILD_TIMEOUT: Final[timedelta] = timedelta(hours=1)
+"""The default timeout for build after which they get cancelled."""

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -976,7 +976,7 @@ class SessionRepository:
             self.builds_config.buildrun_retention_after_succeeded
             or constants.BUILD_RUN_DEFAULT_RETENTION_AFTER_SUCCEEDED
         )
-        build_timeout = self.builds_config.buildrun_build_timeout or constants.BUILD_RUN_BUILD_TIMEOUT
+        build_timeout = self.builds_config.buildrun_build_timeout or constants.BUILD_RUN_DEFAULT_TIMEOUT
 
         return models.ShipwrightBuildRunParams(
             name=build.k8s_name,

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -976,6 +976,7 @@ class SessionRepository:
             self.builds_config.buildrun_retention_after_succeeded
             or constants.BUILD_RUN_DEFAULT_RETENTION_AFTER_SUCCEEDED
         )
+        build_timeout = self.builds_config.buildrun_build_timeout or constants.BUILD_RUN_BUILD_TIMEOUT
 
         return models.ShipwrightBuildRunParams(
             name=build.k8s_name,
@@ -986,6 +987,7 @@ class SessionRepository:
             push_secret_name=push_secret_name,
             retention_after_failed=retention_after_failed,
             retention_after_succeeded=retention_after_succeeded,
+            build_timeout=build_timeout,
         )
 
     async def _get_environment_authorization(

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -297,6 +297,7 @@ class ShipwrightClient:
                             image=params.output_image,
                             pushSecret=params.push_secret_name,
                         ),
+                        timeout=f"{params.build_timeout.total_seconds()}s" if params.build_timeout else None,
                     )
                 ),
                 retention=retention,

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -239,6 +239,7 @@ class ShipwrightBuildRunParams:
     push_secret_name: str
     retention_after_failed: timedelta | None = None
     retention_after_succeeded: timedelta | None = None
+    build_timeout: timedelta | None = None
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)


### PR DESCRIPTION
/deploy #notest renku=build-timeouts renku-notebooks=leafty/shipwright-buildrun-cache renku-ui=build/session-env-builders extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=ralf-docker-secret,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.buildRunTimeoutSeconds=10,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/ralf-dev/

tested in the deployment, builds fail after 10 seconds with
```
- lastTransitionTime: '2025-02-28T08:49:16Z'
      message: BuildRun renku-01jn5vxf3kn6qs8w52h32d57yn failed to finish within 10s
      reason: BuildRunTimeout
      status: 'False'
      type: Succeeded
```