### PR TITLE
fix: Kubernetes client tests

### DIFF
--- a/components/renku_data_services/notebooks/api/classes/k8s_client.py
+++ b/components/renku_data_services/notebooks/api/classes/k8s_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import datetime
 import glob
 import json
 import os
@@ -945,47 +946,80 @@ class MultipleK8sClient(K8sClientProto[_SessionType, _Kr8sType]):
 class DummyK8sClient(K8sClientProto[_SessionType, _Kr8sType]):
     """Dummy Kubernetes client wrapper for unit tests."""
 
+    def __init__(self, server_type: type[_SessionType], kr8s_type: type[_Kr8sType], username_label: str):
+        self._server_type: type[_SessionType] = server_type
+        self._kr8s_type: type[_Kr8sType] = kr8s_type
+        self._username_label = username_label
+        self._servers: list[_SessionType] = []
+
     def sanitize(self, obj: APIObject) -> Any:
         """Sanitize a JSON object."""
         raise NotImplementedError()
 
     def namespace(self) -> str:
         """Return the current kubernetes namespace."""
-        raise NotImplementedError()
+        return "a-name-space"
 
     async def cluster_name_by_class_id(self, class_id: int | None, api_user: APIUser) -> str:
         """Retrieve the cluster name given the resource class id."""
-        raise NotImplementedError()
+        return "a-cluster"
 
     async def list_servers(self, safe_username: str) -> list[_SessionType]:
         """List all the user sessions visible from the safe_username."""
-        raise NotImplementedError()
+        return [s for s in self._servers if safe_username in s.metadata.labels.values()]
 
     async def create_server(
         self, manifest: _SessionType, api_user: AnonymousAPIUser | AuthenticatedAPIUser
     ) -> _SessionType:
         """Launch a user session."""
-        raise NotImplementedError()
+        manifest.metadata.labels[self._username_label] = api_user.id
+        manifest.metadata.creationTimestamp = datetime.datetime.fromisoformat("2025-03-05T15:24:55.474Z")
+
+        self._servers.append(manifest)
+        return manifest
 
     async def get_server(self, name: str, safe_username: str) -> _SessionType | None:
         """Lookup a user session by name."""
-        raise NotImplementedError()
+        for s in self._servers:
+            if s.metadata.name == name:
+                return s
+        return None
 
     async def get_server_logs(
         self, server_name: str, safe_username: str, max_log_lines: Optional[int] = None
     ) -> dict[str, str]:
         """Retrieve the logs for the given user session."""
-        raise NotImplementedError()
+        server = await self.get_server(server_name, safe_username)
+        if server is not None:
+            return {
+                "container-0": "fake log lines\n fake log lines",
+                "container-1": "fake log lines 2 \n fake log lines 2",
+            }
+
+        raise errors.MissingResourceError(
+            message=f"Cannot find server {server_name} for user {safe_username} to retrieve logs."
+        )
 
     async def patch_server(
         self, server_name: str, safe_username: str, patch: dict[str, Any] | list[dict[str, Any]]
     ) -> _SessionType:
-        """Patch the user session."""
-        raise NotImplementedError()
+        """Pretend to Patch the user session."""
+        server = await self.get_server(server_name, safe_username)
+        if not server:
+            raise errors.MissingResourceError(
+                message=f"Cannot find server {server_name} for user {safe_username} in order to patch it."
+            )
+        return server
 
     async def delete_server(self, server_name: str, safe_username: str) -> None:
         """Delete the provided user session."""
