### PR TITLE
fix: remove GIT_CLONE_WORKSPACE_MOUNT_PATH from manifests

### DIFF
--- a/components/renku_data_services/notebooks/api/amalthea_patches/init_containers.py
+++ b/components/renku_data_services/notebooks/api/amalthea_patches/init_containers.py
@@ -46,7 +46,6 @@ async def git_clone_container_v2(
 
     prefix = "GIT_CLONE_"
     env = [
-        {"name": f"{prefix}WORKSPACE_MOUNT_PATH", "value": workspace_mount_path.as_posix()},
         {
             "name": f"{prefix}MOUNT_PATH",
             "value": work_dir.as_posix(),
@@ -168,10 +167,6 @@ async def git_clone_container(server: "UserServer") -> dict[str, Any] | None:
 
     prefix = "GIT_CLONE_"
     env = [
-        {
-            "name": f"{prefix}WORKSPACE_MOUNT_PATH",
-            "value": server.workspace_mount_path.as_posix(),
-        },
         {
             "name": f"{prefix}MOUNT_PATH",
             "value": server.work_dir.as_posix(),


### PR DESCRIPTION
Fixes a forgotten change in #643.

After this is merged, deployments need to specify `renku-notebooks=master` to use a compatible version of `git-clone`.