### PR TITLE
fix: lowercase namespace paths when serializing

### DIFF
--- a/components/renku_data_services/base_models/core.py
+++ b/components/renku_data_services/base_models/core.py
@@ -215,7 +215,7 @@ class DataConnectorSlug(Slug):
 
 class __NamespaceCommonMixin:
     def __repr__(self) -> str:
-        return "/".join([i.value for i in self.to_list()])
+        return "/".join([i.value for i in self.to_list()]).lower()
 
     def __getitem__(self, ind: int) -> Slug:
         return self.to_list()[ind]
@@ -227,7 +227,7 @@ class __NamespaceCommonMixin:
         raise NotImplementedError
 
     def serialize(self) -> str:
-        return "/".join([i.value for i in self.to_list()])
+        return "/".join([i.value for i in self.to_list()]).lower()
 
 
 @dataclass(frozen=True, eq=True, repr=False)

--- a/components/renku_data_services/data_connectors/orm.py
+++ b/components/renku_data_services/data_connectors/orm.py
@@ -92,7 +92,7 @@ class DataConnectorORM(BaseORM):
         return models.DataConnector(
             id=self.id,
             name=self.name,
-            slug=self.slug.slug,
+            slug=self.slug.slug.lower(),
             namespace=self.slug.dump_namespace(),
             visibility=self._dump_visibility(),
             created_by=self.created_by_id,

--- a/components/renku_data_services/namespace/blueprints.py
+++ b/components/renku_data_services/namespace/blueprints.py
@@ -200,9 +200,13 @@ class GroupsBP(CustomBlueprint):
                     dict(
                         id=ns.id,
                         name=ns.name,
-                        slug=ns.latest_slug
+                        slug=ns.latest_slug.lower()
                         if ns.latest_slug
-                        else (ns.path.second.value if isinstance(ns, models.ProjectNamespace) else ns.path.first.value),
+                        else (
+                            ns.path.second.value.lower()
+                            if isinstance(ns, models.ProjectNamespace)
+                            else ns.path.first.value.lower()
+                        ),
                         created_by=ns.created_by,
                         creation_date=ns.creation_date,
                         namespace_kind=apispec.NamespaceKind(ns.kind.value),
@@ -227,7 +231,7 @@ class GroupsBP(CustomBlueprint):
                 dict(
                     id=ns.id,
                     name=ns.name,
-                    slug=ns.latest_slug or ns.path.last().value,
+                    slug=ns.latest_slug.lower() if ns.latest_slug else ns.path.last().value.lower(),
                     created_by=ns.created_by,
                     creation_date=None,  # NOTE: we do not save creation date in the DB
                     namespace_kind=apispec.NamespaceKind(ns.kind.value),
@@ -253,7 +257,7 @@ class GroupsBP(CustomBlueprint):
                 dict(
                     id=ns.id,
                     name=ns.name,
-                    slug=ns.latest_slug or ns.path.last().value,
+                    slug=ns.latest_slug.lower() if ns.latest_slug else ns.path.last().value.lower(),
                     created_by=ns.created_by,
                     creation_date=None,  # NOTE: we do not save creation date in the DB
                     namespace_kind=apispec.NamespaceKind(ns.kind.value),

--- a/components/renku_data_services/namespace/orm.py
+++ b/components/renku_data_services/namespace/orm.py
@@ -119,7 +119,7 @@ class NamespaceORM(BaseORM):
             created_by=self.created_by,
             creation_date=self.creation_date,
             underlying_resource_id=self.group_id,
-            latest_slug=self.slug,
+            latest_slug=self.slug.lower(),
             name=self.name,
             path=NamespacePath.from_strings(self.slug),
         )
@@ -135,7 +135,7 @@ class NamespaceORM(BaseORM):
             created_by=self.created_by,
             creation_date=self.creation_date,
             underlying_resource_id=self.user_id,
-            latest_slug=self.slug,
+            latest_slug=self.slug.lower(),
             name=self.name,
             path=NamespacePath.from_strings(self.slug),
         )

--- a/components/renku_data_services/project/orm.py
+++ b/components/renku_data_services/project/orm.py
@@ -82,7 +82,7 @@ class ProjectORM(BaseORM):
         return models.Project(
             id=self.id,
             name=self.name,
-            slug=self.slug.slug,
+            slug=self.slug.slug.lower(),
             namespace=self.slug.namespace.dump(),
             visibility=authz_models.Visibility.PUBLIC
             if self.visibility == Visibility.public
@@ -105,7 +105,7 @@ class ProjectORM(BaseORM):
             id=self.slug.namespace.id,
             created_by=self.created_by_id,
             underlying_resource_id=self.id,
-            latest_slug=self.slug.slug,
+            latest_slug=self.slug.slug.lower(),
             name=self.name,
             creation_date=self.creation_date,
             path=ProjectPath.from_strings(self.slug.namespace.slug, self.slug.slug),

--- a/test/bases/renku_data_services/data_api/test_projects.py
+++ b/test/bases/renku_data_services/data_api/test_projects.py
@@ -1189,14 +1189,14 @@ async def test_project_slug_case(
     # Get the project
     _, res = await sanic_client.get(f"/api/data/projects/{project_id}", headers=user_headers)
     assert res.status_code == 200
-    assert res.json.get("slug") == uppercase_slug
+    assert res.json.get("slug") == uppercase_slug.lower()
     etag = res.headers["ETag"]
     # Get it by the namespace
     _, res = await sanic_client.get(
         f"/api/data/namespaces/{group['slug']}/projects/{uppercase_slug}", headers=user_headers
     )
     assert res.status_code == 200
-    assert res.json.get("slug") == uppercase_slug
+    assert res.json.get("slug") == uppercase_slug.lower()
     # Patch the project
     new_name = "new-name"
     _, res = await sanic_client.patch(
@@ -1205,7 +1205,7 @@ async def test_project_slug_case(
         headers={"If-Match": etag, **user_headers},
     )
     assert res.status_code == 200
-    assert res.json["slug"] == uppercase_slug
+    assert res.json["slug"] == uppercase_slug.lower()
     assert res.json["name"] == new_name
 
 
@@ -1243,7 +1243,7 @@ async def test_project_copy_basics(
     assert copy_project == snapshot(exclude=props("id", "updated_at", "creation_date", "etag", "template_id"))
 
     _, response = await sanic_client.get(
-        f"/api/data/projects/{copy_project["id"]}", params={"with_documentation": True}, headers=user_headers
+        f"/api/data/projects/{copy_project['id']}", params={"with_documentation": True}, headers=user_headers
     )
     assert response.status_code == 200, response.text
     copy_project = response.json


### PR DESCRIPTION
```
data-service Srv 0 2025-04-02 12:18:03 +0000 ERROR: Exception occurred while handling uri: 'https://renkulab.io/api/data/namespaces?kinds=group&kinds=u
ser&kinds=project&minimum_role=editor'
data-service Traceback (most recent call last):
data-service   File "/app/env/lib/python3.13/site-packages/renku_data_services/base_models/validation.py", line 25, in validate_and_dump
data-service     body = model.model_validate(data).model_dump(exclude_none=exclude_none, mode="json", **kwargs)
data-service            ~~~~~~~~~~~~~~~~~~~~^^^^^^
data-service   File "/app/env/lib/python3.13/site-packages/pydantic/main.py", line 627, in model_validate
data-service     return cls.__pydantic_validator__.validate_python(
data-service            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
data-service         obj, strict=strict, from_attributes=from_attributes, context=context
data-service         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
data-service     )
data-service     ^
data-service pydantic_core._pydantic_core.ValidationError: 4 validation errors for NamespaceResponseList
data-service 6.slug
data-service   String should match pattern '^(?!.*\.git$|.*\.atom$|.*[\-._][\-._].*)[a-z0-9][a-z0-9\-_.]*$' [type=string_pattern_mismatch, input_value=
'test-tasko-PRIVATE-2', input_type=str]
data-service     For further information visit https://errors.pydantic.dev/2.10/v/string_pattern_mismatch
data-service 6.path
data-service   String should match pattern '^(?!.*\.git$|.*\.atom$|.*[\-._][\-._].*)[a-z0-9][a-z0-9\-_.]*(?<!\.git)(?<!\.atom)(?:/[a-z0-9][a-z0-9\-_.]*
){0,1}$' [type=string_pattern_mismatch, input_value='tasko.olevski/test-tasko-PRIVATE-2', input_type=str]
data-service     For further information visit https://errors.pydantic.dev/2.10/v/string_pattern_mismatch
data-service 7.slug
data-service   String should match pattern '^(?!.*\.git$|.*\.atom$|.*[\-._][\-._].*)[a-z0-9][a-z0-9\-_.]*$' [type=string_pattern_mismatch, input_value=
'test-TASKO-PRIVATE-2', input_type=str]
```

This is likely affecting only me. Because only for a brief period we had one of two endpoints that did not have proper lowercase enforcement on slug values. So in production I have some namespaces that have uppercase characters for slugs.