### PR TITLE
chore: pin k9s cli version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,17 +23,19 @@
 			"jqVersion": "latest",
 			"yqVersion": "latest"
 		},
-		"ghcr.io/dhoeric/features/k9s:1": {},
+		"ghcr.io/dhoeric/features/k9s:1": {
+			"version": "0.40.9"
+		},
 		"ghcr.io/EliiseS/devcontainer-features/bash-profile:1": {
 			"command": "alias k=kubectl"
 		},
 		"ghcr.io/devcontainers-extra/features/rclone:1": {},
 		"./k3d": {},
-    "ghcr.io/devcontainers/features/java:1": {
-        "version": "21",
-        "jdkDistro": "open"
-    },
-    "./solr": {}
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "21",
+			"jdkDistro": "open"
+		},
+		"./solr": {}
 	},
 	"overrideFeatureInstallOrder": [
 		"ghcr.io/devcontainers-extra/features/poetry",


### PR DESCRIPTION
The feature was failing because a newer release of k9s has mishapen or different formatting for releases on github. And when this feature tries to install from the github releases it fails.