### PR TITLE
feat: add annotations to buildruns

### DIFF
--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -1022,6 +1022,7 @@ class SessionRepository:
             node_selector=self.builds_config.node_selector,
             tolerations=self.builds_config.tolerations,
             labels=labels,
+            annotations=annotations,
         )
 
     async def _get_environment_authorization(

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -282,6 +282,12 @@ class ShipwrightClient:
 
     async def create_image_build(self, params: models.ShipwrightBuildRunParams) -> None:
         """Create a new BuildRun in Shipwright to support a newly created build."""
+        metadata = crs.Metadata(name=params.name)
+        if params.annotations:
+            metadata.annotations = params.annotations
+        if params.labels:
+            metadata.labels = params.labels
+
         retention: crs.Retention | None = None
         if params.retention_after_failed or params.retention_after_succeeded:
             retention_after_failed = (
@@ -296,7 +302,7 @@ class ShipwrightClient:
             )
 
         build_run = BuildRun(
-            metadata=crs.Metadata(name=params.name),
+            metadata=metadata,
             spec=crs.BuildRunSpec(
                 build=crs.Build(
                     spec=crs.BuildSpec(

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -244,6 +244,8 @@ class ShipwrightBuildRunParams:
     build_timeout: timedelta | None = None
     node_selector: dict[str, str] | None = None
     tolerations: list[crs.Toleration] | None = None
+    labels: dict[str, str] | None = None
+    annotations: dict[str, str] | None = None
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)


### PR DESCRIPTION
Closes #671.

Example BuildRun metadata created with this change:
```yaml
apiVersion: shipwright.io/v1beta1
kind: BuildRun
metadata:
  annotations:
    renku.io/build_id: 01JNJPPZMWRYY0M61Z71VYW5SV
    renku.io/environment_id: 01JNJP4YSFBSX8YXQDQQ84F9XE
    renku.io/launcher_id: 01JNJP4YVB8C57TMMDPBCD4QHD
    renku.io/project_id: 01JNJP4HR642H8PPGGD3RWZG9H
  creationTimestamp: "2025-03-05T08:28:18Z"
  generation: 1
  labels:
    renku.io/safe-username: 89a00f6e-8ada-43f8-92aa-6d28a40ba786
  name: renku-01jnjppzmwryy0m61z71vyw5sv
  namespace: renku-ci-ds-704
  resourceVersion: "455312834"
  uid: de8a6adf-b96e-4fbf-851e-97b3d3cfaa59
```

/deploy #notest renku=build/session-env-builders renku-notebooks=leafty/shipwright-buildrun-cache renku-ui=leafty/session-env-builders-9 extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=flora-docker-secret,dataService.imageBuilders.buildRunTimeoutSeconds=3600,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.buildRunRetentionAfterSucceededSeconds=3600,dataService.imageBuilders.nodeSelector.renku\.io/node-purpose=image-build,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].value=image-build,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/