### PR TITLE
Build/external resources

### DIFF
--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -173,6 +173,15 @@ class Quota(ResourcesCompareMixin):
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)
+class KubeClusterSettings:
+    """K8s Cluster settings."""
+
+    config_name: str
+    node_affinities: list[str]
+    tolerations: list[str]
+
+
+@dataclass(frozen=True, eq=True, kw_only=True)
 class ResourcePool:
     """Resource pool model."""
 
@@ -184,6 +193,7 @@ class ResourcePool:
     hibernation_threshold: Optional[int] = None
     default: bool = False
     public: bool = False
+    cluster: Optional[KubeClusterSettings] = None
 
     def __post_init__(self) -> None:
         """Validate the resource pool after initialization."""

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -251,3 +251,17 @@ class ResourcePool:
             idle_threshold=data.get("idle_threshold"),
             hibernation_threshold=data.get("hibernation_threshold"),
         )
+
+    def get_resource_class(self, resource_class_id: int) -> ResourceClass | None:
+        """Find a specific resource class in the resource pool by the resource class id."""
+        for rc in self.classes:
+            if rc.id == resource_class_id:
+                return rc
+        return None
+
+    def get_default_resource_class(self) -> ResourceClass | None:
+        """Find the default resource class in the pool."""
+        for rc in self.classes:
+            if rc.default:
+                return rc
+        return None

--- a/components/renku_data_services/notebooks/api/amalthea_patches/cloudstorage.py
+++ b/components/renku_data_services/notebooks/api/amalthea_patches/cloudstorage.py
@@ -17,9 +17,7 @@ async def main(server: "UserServer") -> list[dict[str, Any]]:
     repositories = await server.repositories()
     for i, cloud_storage_request in enumerate(server.cloudstorage):
         cloud_storage_patches.extend(
-            cloud_storage_request.get_manifest_patch(
-                f"{server.server_name}-ds-{i}", server.k8s_client.preferred_namespace
-            )
+            cloud_storage_request.get_manifest_patch(f"{server.server_name}-ds-{i}", server.namespace)
         )
         if repositories:
             cloud_storage_patches.append(

--- a/components/renku_data_services/notebooks/api/amalthea_patches/git_sidecar.py
+++ b/components/renku_data_services/notebooks/api/amalthea_patches/git_sidecar.py
@@ -194,7 +194,7 @@ async def main(server: "UserServer") -> list[dict[str, Any]]:
                         "kind": "Service",
                         "metadata": {
                             "name": f"{server.server_name}-rpc-server",
-                            "namespace": server.k8s_client.preferred_namespace,
+                            "namespace": server.namespace,
                         },
                         "spec": {
                             "ports": [

--- a/components/renku_data_services/notebooks/api/amalthea_patches/jupyter_server.py
+++ b/components/renku_data_services/notebooks/api/amalthea_patches/jupyter_server.py
@@ -138,7 +138,7 @@ def image_pull_secret(server: "UserServer", access_token: str | None) -> list[di
                             "kind": "Secret",
                             "metadata": {
                                 "name": image_pull_secret_name,
-                                "namespace": server._k8s_client.preferred_namespace,
+                                "namespace": server.namespace,
                             },
                             "type": "kubernetes.io/dockerconfigjson",
                         },

--- a/components/renku_data_services/notebooks/api/classes/k8s_client.py
+++ b/components/renku_data_services/notebooks/api/classes/k8s_client.py
@@ -4,16 +4,22 @@ import asyncio
 import base64
 import json
 import logging
+import os
+from abc import ABC, abstractmethod
 from contextlib import suppress
 from typing import Any, Generic, Optional, TypeVar, cast
 from urllib.parse import urljoin
 
 import httpx
-from box import Box
+import kr8s
+import kubernetes
+from box.box import Box
 from kr8s import NotFoundError, ServerError
 from kr8s.asyncio.objects import APIObject, Pod, Secret, StatefulSet
-from kubernetes.client import ApiClient, V1Secret
+from kubernetes.client import V1Secret
 
+from renku_data_services.base_models import AnonymousAPIUser, APIUser, AuthenticatedAPIUser
+from renku_data_services.crc.db import ResourcePoolRepository
 from renku_data_services.errors import errors
 from renku_data_services.notebooks.api.classes.auth import GitlabToken, RenkuTokens
 from renku_data_services.notebooks.crs import AmaltheaSessionV1Alpha1, JupyterServerV1Alpha1
@@ -29,8 +35,6 @@ from renku_data_services.notebooks.util.kubernetes_ import find_env_var
 from renku_data_services.notebooks.util.retries import (
     retry_with_exponential_backoff_async,
 )
-
-sanitize_for_serialization = ApiClient().sanitize_for_serialization
 
 
 # NOTE The type ignore below is because the kr8s library has no type stubs, they claim pyright better handles type hints
@@ -62,23 +66,117 @@ class JupyterServerV1Alpha1Kr8s(APIObject):
 _SessionType = TypeVar("_SessionType", JupyterServerV1Alpha1, AmaltheaSessionV1Alpha1)
 _Kr8sType = TypeVar("_Kr8sType", JupyterServerV1Alpha1Kr8s, AmaltheaSessionV1Alpha1Kr8s)
 
+_sanitizer = kubernetes.client.ApiClient().sanitize_for_serialization
 
-class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
+DEFAULT_K8S_CLUSTER = "default_k8s_cluster"
+
+
+class K8sClientProto[_SessionType, _Kr8sType](ABC):
+    """K8s Client wrapper interface."""
+
+    @abstractmethod
+    def sanitize(self, obj: APIObject) -> Any:
+        """Sanitize a JSON object."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def namespace(self) -> str:
+        """Return the current kubernetes namespace."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def cluster_name_by_class_id(self, class_id: int | None, api_user: APIUser) -> str:
+        """Retrieve the cluster name given the resource class id."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def list_servers(self, safe_username: str) -> list[_SessionType]:
+        """List all the user sessions visible from the safe_username."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_server(
+        self, manifest: _SessionType, api_user: AnonymousAPIUser | AuthenticatedAPIUser
+    ) -> _SessionType:
+        """Launch a user session."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def get_server(self, name: str, safe_username: str) -> _SessionType | None:
+        """Lookup a user session by name."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def get_server_logs(
+        self, server_name: str, safe_username: str, max_log_lines: Optional[int] = None
+    ) -> dict[str, str]:
+        """Retrieve the logs for the given user session."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def patch_server(
+        self, server_name: str, safe_username: str, patch: dict[str, Any] | list[dict[str, Any]]
+    ) -> _SessionType:
+        """Patch the user session."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def delete_server(self, server_name: str, safe_username: str) -> None:
+        """Delete the provided user session."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def patch_server_tokens(self, server_name: str, renku_tokens: RenkuTokens, gitlab_token: GitlabToken) -> None:
+        """Patch user authentication tokens in a user session."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def patch_statefulset(
+        self, server_name: str, patch: dict[str, Any] | list[dict[str, Any]]
+    ) -> StatefulSet | None:
+        """Patch a user session."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_secret(self, secret: V1Secret) -> V1Secret:
+        """Create a kubernetes secret."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def delete_secret(self, name: str) -> None:
+        """Delete a kubernetes secret."""
+        raise NotImplementedError()
+
+
+# WARNING:
+#   As of mypy 1.14.1, it does not support instantiating an object using a field containing a type using the new syntax,
+#    which is why we have a mix of new and old syntax for the generics.
+
+
+class _BaseK8sClient(Generic[_SessionType, _Kr8sType]):
     """A kubernetes client that operates in a specific namespace."""
 