-        raise NotImplementedError()
+        server = await self.get_server(server_name, safe_username)
+        if server is not None:
+            self._servers.remove(server)
+        else:
+            raise errors.MissingResourceError(
+                message=f"Cannot find server {server_name} for user {safe_username} in order to delete it."
+            )
 
     async def patch_server_tokens(
         self, server_name: str, safe_username: str, renku_tokens: RenkuTokens, gitlab_token: GitlabToken

--- a/components/renku_data_services/notebooks/config/__init__.py
+++ b/components/renku_data_services/notebooks/config/__init__.py
@@ -121,8 +121,16 @@ class NotebooksConfig:
             git_provider_helper = DummyGitProviderHelper()
             amalthea_config = _AmaltheaConfig(cache_url="http://not.specified")
             git_config = _GitConfig("http://not.specified", "registry.not.specified")
-            k8s_client = DummyK8sClient()
-            k8s_v2_client = DummyK8sClient()
+            k8s_client = DummyK8sClient(
+                server_type=JupyterServerV1Alpha1,
+                kr8s_type=JupyterServerV1Alpha1Kr8s,
+                username_label="renku.io/userId",
+            )
+            k8s_v2_client = DummyK8sClient(
+                server_type=AmaltheaSessionV1Alpha1,
+                kr8s_type=AmaltheaSessionV1Alpha1Kr8s,
+                username_label="renku.io/safe-username",
+            )
         else:
             quota_repo = QuotaRepository(K8sCoreClient(), K8sSchedulingClient(), namespace=k8s_namespace)
             rp_repo = ResourcePoolRepository(db_config.async_session_maker, quota_repo)

--- a/components/renku_data_services/notebooks/core.py
+++ b/components/renku_data_services/notebooks/core.py
@@ -311,6 +311,7 @@ async def launch_notebook_helper(
     user: AnonymousAPIUser | AuthenticatedAPIUser,
     image: str | None,
     resource_class_id: int | None,
+    cluster_name: str,
     storage: int | None,
     environment_variables: dict[str, str],
     user_secrets: apispec.UserSecrets | None,
@@ -509,6 +510,7 @@ async def launch_notebook_helper(
         is_image_private=is_image_private,
         repositories=[Repository.from_dict(r.model_dump()) for r in repositories],
         config=nb_config,
+        cluster_name=cluster_name,
         **extra_kwargs,
     )
 
@@ -625,6 +627,7 @@ async def launch_notebook(
         user=user,
         image=launch_request.image,
         resource_class_id=launch_request.resource_class_id,
+        cluster_name=cluster_name,
         storage=launch_request.storage,
         environment_variables=launch_request.environment_variables,
         user_secrets=launch_request.user_secrets,

--- a/test/bases/renku_data_services/data_api/test_notebooks.py
+++ b/test/bases/renku_data_services/data_api/test_notebooks.py
@@ -1,135 +1,9 @@
 """Tests for notebook blueprints."""
 
-import asyncio
-import os
-from collections.abc import AsyncIterator
-from contextlib import suppress
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
-import pytest_asyncio
-from kr8s import NotFoundError
-from kr8s.asyncio.objects import Pod
 from sanic_testing.testing import SanicASGITestClient
-
-from renku_data_services.notebooks.api.classes.k8s_client import JupyterServerV1Alpha1Kr8s
-
-from .utils import ClusterRequired, setup_amalthea
-
-os.environ["KUBECONFIG"] = ".k3d-config.yaml"
-
-
-@pytest.fixture
-def non_mocked_hosts() -> list:
-    """Hosts that should not get mocked during tests."""
-
-    return ["127.0.0.1"]
-
-
-@pytest.fixture
-def renku_image() -> str:
-    return "renku/renkulab-py:3.10-0.24.0"
-
-
-@pytest.fixture
-def unknown_server_name() -> str:
-    return "unknown"
-
-
-@pytest.fixture
-def server_name() -> str:
-    random_name_part = str(uuid4())
-    session_name = f"test-session-{random_name_part}"
-    return session_name
-
-
-@pytest.fixture
-def pod_name(server_name: str) -> str:
-    return f"{server_name}-0"
-
-
-@pytest_asyncio.fixture
-async def jupyter_server(renku_image: str, server_name: str, pod_name: str) -> AsyncIterator[JupyterServerV1Alpha1Kr8s]:
-    """Fake server to have the minimal set of objects for tests"""
-
-    server = await JupyterServerV1Alpha1Kr8s(
-        {
-            "metadata": {
-                "name": server_name,
-                "labels": {"renku.io/safe-username": "user", "renku.io/userId": "user"},
-            },
-            "spec": {
-                "jupyterServer": {"image": renku_image},
-                "routing": {"host": "locahost"},
-                "auth": {"token": ""},
-            },
-        }
-    )
-
-    await server.create()
-    pod = await Pod(dict(metadata=dict(name=pod_name)))
-    max_retries = 200
-    sleep_seconds = 0.2
-    retries = 0
-    while True:
-        retries += 1
-        pod_exists = await pod.exists()
-        if pod_exists:
-            break
-        if retries > max_retries:
-            raise ValueError(
-                f"The pod {pod_name} for the session {server_name} could not found even after {max_retries} "
-                f"retries with {sleep_seconds} seconds of sleep after each retry."
-            )
-        await asyncio.sleep(sleep_seconds)
-    await pod.refresh()
-    await pod.wait("condition=Ready")
-    yield server
-    # NOTE: This is used also in tests that check if the server was properly stopped
-    # in this case the server will already be gone when we try to delete it in the cleanup here.
-    with suppress(NotFoundError):
-        await server.delete("Foreground")
-
-
-@pytest_asyncio.fixture()
-async def practice_jupyter_server(renku_image: str, server_name: str) -> AsyncIterator[JupyterServerV1Alpha1Kr8s]:
-    """Fake server for non pod related tests"""
-
-    server = await JupyterServerV1Alpha1Kr8s(
-        {
-            "metadata": {
-                "name": server_name,
-                "labels": {"renku.io/safe-username": "user", "renku.io/userId": "user"},
-                "annotations": {
-                    "renku.io/branch": "dummy",
-                    "renku.io/commit-sha": "sha",
-                    "renku.io/default_image_used": "default/image",
-                    "renku.io/namespace": "default",
-                    "renku.io/projectName": "dummy",
-                    "renku.io/repository": "dummy",
-                },
-            },
-            "spec": {
-                "jupyterServer": {
-                    "image": renku_image,
-                    "resources": {
-                        "requests": {
-                            "cpu": 0.1,
-                            "memory": 100_000_000,
-                        },
-                    },
-                },
-            },
-        }
-    )
-
-    await server.create()
-    yield server
-    # NOTE: This is used also in tests that check if the server was properly stopped
-    # in this case the server will already be gone when we try to delete it in the cleanup here.
-    with suppress(NotFoundError):
-        await server.delete("Foreground")
 
 
 @pytest.fixture()
@@ -141,6 +15,7 @@ class AttributeDictionary(dict):
     """Enables accessing dictionary keys as attributes"""
 
     def __init__(self, dictionary):
+        super().__init__()
         for key, value in dictionary.items():
             # TODO check if key is a valid identifier
             if key == "list":
@@ -153,7 +28,7 @@ class AttributeDictionary(dict):
             self[key] = value
 
     def list(self):
-        [value for _, value in self.items()]
+        return [value for _, value in self.items()]
 
     def __setitem__(self, k, v):
         if k == "list":
@@ -198,6 +73,30 @@ def fake_gitlab(mocker, fake_gitlab_projects):
     gitlab_mock.url = "https://gitlab-url.com"
     gitlab.return_value = gitlab_mock
     return gitlab
+
+
+async def _create_server(sanic_client: SanicASGITestClient, server_exists: bool, authenticated_user_headers) -> str:
+    if server_exists:
+        data = {
+            "branch": "main",
+            "commit_sha": "ee4b1c9fedc99abe5892ee95320bbd8471c5985b",
+            "namespace": "test-namespace",
+            "project": "my-test",
+            "image": "alpine:3",
+        }
+        _, res = await sanic_client.post("/api/data/notebooks/servers/", json=data, headers=authenticated_user_headers)
+        return res.json["name"]
+    else:
+        return "unknown_server"
+
+
+async def _delete_server(
+    sanic_client: SanicASGITestClient, server_exists: bool, server_name: str, authenticated_user_headers
+) -> None:
+    if server_exists:
+        _, res = await sanic_client.delete(
+            f"/api/data/notebooks/servers/{server_name}", headers=authenticated_user_headers
+        )
 
 
 @pytest.mark.asyncio
@@ -268,18 +167,11 @@ async def test_check_docker_image(sanic_client: SanicASGITestClient, user_header
     assert res.status_code == expected_status_code, res.text
 
 
-class TestNotebooks(ClusterRequired):
-    @pytest.fixture(scope="class", autouse=True)
-    def amalthea(self, cluster) -> None:
-        if cluster is not None:
-            setup_amalthea("amalthea-js", "amalthea", "0.12.2", cluster)
-
+class TestNotebooks:
     @pytest.mark.asyncio
     async def test_user_server_list(
         self,
         sanic_client: SanicASGITestClient,
-        request,
-        server_name,
         authenticated_user_headers,
         fake_gitlab,
     ):
@@ -293,7 +185,7 @@ class TestNotebooks(ClusterRequired):
         }
         _, res = await sanic_client.post("/api/data/notebooks/servers/", json=data, headers=authenticated_user_headers)
         assert res.status_code == 201, res.text
-        server_name = res.json["name"]
+        server_name: str = res.json["name"]
 
         _, res = await sanic_client.get("/api/data/notebooks/servers", headers=authenticated_user_headers)
         assert res.status_code == 200, res.text
@@ -306,40 +198,36 @@ class TestNotebooks(ClusterRequired):
         assert res.status_code == 204, res.text
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "server_name_fixture,expected_status_code", [("unknown_server_name", 404), ("server_name", 200)]
-    )
+    @pytest.mark.parametrize("server_exists,expected_status_code", [(False, 404), (True, 200)])
     async def test_log_retrieval(
         self,
         sanic_client: SanicASGITestClient,
-        request,
-        server_name_fixture,
+        server_exists,
         expected_status_code,
-        jupyter_server,
         authenticated_user_headers,
+        fake_gitlab,
     ):
         """Validate that the logs endpoint answers correctly"""
 
-        server_name = request.getfixturevalue(server_name_fixture)
+        server_name = await _create_server(sanic_client, server_exists, authenticated_user_headers)
 
         _, res = await sanic_client.get(f"/api/data/notebooks/logs/{server_name}", headers=authenticated_user_headers)
 
         assert res.status_code == expected_status_code, res.text
 
+        await _delete_server(sanic_client, server_exists, server_name, authenticated_user_headers)
+
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "server_name_fixture,expected_status_code", [("unknown_server_name", 404), ("server_name", 204)]
-    )
+    @pytest.mark.parametrize("server_exists,expected_status_code", [(False, 404), (True, 204)])
     async def test_stop_server(
         self,
         sanic_client: SanicASGITestClient,
-        request,
-        server_name_fixture,
+        server_exists,
         expected_status_code,
-        practice_jupyter_server,
         authenticated_user_headers,
+        fake_gitlab,
     ):
-        server_name = request.getfixturevalue(server_name_fixture)
+        server_name = await _create_server(sanic_client, server_exists, authenticated_user_headers)
 
         _, res = await sanic_client.delete(
             f"/api/data/notebooks/servers/{server_name}", headers=authenticated_user_headers
@@ -349,20 +237,19 @@ class TestNotebooks(ClusterRequired):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "server_name_fixture,expected_status_code, patch",
-        [("unknown_server_name", 404, {}), ("server_name", 200, {"state": "hibernated"})],
+        "server_exists,expected_status_code, patch",
+        [(False, 404, {}), (True, 200, {"state": "hibernated"})],
     )
     async def test_patch_server(
         self,
         sanic_client: SanicASGITestClient,
-        request,
-        server_name_fixture,
+        server_exists,
         expected_status_code,
         patch,
-        practice_jupyter_server,
         authenticated_user_headers,
+        fake_gitlab,
     ):
-        server_name = request.getfixturevalue(server_name_fixture)
+        server_name = await _create_server(sanic_client, server_exists, authenticated_user_headers)
 
         _, res = await sanic_client.patch(
             f"/api/data/notebooks/servers/{server_name}", json=patch, headers=authenticated_user_headers
@@ -370,26 +257,7 @@ class TestNotebooks(ClusterRequired):
 
         assert res.status_code == expected_status_code, res.text
 
-    @pytest.mark.asyncio
-    async def test_old_start_server(self, sanic_client: SanicASGITestClient, authenticated_user_headers, fake_gitlab):
-        data = {
-            "branch": "main",
-            "commit_sha": "ee4b1c9fedc99abe5892ee95320bbd8471c5985b",
-            "namespace": "test-namespace",
-            "project": "my-test",
-            "image": "alpine:3",
-        }
-
-        _, res = await sanic_client.post("/api/data/notebooks/servers/", json=data, headers=authenticated_user_headers)
-
-        assert res.status_code == 201, res.text
-
-        server_name = res.json["name"]
-        _, res = await sanic_client.delete(
-            f"/api/data/notebooks/servers/{server_name}", headers=authenticated_user_headers
-        )
-
-        assert res.status_code == 204, res.text
+        await _delete_server(sanic_client, server_exists, server_name, authenticated_user_headers)
 
     @pytest.mark.asyncio
     async def test_start_server(self, sanic_client: SanicASGITestClient, authenticated_user_headers, fake_gitlab):
@@ -405,7 +273,7 @@ class TestNotebooks(ClusterRequired):
 
         assert res.status_code == 201, res.text
 
-        server_name = res.json["name"]
+        server_name: str = res.json["name"]
         _, res = await sanic_client.delete(
             f"/api/data/notebooks/servers/{server_name}", headers=authenticated_user_headers
         )


### PR DESCRIPTION
 * Using the DummyK8sClient we don't need an actual K8s cluster to check our api calls end up where expected.
   * Implemented the strict minimum to pass the current tests
   * Everything else raises an exception.

 * Removed code in the test

 * Fixed warnings
   * Fixed missing call to `super().__init__()`
   * Removed unused fixtures
   * Removed dependency on `ClusterRequired`