### PR TITLE
fix: validate git URLs

### DIFF
--- a/components/renku_data_services/project/core.py
+++ b/components/renku_data_services/project/core.py
@@ -204,7 +204,7 @@ def _validate_repository(repository: str) -> str:
     """Validate a git repository."""
     stripped = repository.strip()
     parsed = urlparse(stripped)
-    if parsed.scheme != "http" and parsed.scheme != "https":
+    if parsed.scheme not in ["http", "https"]:
         raise errors.ValidationError(message=f'The repository URL "{repository}" is not a valid HTTP or HTTPS URL.')
     return stripped
 

--- a/components/renku_data_services/project/core.py
+++ b/components/renku_data_services/project/core.py
@@ -205,7 +205,7 @@ def _validate_repository(repository: str) -> str:
     stripped = repository.strip()
     parsed = urlparse(stripped)
     if parsed.scheme != "http" and parsed.scheme != "https":
-        raise errors.ValidationError(message=f"The repository URL {repository} is not a valid HTTP or HTTPS URL.")
+        raise errors.ValidationError(message=f'The repository URL "{repository}" is not a valid HTTP or HTTPS URL.')
     return stripped
 
 

--- a/components/renku_data_services/project/core.py
+++ b/components/renku_data_services/project/core.py
@@ -190,7 +190,14 @@ def _validate_repositories(repositories: list[str] | None) -> list[str] | None:
     """Validate a list of git repositories."""
     if repositories is None:
         return None
-    return [_validate_repository(repo) for repo in repositories]
+    seen: set[str] = set()
+    without_duplicates: list[str] = []
+    for repo in repositories:
+        repo = _validate_repository(repo)
+        if repo not in seen:
+            without_duplicates.append(repo)
+            seen.add(repo)
+    return without_duplicates
 
 
 def _validate_repository(repository: str) -> str:

--- a/components/renku_data_services/project/core.py
+++ b/components/renku_data_services/project/core.py
@@ -1,6 +1,7 @@
 """Business logic for projects."""
 
 from pathlib import PurePosixPath
+from urllib.parse import urlparse
 
 from ulid import ULID
 
@@ -18,12 +19,13 @@ def validate_unsaved_project(body: apispec.ProjectPost, created_by: str) -> mode
     keywords = [kw.root for kw in body.keywords] if body.keywords is not None else []
     visibility = Visibility.PRIVATE if body.visibility is None else Visibility(body.visibility.value)
     secrets_mount_directory = PurePosixPath(body.secrets_mount_directory) if body.secrets_mount_directory else None
+    repositories = _validate_repositories(body.repositories)
     return models.UnsavedProject(
         name=body.name,
         namespace=body.namespace,
         slug=body.slug or Slug.from_name(body.name).value,
         description=body.description,
-        repositories=body.repositories or [],
+        repositories=repositories or [],
         created_by=created_by,
         visibility=visibility,
         keywords=keywords,
@@ -43,12 +45,13 @@ def validate_project_patch(patch: apispec.ProjectPatch) -> models.ProjectPatch:
             secrets_mount_directory = PurePosixPath(patch.secrets_mount_directory)
         case _:
             secrets_mount_directory = None
+    repositories = _validate_repositories(patch.repositories)
     return models.ProjectPatch(
         name=patch.name,
         namespace=patch.namespace,
         slug=patch.slug,
         visibility=Visibility(patch.visibility.value) if patch.visibility is not None else None,
-        repositories=patch.repositories,
+        repositories=repositories,
         description=patch.description,
         keywords=keywords,
         documentation=patch.documentation,
@@ -76,13 +79,14 @@ async def copy_project(
 ) -> models.Project:
     """Create a copy of a given project."""
     template = await project_repo.get_project(user=user, project_id=project_id)
+    repositories_ = _validate_repositories(repositories)
 
     unsaved_project = models.UnsavedProject(
         name=name,
         namespace=namespace,
         slug=slug or Slug.from_name(name).value,
         description=description or template.description,
-        repositories=repositories or template.repositories,
+        repositories=repositories_ or template.repositories,
         created_by=user.id,  # type: ignore[arg-type]
         visibility=template.visibility if visibility is None else visibility,
         keywords=keywords or template.keywords,
@@ -180,6 +184,22 @@ def validate_session_secrets_patch(
                 )
             )
     return result
+
+
+def _validate_repositories(repositories: list[str] | None) -> list[str] | None:
+    """Validate a list of git repositories."""
+    if repositories is None:
+        return None
+    return [_validate_repository(repo) for repo in repositories]
+
+
+def _validate_repository(repository: str) -> str:
+    """Validate a git repository."""
+    stripped = repository.strip()
+    parsed = urlparse(stripped)
+    if parsed.scheme != "http" and parsed.scheme != "https":
+        raise errors.ValidationError(message=f"The repository URL {repository} is not a valid HTTP or HTTPS URL.")
+    return stripped
 
 
 def _validate_session_launcher_secret_slot_filename(filename: str) -> None:

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -226,6 +226,25 @@ async def test_project_creation_with_conflicting_slug(sanic_client, user_headers
 
 
 @pytest.mark.asyncio
+async def test_project_creation_with_duplicate_repositories(sanic_client, user_headers, regular_user) -> None:
+    namespace = regular_user.namespace.slug
+    payload = {
+        "name": "My Project",
+        "namespace": namespace,
+        "repositories": [
+            "https://github.com/SwissDataScienceCenter/renku-data-services.git",
+            "https://github.com/SwissDataScienceCenter/renku-data-services.git",
+        ],
+    }
+
+    _, response = await sanic_client.post("/api/data/projects", headers=user_headers, json=payload)
+
+    assert response.status_code == 201, response.text
+    project = response.json
+    assert project["repositories"] == ["https://github.com/SwissDataScienceCenter/renku-data-services.git"]
+
+
+@pytest.mark.asyncio
 async def test_get_a_project(create_project, get_project) -> None:
     # Create some projects
     await create_project("Project 1")

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -245,6 +245,23 @@ async def test_project_creation_with_duplicate_repositories(sanic_client, user_h
 
 
 @pytest.mark.asyncio
+async def test_project_creation_with_invalid_repository(sanic_client, user_headers, regular_user) -> None:
+    namespace = regular_user.namespace.slug
+    payload = {
+        "name": "My Project",
+        "namespace": namespace,
+        "repositories": [
+            "git@github.com:SwissDataScienceCenter/renku-data-services.git",
+        ],
+    }
+
+    _, response = await sanic_client.post("/api/data/projects", headers=user_headers, json=payload)
+
+    assert response.status_code == 422, response.text
+    assert "is not a valid HTTP or HTTPS URL" in response.json["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_get_a_project(create_project, get_project) -> None:
     # Create some projects
     await create_project("Project 1")


### PR DESCRIPTION
See: #712.

What is done with this change:
* Validate the repository URL (when the project is created or updated): the repository URL must be an HTTP or HTTPS URL. SSH is not supported by RenkuLab at the moment.
* Remove exact duplicates.

What is not included with this change:
* Resolve the user-provided URL to a canonical URL (e.g. https://github.com/SwissDataScienceCenter/renku-data-services -> https://github.com/SwissDataScienceCenter/renku-data-services.git). This would require connecting validation code with connected services and is left for a future change.

/deploy #notest renku=release-0.66.0