-    def __init__(self, namespace: str, server_type: type[_SessionType], kr8s_type: type[_Kr8sType]):
-        self.namespace = namespace
-        self.server_type: type[_SessionType] = server_type
+    # Mypy does not support inferring type dynamically from another generic type (_SessionType => _Kr8sType)
+    def __init__(
+        self, server_type: type[_SessionType], kr8s_type: type[_Kr8sType], api: kr8s.asyncio.Api, username_label: str
+    ):
+        self._api = api
+        self._server_type: type[_SessionType] = server_type
         self._kr8s_type: type[_Kr8sType] = kr8s_type
-        if (self.server_type == AmaltheaSessionV1Alpha1 and self._kr8s_type == JupyterServerV1Alpha1Kr8s) or (
-            self.server_type == JupyterServerV1Alpha1 and self._kr8s_type == AmaltheaSessionV1Alpha1Kr8s
+        if (self._server_type == AmaltheaSessionV1Alpha1 and self._kr8s_type == JupyterServerV1Alpha1Kr8s) or (
+            self._server_type == JupyterServerV1Alpha1 and self._kr8s_type == AmaltheaSessionV1Alpha1Kr8s
         ):
             raise errors.ProgrammingError(message="Incompatible manifest and client types in k8s client")
-        self.sanitize = ApiClient().sanitize_for_serialization
 
-    async def get_pod_logs(self, name: str, max_log_lines: Optional[int] = None) -> dict[str, str]:
+        self._username_label = username_label
+
+    @property
+    def namespace(self) -> str:
+        return self._api.namespace
+
+    async def get_pod_logs(self, name: str, max_log_lines: int | None = None) -> dict[str, str]:
         """Get the logs of all containers in the session."""
-        pod = await Pod.get(name=name, namespace=self.namespace)
+        pod = await Pod.get(api=self._api, name=name)
         logs: dict[str, str] = {}
         containers = [container.name for container in pod.spec.containers + pod.spec.get("initContainers", [])]
         for container in containers:
@@ -86,12 +184,12 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
                 # NOTE: calling pod.logs without a container name set crashes the library
                 clogs: list[str] = [clog async for clog in pod.logs(container=container, tail_lines=max_log_lines)]
             except httpx.ResponseNotRead:
-                # NOTE: This occurs when the container is still starting but we try to read its logs
+                # NOTE: This occurs when the container is still starting, but we try to read its logs
                 continue
             except NotFoundError:
                 raise errors.MissingResourceError(message=f"The session pod {name} does not exist.")
             except ServerError as err:
-                if err.status == 404:
+                if err.status == "404":
                     raise errors.MissingResourceError(message=f"The session pod {name} does not exist.")
                 raise
             else:
@@ -101,18 +199,20 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
     async def get_secret(self, name: str) -> Secret | None:
         """Read a specific secret from the cluster."""
         try:
-            secret = await Secret.get(name, self.namespace)
+            secret = await Secret.get(api=self._api, name=name)
         except NotFoundError:
             return None
         return secret
 
     async def create_server(self, manifest: _SessionType) -> _SessionType:
         """Create a jupyter server in the cluster."""
+
         # NOTE: You have to exclude none when using model dump below because otherwise we get
         # namespace=null which seems to break the kr8s client or simply k8s does not translate
         # namespace = null to the default namespace.
-        manifest.metadata.namespace = self.namespace
-        js = await self._kr8s_type(manifest.model_dump(exclude_none=True, mode="json"))
+        js = await self._kr8s_type(
+            api=self._api, namespace=self.namespace, resource=manifest.model_dump(exclude_none=True, mode="json")
+        )
         server_name = manifest.metadata.name
         try:
             await js.create()
@@ -136,7 +236,9 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
 
     async def patch_server(self, server_name: str, patch: dict[str, Any] | list[dict[str, Any]]) -> _SessionType:
         """Patch the server."""
-        server = await self._kr8s_type(dict(metadata=dict(name=server_name, namespace=self.namespace)))
+        server = await self._kr8s_type(
+            api=self._api, namespace=self.namespace, resource=dict(metadata=dict(name=server_name))
+        )
         patch_type: str | None = None  # rfc7386 patch
         if isinstance(patch, list):
             patch_type = "json"  # rfc6902 patch
@@ -146,20 +248,20 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
             logging.exception(f"Cannot patch server {server_name} because of {e}")
             raise PatchServerError()
 
-        return self.server_type.model_validate(server.to_dict())
+        return self._server_type.model_validate(server.to_dict())
 
     async def patch_statefulset(
         self, server_name: str, patch: dict[str, Any] | list[dict[str, Any]]
     ) -> StatefulSet | None:
         """Patch a statefulset."""
-        sts = await StatefulSet(dict(metadata=dict(name=server_name, namespace=self.namespace)))
+        sts = await StatefulSet(api=self._api, namespace=self.namespace, resource=dict(metadata=dict(name=server_name)))
         patch_type: str | None = None  # rfc7386 patch
         if isinstance(patch, list):
             patch_type = "json"  # rfc6902 patch
         try:
             await sts.patch(patch, type=patch_type)
         except ServerError as err:
-            if err.status == 404:
+            if err.response is not None and err.response.status_code == 404:
                 # NOTE: It can happen potentially that another request or something else
                 # deleted the session as this request was going on, in this case we ignore
                 # the missing statefulset
@@ -169,7 +271,9 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
 
     async def delete_server(self, server_name: str) -> None:
         """Delete the server."""
-        server = await self._kr8s_type(dict(metadata=dict(name=server_name, namespace=self.namespace)))
+        server = await self._kr8s_type(
+            api=self._api, namespace=self.namespace, resource=dict(metadata=dict(name=server_name))
+        )
         try:
             await server.delete(propagation_policy="Foreground")
         except ServerError as e:
@@ -180,7 +284,7 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
     async def get_server(self, name: str, num_retries: int = 0) -> _SessionType | None:
         """Get a specific JupyterServer object."""
         try:
-            server = await self._kr8s_type.get(name=name, namespace=self.namespace)
+            server = await self._kr8s_type.get(api=self._api, name=name)
         except NotFoundError:
             return None
         except ServerError as err:
@@ -197,27 +301,38 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
                 logging.exception(f"Cannot get server {name} because of {err}")
                 raise IntermittentError(f"Cannot get server {name} from the k8s API.")
             return None
-        return self.server_type.model_validate(server.to_dict())
+        return self._server_type.model_validate(server.to_dict())
 
-    async def list_servers(self, label_selector: Optional[str] = None) -> list[_SessionType]:
+    async def list_sessions(self, safe_username: str) -> list[_SessionType]:
         """Get a list of k8s jupyterserver objects for a specific user."""
+
+        # NOTE: we use the selector if for network efficiency, we do not guarantee the sessions are limited to
+        # the ones belonging to safe_username
+        label_selector = f"{self._username_label}={safe_username}"
         try:
-            servers = await self._kr8s_type.list(namespace=self.namespace, label_selector=label_selector)
+            # We cannot use kr8s.APIObject.list as it ignores the api object argument and instead instantiate a default
+            # one, so let's do this by hand (Mostly a copy-pasta of the aforementioned function, adapted to use the
+            # correct api object).
+            resources = await self._api.async_get(kind=APIObject, api=self._api, label_selector=label_selector)
+            if not isinstance(resources, list):
+                resources = [resources]
+            servers = [resource for resource in resources if isinstance(resource, APIObject)]
+
         except ServerError as err:
             if err.response is None or err.response.status_code not in [400, 404]:
                 logging.exception(f"Cannot list servers because of {err}")
                 raise IntermittentError(f"Cannot list servers from the k8s API with selector {label_selector}.")
             return []
-        output: list[_SessionType] = [self.server_type.model_validate(server.to_dict()) for server in servers]
+        output: list[_SessionType] = [self._server_type.model_validate(server.to_dict()) for server in servers]
         return output
 
     async def patch_image_pull_secret(self, server_name: str, gitlab_token: GitlabToken) -> None:
         """Patch the image pull secret used in a Renku session."""
         secret_name = f"{server_name}-image-secret"
-        try:
-            secret = await Secret.get(name=secret_name, namespace=self.namespace)
-        except NotFoundError:
+        secret = await self.get_secret(secret_name)
+        if secret is None:
             return None
+
         secret_data = secret.data.to_dict()
         old_docker_config = json.loads(base64.b64decode(secret_data[".dockerconfigjson"]).decode())
         hostname = next(iter(old_docker_config["auths"].keys()), None)
@@ -243,7 +358,7 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
                 "value": base64.b64encode(json.dumps(new_docker_config).encode()).decode(),
             }
         ]
