### PR TITLE
test: force temporary db name to start with a letter

### DIFF
--- a/components/renku_data_services/base_api/error_handler.py
+++ b/components/renku_data_services/base_api/error_handler.py
@@ -29,7 +29,7 @@ class BaseError(Protocol):
 
 
 class BaseErrorResponse(Protocol):
-    """Porotocol for the error response class of an apispec module."""
+    """Protocol for the error response class of an apispec module."""
 
     error: BaseError
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -101,7 +101,7 @@ async def authz_setup(monkeysession) -> AsyncGenerator[None, None]:
 
 @pytest_asyncio.fixture
 async def db_config(monkeypatch, worker_id, authz_setup) -> AsyncGenerator[DBConfig, None]:
-    db_name = str(ULID()).lower() + "_" + worker_id
+    db_name = "R_" + str(ULID()).lower() + "_" + worker_id
     user = os.getenv("DB_USER", "renku")
     host = os.getenv("DB_HOST", "127.0.0.1")
     port = os.getenv("DB_PORT", "5432")
@@ -124,7 +124,7 @@ async def db_config(monkeypatch, worker_id, authz_setup) -> AsyncGenerator[DBCon
 
 @pytest_asyncio.fixture
 async def db_instance(monkeysession, worker_id, app_config, event_loop) -> AsyncGenerator[DBConfig, None]:
-    db_name = str(ULID()).lower() + "_" + worker_id
+    db_name = "R_" + str(ULID()).lower() + "_" + worker_id
     user = os.getenv("DB_USER", "renku")
     host = os.getenv("DB_HOST", "127.0.0.1")
     port = os.getenv("DB_PORT", "5432")


### PR DESCRIPTION
This PR aims to force the temporary database names to start with a letter rather than a number. Please suggest a more reasonable solution if the solution here isn't acceptable.

The reason behind this change is the following: most Postgres clients use a syntax like the following for interacting with databases:

```
DROP DATABASE 01jqedjvej25v1c50jfba9m7w1_master
```

Any database name starting with a number is interpreted as the beginning of a numeric literal _in Postgres_ (citation needed) and requires proper escaping. Sadly, in all the clients I tried, that doesn't happen and I get some variation of the following error when trying to drop temporary DBs

> ERROR:  trailing junk after numeric literal at or near "01jqedjvej25v1c50jfba9m7w1_master"
LINE 1: drop database 01jqedjvej25v1c50jfba9m7w1_master

For convenience, it would be great to pick a naming scheme that avoids this very unique corner case
