### PR TITLE
Disable accessing solr by default

### DIFF
--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -171,6 +171,7 @@ class Config:
     default_resource_pool: models.ResourcePool = default_resource_pool
     server_options_file: Optional[str] = None
     server_defaults_file: Optional[str] = None
+    search_enabled: bool = False
     async_oauth2_client_class: type[AsyncOAuth2Client] = AsyncOAuth2Client
     _user_repo: UserRepository | None = field(default=None, repr=False, init=False)
     _rp_repo: ResourcePoolRepository | None = field(default=None, repr=False, init=False)
@@ -478,6 +479,7 @@ class Config:
         user_preferences_config = UserPreferencesConfig(max_pinned_projects=max_pinned_projects)
         db = DBConfig.from_env(prefix)
         solr_config = SolrClientConfig.from_env(prefix)
+        search_enabled = os.environ.get(f"{prefix}SEARCH_ENABLED", "false").lower() == "true"
         kc_api: IKeycloakAPI
         secrets_service_public_key: PublicKeyTypes
         gitlab_url: str | None
@@ -571,6 +573,7 @@ class Config:
             user_preferences_config=user_preferences_config,
             db=db,
             solr_config=solr_config,
+            search_enabled=search_enabled,
             redis=redis,
             kc_api=kc_api,
             message_queue=message_queue,

--- a/components/renku_data_services/solr/solr_client.py
+++ b/components/renku_data_services/solr/solr_client.py
@@ -43,19 +43,24 @@ class SolrClientConfig:
     @classmethod
     def from_env(cls, prefix: str = "") -> "SolrClientConfig":
         """Create a configuration from environment variables."""
-        url = os.environ[f"{prefix}SOLR_URL"]
-        core = os.environ.get(f"{prefix}SOLR_CORE", "renku-search")
-        username = os.environ.get(f"{prefix}SOLR_USER")
-        password = os.environ.get(f"{prefix}SOLR_PASSWORD")
-        tstr = os.environ.get(f"{prefix}SOLR_REQUEST_TIMEOUT", "600")
-        try:
-            timeout = int(tstr) if tstr is not None else 600
-        except ValueError:
-            logging.warning(f"SOLR_REQUEST_TIMEOUT is not an integer: {tstr}")
-            timeout = 600
+        enabled = os.environ.get(f"{prefix}SEARCH_ENABLED", "false") == "true"
+        if enabled:
+            url = os.environ[f"{prefix}SOLR_URL"]
+            core = os.environ.get(f"{prefix}SOLR_CORE", "renku-search")
+            username = os.environ.get(f"{prefix}SOLR_USER")
+            password = os.environ.get(f"{prefix}SOLR_PASSWORD")
 
-        user = SolrUser(username=username, password=str(password)) if username is not None else None
-        return cls(url, core, user, timeout)
+            tstr = os.environ.get(f"{prefix}SOLR_REQUEST_TIMEOUT", "600")
+            try:
+                timeout = int(tstr) if tstr is not None else 600
+            except ValueError:
+                logging.warning(f"SOLR_REQUEST_TIMEOUT is not an integer: {tstr}")
+                timeout = 600
+
+            user = SolrUser(username=username, password=str(password)) if username is not None else None
+            return cls(url, core, user, timeout)
+        else:
+            return cls("", "")
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
It can be enabled by setting a corresponding environment variable. If this is not set to `true`, there is no attempt to connect to solr.

/deploy