-        await secret.patch(patch, type="json")
+        await secret.patch(patch=patch, type="json")
 
     @staticmethod
     def _get_statefulset_token_patches(sts: StatefulSet, renku_tokens: RenkuTokens) -> list[dict[str, str]]:
@@ -336,10 +451,10 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
 
     async def patch_statefulset_tokens(self, name: str, renku_tokens: RenkuTokens) -> None:
         """Patch the Renku and Gitlab access tokens that are used in the session statefulset."""
-        if self.server_type != JupyterServerV1Alpha1 or self._kr8s_type != JupyterServerV1Alpha1Kr8s:
+        if self._server_type != JupyterServerV1Alpha1 or self._kr8s_type != JupyterServerV1Alpha1Kr8s:
             raise NotImplementedError("patch_statefulset_tokens is only implemented for JupyterServers")
         try:
-            sts = await StatefulSet.get(name=name, namespace=self.namespace)
+            sts = await StatefulSet.get(api=self._api, name=name)
         except NotFoundError:
             return None
 
@@ -351,15 +466,16 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
     async def create_secret(self, secret: V1Secret) -> V1Secret:
         """Create a new secret."""
 
-        new_secret = await Secret(self.sanitize(secret), self.namespace)
+        new_secret = await Secret(api=self._api, namespace=self.namespace, resource=_sanitizer(secret))
         await new_secret.create()
         return V1Secret(metadata=new_secret.metadata, data=new_secret.data, type=new_secret.raw.get("type"))
 
     async def delete_secret(self, name: str) -> None:
         """Delete a secret."""
-        secret = await Secret(dict(metadata=dict(name=name, namespace=self.namespace)))
-        with suppress(NotFoundError):
-            await secret.delete()
+        secret = await self.get_secret(name)
+        if secret is not None:
+            with suppress(NotFoundError):
+                await secret.delete()
         return None
 
     async def patch_secret(self, name: str, patch: dict[str, Any] | list[dict[str, Any]]) -> None:
@@ -367,14 +483,14 @@ class NamespacedK8sClient(Generic[_SessionType, _Kr8sType]):
         patch_type: str | None = None  # rfc7386 patch
         if isinstance(patch, list):
             patch_type = "json"  # rfc6902 patch
-        secret = await Secret(dict(metadata=dict(name=name, namespace=self.namespace)))
-        if not secret:
+        secret = await self.get_secret(name)
+        if secret is None:
             raise errors.MissingResourceError(message=f"Cannot find secret {name}.")
         with suppress(NotFoundError):
             await secret.patch(patch, type=patch_type)
 
 
-class ServerCache(Generic[_SessionType]):
+class _ServerCache(Generic[_SessionType]):
     """Utility class for calling the jupyter server cache."""
 
     def __init__(self, url: str, server_type: type[_SessionType]):
@@ -385,7 +501,7 @@ class ServerCache(Generic[_SessionType]):
         if server_type == AmaltheaSessionV1Alpha1:
             self.url_path_name = "sessions"
 
-    async def list_servers(self, safe_username: str) -> list[_SessionType]:
+    async def list_sessions(self, safe_username: str) -> list[_SessionType]:
         """List the jupyter servers."""
         url = urljoin(self.url, f"/users/{safe_username}/{self.url_path_name}")
         try:
@@ -422,63 +538,102 @@ class ServerCache(Generic[_SessionType]):
         if len(output) == 0:
             return None
         if len(output) > 1:
-            raise ProgrammingError(f"Expected to find 1 server when getting server {name}, " f"found {len(output)}.")
+            raise ProgrammingError(f"Expected to find 1 server when getting server {name}, found {len(output)}.")
         return self.server_type.model_validate(output[0])
 
 
-class K8sClient(Generic[_SessionType, _Kr8sType]):
-    """The K8s client that combines a namespaced client and a jupyter server cache."""
+class _CachedK8sClient[_SessionType, _Kr8sType](_BaseK8sClient):
+    """Cached K8s client. NB: Not everything is cached at the moment."""
 
     def __init__(
         self,
-        cache: ServerCache[_SessionType],
-        renku_ns_client: NamespacedK8sClient[_SessionType, _Kr8sType],
+        server_type: type[_SessionType],
+        kr8s_type: type[_Kr8sType],
+        api: kr8s.asyncio.Api,
+        cache_url: str,
         username_label: str,
         # NOTE: If cache skipping is enabled then when the cache fails a large number of
         # sessions can overload the k8s API by submitting a lot of calls directly.
         skip_cache_if_unavailable: bool = False,
     ):
-        self.cache: ServerCache[_SessionType] = cache
-        self.renku_ns_client: NamespacedK8sClient[_SessionType, _Kr8sType] = renku_ns_client
-        self.username_label = username_label
-        if not self.username_label:
-            raise ProgrammingError("username_label has to be provided to K8sClient")
-        self.sanitize = self.renku_ns_client.sanitize
-        self.skip_cache_if_unavailable = skip_cache_if_unavailable
+        super().__init__(server_type, kr8s_type, api, username_label)
+        self._cache: _ServerCache = _ServerCache(cache_url, server_type)
+        self._username_label = username_label
+        self._skip_cache_if_unavailable = skip_cache_if_unavailable
 
-    async def list_servers(self, safe_username: str) -> list[_SessionType]:
+    async def list_sessions(self, safe_username: str) -> list[_SessionType]:
         """Get a list of servers that belong to a user.
 
         Attempt to use the cache first but if the cache fails then use the k8s API.
         """
         try:
-            return await self.cache.list_servers(safe_username)
+            return await self._cache.list_sessions(safe_username)
         except JSCacheError:
-            if self.skip_cache_if_unavailable:
+            if self._skip_cache_if_unavailable:
                 logging.warning(f"Skipping the cache to list servers for user: {safe_username}")
-                # NOTE: The label selector ensures that users can only see their own servers
-                label_selector = f"{self.username_label}={safe_username}"
-                return await self.renku_ns_client.list_servers(label_selector)
+                return await super().list_sessions(safe_username)
             else:
                 raise
+
+    async def get_server(self, name: str, num_retries: int = 0) -> _SessionType | None:
+        """Get a list a server.
+
+        Attempt to use the cache first but if the cache fails then use the k8s API.
+        """
+        try:
+            return await self._cache.get_server(name)
+        except JSCacheError:
+            if self._skip_cache_if_unavailable:
+                return await super().get_server(name, num_retries)
+            else:
+                raise
+
+
+class _SingleK8sClient(Generic[_SessionType, _Kr8sType]):
+    """The K8s client that combines a namespaced client and a jupyter server cache."""
+
+    def __init__(
+        self,
+        server_type: type[_SessionType],
+        kr8s_type: type[_Kr8sType],
+        api: kr8s.asyncio.Api,
+        cache_url: str,
+        username_label: str,
+        skip_cache_if_unavailable: bool = False,
+    ):
+        self._k8s_client: _BaseK8sClient[_SessionType, _Kr8sType] = _CachedK8sClient(
+            server_type, kr8s_type, api, cache_url, username_label, skip_cache_if_unavailable
+        )
+
+        self.username_label = username_label
+        if not self.username_label:
+            raise ProgrammingError("username_label has to be provided to K8sClient")
+
+    async def list_servers(self, safe_username: str) -> list[_SessionType]:
+        """Get a list of servers that belong to a user."""
+        sessions: list[_SessionType] = await self._k8s_client.list_sessions(safe_username=safe_username)
+        return [
+            session
+            for session in sessions
+            if session.metadata is not None
+            and session.metadata.labels is not None
+            and session.metadata.labels.get(self.username_label) == safe_username
+        ]
 
     async def get_server(self, name: str, safe_username: str) -> _SessionType | None:
         """Attempt to get a specific server by name from the cache.
 
         If the request to the cache fails, fallback to the k8s API.
         """
-        server = None
-        try:
-            server = await self.cache.get_server(name)
-        except JSCacheError:
-            if self.skip_cache_if_unavailable:
-                server = await self.renku_ns_client.get_server(name)
-            else:
-                raise
+        server: _SessionType | None = await self._k8s_client.get_server(name)
 
         # NOTE: only the user that the server belongs to can read it, without the line
         # below anyone can request and read any one else's server
-        if server and server.metadata and server.metadata.labels.get(self.username_label) != safe_username:
+        if (
+            server is not None
+            and server.metadata is not None
+            and server.metadata.labels.get(self.username_label) != safe_username
+        ):
             return None
         return server
 
@@ -493,11 +648,7 @@ class K8sClient(Generic[_SessionType, _Kr8sType]):
                 message=f"Cannot find server {server_name} for user {safe_username} to retrieve logs."
             )
         pod_name = f"{server_name}-0"
-        return await self.renku_ns_client.get_pod_logs(pod_name, max_log_lines)
-
-    async def _get_secret(self, name: str) -> Secret | None:
-        """Get a specific secret."""
-        return await self.renku_ns_client.get_secret(name)
+        return await self._k8s_client.get_pod_logs(pod_name, max_log_lines)
 
     async def create_server(self, manifest: _SessionType, safe_username: str) -> _SessionType:
         """Create a server."""
@@ -507,7 +658,7 @@ class K8sClient(Generic[_SessionType, _Kr8sType]):
             # NOTE: server already exists
             return server
         manifest.metadata.labels[self.username_label] = safe_username
-        return await self.renku_ns_client.create_server(manifest)
+        return await self._k8s_client.create_server(manifest)
 
     async def patch_server(
         self, server_name: str, safe_username: str, patch: dict[str, Any] | list[dict[str, Any]]
@@ -518,14 +669,7 @@ class K8sClient(Generic[_SessionType, _Kr8sType]):
             raise errors.MissingResourceError(
                 message=f"Cannot find server {server_name} for user {safe_username} in order to patch it."
             )
-        return await self.renku_ns_client.patch_server(server_name=server_name, patch=patch)
-
-    async def patch_statefulset(
-        self, server_name: str, patch: dict[str, Any] | list[dict[str, Any]]
-    ) -> StatefulSet | None:
-        """Patch a statefulset."""
-        client = self.renku_ns_client
-        return await client.patch_statefulset(server_name=server_name, patch=patch)
+        return await self._k8s_client.patch_server(server_name=server_name, patch=patch)
 
     async def delete_server(self, server_name: str, safe_username: str) -> None:
         """Delete the server."""
@@ -534,27 +678,266 @@ class K8sClient(Generic[_SessionType, _Kr8sType]):
             raise errors.MissingResourceError(
                 message=f"Cannot find server {server_name} for user {safe_username} in order to delete it."
             )
-        return await self.renku_ns_client.delete_server(server_name)
+        return await self._k8s_client.delete_server(server_name)
 
-    async def patch_tokens(self, server_name: str, renku_tokens: RenkuTokens, gitlab_token: GitlabToken) -> None:
+    async def patch_server_tokens(self, server_name: str, renku_tokens: RenkuTokens, gitlab_token: GitlabToken) -> None:
         """Patch the Renku and Gitlab access tokens used in a session."""
-        client = self.renku_ns_client
-        await client.patch_statefulset_tokens(server_name, renku_tokens)
-        await client.patch_image_pull_secret(server_name, gitlab_token)
+        await self._k8s_client.patch_statefulset_tokens(server_name, renku_tokens)
+        await self._k8s_client.patch_image_pull_secret(server_name, gitlab_token)
 
     @property
-    def preferred_namespace(self) -> str:
+    def namespace(self) -> str:
         """Get the preferred namespace for creating jupyter servers."""
-        return self.renku_ns_client.namespace
+        return self._k8s_client.namespace
+
+    async def patch_statefulset(
+        self, server_name: str, patch: dict[str, Any] | list[dict[str, Any]]
+    ) -> StatefulSet | None:
+        return await self._k8s_client.patch_statefulset(server_name, patch)
 
     async def create_secret(self, secret: V1Secret) -> V1Secret:
-        """Create a secret."""
-        return await self.renku_ns_client.create_secret(secret)
+        return await self._k8s_client.create_secret(secret)
 
     async def delete_secret(self, name: str) -> None:
-        """Delete a secret."""
-        return await self.renku_ns_client.delete_secret(name)
+        await self._k8s_client.delete_secret(name)
 
-    async def patch_secret(self, name: str, patch: dict[str, Any] | list[dict[str, Any]]) -> None:
-        """Patch a secret."""
-        return await self.renku_ns_client.patch_secret(name, patch)
+
+class MultipleK8sClient(K8sClientProto[_SessionType, _Kr8sType]):
+    """Multiple Kubernetes cluster client wrapper."""
+
+    def __init__(
+        self,
+        server_type: type[_SessionType],
+        kr8s_type: type[_Kr8sType],
+        cache_url: str,
+        username_label: str,
+        rp_repo: ResourcePoolRepository,
+        skip_cache_if_unavailable: bool = False,
+    ):
+        self._clients: dict[str, _SingleK8sClient[_SessionType, _Kr8sType]] = dict()
+        self._kube_conf_root_dir = "/secrets/kube_configs"
+        self._rp_repo = rp_repo
+
+        # Add at least one connection, to the default cluster.
+        self._clients[DEFAULT_K8S_CLUSTER] = _SingleK8sClient(
+            server_type,
+            kr8s_type,
+            kr8s.api(),
+            cache_url,
+            username_label,
+            skip_cache_if_unavailable,
+        )
+
+        if os.path.exists(self._kube_conf_root_dir):
+            for f in os.scandir(self.kube_conf_root_dir):
+                self._clients[f.name.removesuffix(".yaml")] = _SingleK8sClient(
+                    server_type,
+                    kr8s_type,
+                    kr8s.api(kubeconfig=f"{self.kube_conf_root_dir}/{f.name}"),
+                    cache_url,
+                    username_label,
+                    skip_cache_if_unavailable,
+                )
+        else:
+            logging.warning(f"Cannot open directory '{self._kube_conf_root_dir}', ignoring kube configs...")
+
+        # maps session/server name to k8s client
+        self._session2client: dict[str, _SingleK8sClient[_SessionType, _Kr8sType]] = {}
+
+    async def _client_by_session(
+        self, session_name: str, safe_username: str
+    ) -> _SingleK8sClient[_SessionType, _Kr8sType] | None:
+        # Try in our cache, if not there look it up in K8s and update our cache
+        client = self._session2client.get(session_name, None)
+        if client is None:
+            for c in self._clients.values():
+                if session_name in await c.list_servers(safe_username):
+                    self._session2client[session_name] = c
+                    client = c
+                    break
+
+        return client
+
+    async def _client_by_class_id(self, class_id: str, api_user: APIUser) -> _SingleK8sClient[_SessionType, _Kr8sType]:
+        # **NOTE**: This assumes class_ids are unique over all the clusters.
+        _id = int(class_id)
+        name = await self.cluster_name_by_class_id(_id, api_user)
+        return self._clients[name]
+
+    @property
+    def kube_conf_root_dir(self) -> str:
+        """Root folder of the kube configs."""
+        return self._kube_conf_root_dir
+
+    def sanitize(self, obj: APIObject) -> Any:
+        """Sanitize json object."""
+        return _sanitizer(obj)
+
+    def namespace(self) -> str:
+        """Current namespace of the main cluster."""
+        # TODO: LSA Does not break current code, but bad, as it may be different based on the cluster
+        return self._clients[DEFAULT_K8S_CLUSTER].namespace
+
+    async def cluster_name_by_class_id(self, class_id: int | None, api_user: APIUser) -> str:
+        """Retrieve the cluster name given the resource class id."""
+        # If the config_name is not set or not found, fall back on the default cluster.
+        name = DEFAULT_K8S_CLUSTER
+
+        if class_id is not None:
+            rp = await self._rp_repo.get_resource_pool_from_class(api_user, class_id)
+            if rp.cluster is not None:
+                name = rp.cluster.config_name
+
+        return name
+
+    async def list_servers(self, safe_username: str) -> list[_SessionType]:
+        """List all the user sessions visible from the safe_username."""
+        # Don't blame me, blame python's list comprehension syntax
+        return [s for c in self._clients.values() for s in await c.list_servers(safe_username)]
+
+    async def create_server(
+        self, manifest: _SessionType, api_user: AnonymousAPIUser | AuthenticatedAPIUser
+    ) -> _SessionType:
+        """Launch a user session."""
+        class_id = manifest.metadata.annotations["renku.io/resource_class_id"]
+        server_name = manifest.metadata.name
+
+        client = await self._client_by_class_id(class_id, api_user)
+
+        session = await client.create_server(manifest, api_user.id)
+        self._session2client[server_name] = client
+
+        return session
+
+    async def get_server(self, name: str, safe_username: str) -> _SessionType | None:
+        """Lookup a user session by name."""
+        client = await self._client_by_session(name, safe_username)
+        if client is not None:
+            return await client.get_server(name, safe_username)
+
+        return None
+
+    async def get_server_logs(
+        self, server_name: str, safe_username: str, max_log_lines: Optional[int] = None
+    ) -> dict[str, str]:
+        """Retrieve the logs for the given user session."""
+        client = await self._client_by_session(server_name, safe_username)
+        if client is not None:
+            return await client.get_server_logs(server_name, safe_username, max_log_lines)
+
+        raise errors.MissingResourceError(
+            message=f"Cannot find server {server_name} for user {safe_username} to retrieve logs."
+        )
+
+    async def patch_server(
+        self, server_name: str, safe_username: str, patch: dict[str, Any] | list[dict[str, Any]]
+    ) -> _SessionType:
+        """Patch the user session."""
+        client = await self._client_by_session(server_name, safe_username)
+        if client is not None:
+            return await client.patch_server(server_name, safe_username, patch)
+
+        raise errors.MissingResourceError(
+            message=f"Cannot find cluster connection to server {server_name}"
+            f" for user {safe_username} in order to patch it."
+        )
+
+    async def delete_server(self, server_name: str, safe_username: str) -> None:
+        """Delete the provided user session."""
+        # Retrieve and remove from the mapping to the k8s client for this session
+        client = self._session2client.pop(server_name, None)
+        if client is not None:
+            await client.delete_server(server_name, safe_username)
+
+    async def patch_server_tokens(self, server_name: str, renku_tokens: RenkuTokens, gitlab_token: GitlabToken) -> None:
+        """Patch user authentication tokens in a user session."""
+        # TODO: Brute force this for now, not pretty
+        for c in self._clients.values():
+            await c.patch_server_tokens(server_name, renku_tokens, gitlab_token)
+
+    async def patch_statefulset(
+        self, server_name: str, patch: dict[str, Any] | list[dict[str, Any]]
+    ) -> StatefulSet | None:
+        """Patch a user session."""
+        # TODO: Brute force this for now, not pretty
+        for c in self._clients.values():
+            r = await c.patch_statefulset(server_name, patch)
+            if r is not None:
+                return r
+
+        # If the stateful set is missing, we ignore the operation
+        return None
+
+    async def create_secret(self, secret: V1Secret) -> V1Secret:
+        """Create a kubernetes secret."""
+        # TODO: LSA Does not break current code, but bad, as it may be different based on the cluster
+        return await self._clients[DEFAULT_K8S_CLUSTER].create_secret(secret)
+
+    async def delete_secret(self, name: str) -> None:
+        """Delete a kubernetes secret."""
+        # TODO: LSA Does not break current code, but bad, as it may be different based on the cluster
+        await self._clients[DEFAULT_K8S_CLUSTER].delete_secret(name)
+
+
+class DummyK8sClient(K8sClientProto[_SessionType, _Kr8sType]):
+    """Dummy Kubernetes client wrapper for unit tests."""
+
+    def sanitize(self, obj: APIObject) -> Any:
+        """Sanitize a JSON object."""
+        raise NotImplementedError()
+
+    def namespace(self) -> str:
+        """Return the current kubernetes namespace."""
+        raise NotImplementedError()
+
+    async def cluster_name_by_class_id(self, class_id: int | None, api_user: APIUser) -> str:
+        """Retrieve the cluster name given the resource class id."""
+        raise NotImplementedError()
+
+    async def list_servers(self, safe_username: str) -> list[_SessionType]:
+        """List all the user sessions visible from the safe_username."""
+        raise NotImplementedError()
+
+    async def create_server(
+        self, manifest: _SessionType, api_user: AnonymousAPIUser | AuthenticatedAPIUser
+    ) -> _SessionType:
+        """Launch a user session."""
+        raise NotImplementedError()
+
+    async def get_server(self, name: str, safe_username: str) -> _SessionType | None:
+        """Lookup a user session by name."""
+        raise NotImplementedError()
+
+    async def get_server_logs(
+        self, server_name: str, safe_username: str, max_log_lines: Optional[int] = None
+    ) -> dict[str, str]:
+        """Retrieve the logs for the given user session."""
+        raise NotImplementedError()
+
+    async def patch_server(
+        self, server_name: str, safe_username: str, patch: dict[str, Any] | list[dict[str, Any]]
+    ) -> _SessionType:
+        """Patch the user session."""
+        raise NotImplementedError()
+
+    async def delete_server(self, server_name: str, safe_username: str) -> None:
+        """Delete the provided user session."""
+        raise NotImplementedError()
+
+    async def patch_server_tokens(self, server_name: str, renku_tokens: RenkuTokens, gitlab_token: GitlabToken) -> None:
+        """Patch user authentication tokens in a user session."""
+        raise NotImplementedError()
+
+    async def patch_statefulset(
+        self, server_name: str, patch: dict[str, Any] | list[dict[str, Any]]
+    ) -> StatefulSet | None:
+        """Patch a user session."""
+        raise NotImplementedError()
+
+    async def create_secret(self, secret: V1Secret) -> V1Secret:
+        """Create a kubernetes secret."""
+        raise NotImplementedError()
+
+    async def delete_secret(self, name: str) -> None:
+        """Delete a kubernetes secret."""
+        raise NotImplementedError()

--- a/components/renku_data_services/notebooks/api/schemas/servers_post.py
+++ b/components/renku_data_services/notebooks/api/schemas/servers_post.py
@@ -35,6 +35,7 @@ class LaunchNotebookRequestWithoutStorageBase(Schema):
     # User uploaded secrets
     # Contains secret id list and mount path
     user_secrets = fields.Nested(UserSecrets(), required=False, load_default=None)
+    cluster_name = fields.Str(required=False, load_default=None)
 
 
 class LaunchNotebookRequestWithoutStorage(LaunchNotebookRequestWithoutStorageBase):

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -249,10 +249,12 @@ class NotebooksNewBP(CustomBlueprint):
             body: apispec.SessionPostRequest,
         ) -> JSONResponse:
             # gitlab_client = NotebooksGitlabClient(self.nb_config.git.url, internal_gitlab_user.access_token)
+
             launcher = await self.session_repo.get_launcher(user, ULID.from_str(body.launcher_id))
             project = await self.project_repo.get_project(user=user, project_id=launcher.project_id)
+            cluster_name = await self.nb_config.k8s_client.cluster_name_by_class_id(launcher.resource_class_id, user)
             server_name = renku_2_make_server_name(
-                user=user, project_id=str(launcher.project_id), launcher_id=body.launcher_id
+                user=user, project_id=str(launcher.project_id), launcher_id=body.launcher_id, cluster_name=cluster_name
             )
             existing_session = await self.nb_config.k8s_v2_client.get_server(server_name, user.id)
             if existing_session is not None and existing_session.spec is not None:
@@ -436,7 +438,7 @@ class NotebooksNewBP(CustomBlueprint):
             for s in secrets_to_create:
                 await self.nb_config.k8s_v2_client.create_secret(s.secret)
             try:
-                manifest = await self.nb_config.k8s_v2_client.create_server(manifest, user.id)
+                manifest = await self.nb_config.k8s_v2_client.create_server(manifest, user)
             except Exception:
                 for s in secrets_to_create:
                     await self.nb_config.k8s_v2_client.delete_secret(s.secret.metadata.name)

--- a/components/renku_data_services/notebooks/core.py
+++ b/components/renku_data_services/notebooks/core.py
@@ -243,7 +243,7 @@ async def patch_server(
                 floor(user.access_token_expires_at.timestamp()) if user.access_token_expires_at is not None else -1
             ),
         )
-        await config.k8s_client.patch_tokens(server_name, renku_tokens, gitlab_token)
+        await config.k8s_client.patch_server_tokens(server_name, renku_tokens, gitlab_token)
         new_server = await config.k8s_client.patch_server(server_name=server_name, safe_username=user.id, patch=patch)
 
     return UserServerManifest(new_server, config.sessions.default_image)
@@ -553,7 +553,7 @@ async def launch_notebook_helper(
     if k8s_user_secret is not None:
         request_data: dict[str, Any] = {
             "name": k8s_user_secret.name,
-            "namespace": server.k8s_client.preferred_namespace,
+            "namespace": server.namespace,
             "secret_ids": [str(id_) for id_ in k8s_user_secret.user_secret_ids],
             "owner_references": [owner_reference],
         }
@@ -567,7 +567,7 @@ async def launch_notebook_helper(
                 base_name = f"{server_name}-ds-{icloud_storage}"
             request_data = {
                 "name": f"{base_name}-secrets",
-                "namespace": server.k8s_client.preferred_namespace,
+                "namespace": server.namespace,
                 "secret_ids": list(cloud_storage.secrets.keys()),
                 "owner_references": [owner_reference],
                 "key_mapping": cloud_storage.secrets,
@@ -586,6 +586,9 @@ async def launch_notebook(
     storage_repo: StorageRepository,
 ) -> tuple[UserServerManifest, int]:
     """Starts a server using the old operator."""
+
+    cluster_name = await config.k8s_client.cluster_name_by_class_id(launch_request.resource_class_id, user)
+
     if isinstance(user, AnonymousAPIUser):
         safe_username = escapism.escape(user.id, escape_char="-").lower()
     else:
@@ -596,6 +599,7 @@ async def launch_notebook(
         launch_request.project,
         launch_request.branch,
         launch_request.commit_sha,
+        cluster_name,
     )
     project_slug = f"{launch_request.namespace}/{launch_request.project}"
     gitlab_client = NotebooksGitlabClient(config.git.url, internal_gitlab_user.access_token)

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -223,7 +223,7 @@ async def get_data_sources(
         secret = ExtraSecret(
             cs.secret(
                 secret_name,
-                nb_config.k8s_client.preferred_namespace,
+                nb_config.k8s_client.namespace(),
                 user_secret_key=user_secret_key if secret_key_needed else None,
             )
         )
@@ -260,7 +260,7 @@ async def request_dc_secret_creation(
             continue
         request_data = {
             "name": f"{manifest.metadata.name}-ds-{s_id.lower()}-secrets",
-            "namespace": nb_config.k8s_v2_client.preferred_namespace,
+            "namespace": nb_config.k8s_v2_client.namespace(),
             "secret_ids": [str(secret.secret_id) for secret in secrets],
             "owner_references": [owner_reference],
             "key_mapping": {str(secret.secret_id): secret.name for secret in secrets},
@@ -301,7 +301,7 @@ async def request_session_secret_creation(
         key_mapping[secret_id].append(s.secret_slot.filename)
     request_data = {
         "name": f"{manifest.metadata.name}-secrets",
-        "namespace": nb_config.k8s_v2_client.preferred_namespace,
+        "namespace": nb_config.k8s_v2_client.namespace(),
         "secret_ids": [str(s.secret_id) for s in session_secrets],
         "owner_references": [owner_reference],
         "key_mapping": key_mapping,

--- a/components/renku_data_services/notebooks/crs.py
+++ b/components/renku_data_services/notebooks/crs.py
@@ -289,6 +289,7 @@ class AmaltheaSessionV1Alpha1SpecPatch(BaseCRD):
     tolerations: list[Toleration] | None = None
     affinity: Affinity | None = None
     session: AmaltheaSessionV1Alpha1SpecSessionPatch | None = None
+    culling: Culling | None = None
 
 
 class AmaltheaSessionV1Alpha1Patch(BaseCRD):

--- a/components/renku_data_services/notebooks/util/kubernetes_.py
+++ b/components/renku_data_services/notebooks/util/kubernetes_.py
@@ -24,18 +24,20 @@ from hashlib import md5
 from typing import Any, TypeAlias, cast
 
 import escapism
-from box import Box
+from box.box import Box
 
 from renku_data_services.base_models.core import AnonymousAPIUser, AuthenticatedAPIUser, Slug
 from renku_data_services.notebooks.crs import Patch, PatchType
 
 
-def renku_1_make_server_name(safe_username: str, namespace: str, project: str, branch: str, commit_sha: str) -> str:
+def renku_1_make_server_name(
+    safe_username: str, namespace: str, project: str, branch: str, commit_sha: str, cluster_name: str
+) -> str:
     """Form a unique server name for Renku 1.0 sessions.
 
     This is used in naming all the k8s resources created by amalthea.
     """
-    server_string_for_hashing = f"{safe_username}-{namespace}-{project}-{branch}-{commit_sha}"
+    server_string_for_hashing = f"{safe_username}-{namespace}-{project}-{branch}-{commit_sha}-{cluster_name}"
     server_hash = md5(server_string_for_hashing.encode(), usedforsecurity=False).hexdigest().lower()
     prefix = _make_server_name_prefix(safe_username)
     # NOTE: A K8s object name can only contain lowercase alphanumeric characters, hyphens, or dots.
@@ -52,7 +54,9 @@ def renku_1_make_server_name(safe_username: str, namespace: str, project: str, b
     )
 
 
-def renku_2_make_server_name(user: AuthenticatedAPIUser | AnonymousAPIUser, project_id: str, launcher_id: str) -> str:
+def renku_2_make_server_name(
+    user: AuthenticatedAPIUser | AnonymousAPIUser, project_id: str, launcher_id: str, cluster_name: str
+) -> str:
     """Form a unique server name for Renku 2.0 sessions.
 
     This is used in naming all the k8s resources created by amalthea.
@@ -61,7 +65,7 @@ def renku_2_make_server_name(user: AuthenticatedAPIUser | AnonymousAPIUser, proj
     safe_username = safe_username.lower()
     safe_username = re.sub(r"[^a-z0-9-]", "-", safe_username)
     prefix = _make_server_name_prefix(safe_username)
-    server_string_for_hashing = f"{user.id}-{project_id}-{launcher_id}"
+    server_string_for_hashing = f"{user.id}-{project_id}-{launcher_id}-{cluster_name}"
     server_hash = md5(server_string_for_hashing.encode(), usedforsecurity=False).hexdigest().lower()
     # NOTE: A K8s object name can only contain lowercase alphanumeric characters, hyphens, or dots.
     # Must be no more than 63 characters because the name is used to create a k8s Service and Services

--- a/test/bases/renku_data_services/background_jobs/test_sync.py
+++ b/test/bases/renku_data_services/background_jobs/test_sync.py
@@ -19,11 +19,11 @@ from authzed.api.v1 import (
 )
 from ulid import ULID
 
-from bases.renku_data_services.background_jobs.config import SyncConfig
 from renku_data_services.authz.admin_sync import sync_admins_from_keycloak
 from renku_data_services.authz.authz import Authz, ResourceType, _AuthzConverter, _Relation
 from renku_data_services.authz.config import AuthzConfig
 from renku_data_services.authz.models import Role, UnsavedMember
+from renku_data_services.background_jobs.config import SyncConfig
 from renku_data_services.background_jobs.core import (
     bootstrap_user_namespaces,
     fix_mismatched_project_namespace_ids,

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -9,7 +9,6 @@ from sanic import Sanic
 from sanic_testing.testing import SanicASGITestClient
 from ulid import ULID
 
-from components.renku_data_services.utils.middleware import validate_null_byte
 from renku_data_services.app_config.config import Config
 from renku_data_services.authz.admin_sync import sync_admins_from_keycloak
 from renku_data_services.authz.authz import _AuthzConverter
@@ -22,6 +21,7 @@ from renku_data_services.secrets_storage_api.app import register_all_handlers as
 from renku_data_services.storage.rclone import RCloneValidator
 from renku_data_services.users.dummy_kc_api import DummyKeycloakAPI
 from renku_data_services.users.models import UserInfo
+from renku_data_services.utils.middleware import validate_null_byte
 from test.bases.renku_data_services.background_jobs.test_sync import get_kc_users
 from test.utils import SanicReusableASGITestClient
 

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -11,8 +11,8 @@ from sqlalchemy import select
 from syrupy.filters import props
 from ulid import ULID
 
-from components.renku_data_services.message_queue.avro_models.io.renku.events import v2 as avro_schema_v2
 from renku_data_services.app_config.config import Config
+from renku_data_services.message_queue.avro_models.io.renku.events import v2 as avro_schema_v2
 from renku_data_services.message_queue.avro_models.io.renku.events.v2.member_role import MemberRole
 from renku_data_services.message_queue.models import deserialize_binary
 from renku_data_services.users.models import UserInfo

--- a/test/components/renku_data_services/k8s/test_k8s_adapter.py
+++ b/test/components/renku_data_services/k8s/test_k8s_adapter.py
@@ -19,7 +19,7 @@ from renku_data_services.crc import models
 from renku_data_services.k8s.clients import DummyCoreClient, DummySchedulingClient
 from renku_data_services.k8s.quota import QuotaRepository
 from renku_data_services.notebooks.api.classes.auth import RenkuTokens
-from renku_data_services.notebooks.api.classes.k8s_client import NamespacedK8sClient
+from renku_data_services.notebooks.api.classes.k8s_client import _BaseK8sClient
 from renku_data_services.notebooks.util.kubernetes_ import find_env_var
 from test.components.renku_data_services.crc_models.hypothesis import quota_strat
 
@@ -171,7 +171,7 @@ def test_patch_statefulset_tokens() -> None:
         )
     )
     sanitized_sts = client.ApiClient().sanitize_for_serialization(sts)
-    patches = NamespacedK8sClient._get_statefulset_token_patches(StatefulSet(sanitized_sts), new_renku_tokens)
+    patches = _BaseK8sClient._get_statefulset_token_patches(StatefulSet(sanitized_sts), new_renku_tokens)
 
     # Order of patches should be git proxy access, git proxy refresh, git clone, secrets
     assert len(patches) == 4


### PR DESCRIPTION
feat: add multi-kubernetes-cluster client
* Add `KubeClusterSettings` and a cluster field of that type to
  ResourcePool

* Explicitly pass the ApiClient parameters in k8s/clients.py and
  simplify`__init__(...)` functions

* Refactor k8s_client.py
  * Made sure we had a single sanitize function pointer, no need for
    multiple ones.
  * Introduce `K8sClientProto[_SessionType, _Kr8sType](ABC)` as the public
    interface for the Kubernetes cluster wrapper
  * Added `DummyK8sClient` for tests
  * Added `MultipleK8sClient` which manages multiple Kubernetes API
    connections.
  * Prefixed private items (classes, variables & methods) with `_` to
    be more explicit.

* Added the cluster name as a parameter in the hashed string used for
  unique references of user sessions.
  
  /deploy