### PR TITLE
fix: Start reprovisioning search index if a migration requires it

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -25,6 +25,7 @@ from renku_data_services.platform.blueprints import PlatformConfigBP
 from renku_data_services.project.blueprints import ProjectsBP, ProjectSessionSecretBP
 from renku_data_services.repositories.blueprints import RepositoriesBP
 from renku_data_services.search.blueprints import SearchBP
+from renku_data_services.search.reprovision import SearchReprovision
 from renku_data_services.session.blueprints import BuildsBP, EnvironmentsBP, SessionLaunchersBP
 from renku_data_services.storage.blueprints import StorageBP, StorageSchemaBP
 from renku_data_services.users.blueprints import KCUsersBP, UserPreferencesBP, UserSecretsBP
@@ -207,12 +208,15 @@ def register_all_handlers(app: Sanic, config: Config) -> Sanic:
         name="search2",
         url_prefix=url_prefix,
         authenticator=config.authenticator,
-        reprovisioning_repo=config.reprovisioning_repo,
-        user_repo=config.kc_user_repo,
-        group_repo=config.group_repo,
+        search_reprovision=SearchReprovision(
+            search_updates_repo=config.search_updates_repo,
+            reprovisioning_repo=config.reprovisioning_repo,
+            solr_config=config.solr_config,
+            user_repo=config.kc_user_repo,
+            group_repo=config.group_repo,
+            project_repo=config.project_repo,
+        ),
         solr_config=config.solr_config,
-        project_repo=config.project_repo,
-        search_updates_repo=config.search_updates_repo,
         authz=config.authz,
     )
     data_connectors = DataConnectorsBP(

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import concurrent.futures
 from os import environ
 from typing import TYPE_CHECKING, Any
 
@@ -181,8 +182,8 @@ def create_app() -> Sanic:
         # admin = APIUser(is_admin=True)
         # await config.search_reprovisioning.run_reprovision(admin)
         while True:
-            await asyncio.sleep(1)
-            print("Notification: hello")
+            await asyncio.sleep(0)
+            print("++++++ Notification: hello")
 
     @app.main_process_start
     async def do_solr_migrations(app: Sanic) -> None:
@@ -195,8 +196,10 @@ def create_app() -> Sanic:
         try:
             ## why is this not working???
             ## with a name=... there is a runtime error. docs say not to create the coro object, but either way it doesn't work
-            app.add_task(notify_me)
-            print("Task added, i think…")
+            t = asyncio.create_task(notify_me(), name="my_task")
+            print(f"Task added, i think… {t}")
+            print("But the loop is not executed, because the sleep doesn't return. But why?")
+
             # app.add_task(testing)
             # await config.search_reprovisioning.reprovision_task(requested_by=APIUser(is_admin = True))
         except Exception as exc:

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -213,7 +213,7 @@ def create_app() -> Sanic:
         logger.info("starting events background job.")
         app.manager.manage("SendEvents", send_pending_events, {"app_name": app.name}, transient=True)
         app.manager.manage("UpdateSearch", update_search, {"app_name": app.name}, transient=True)
-        if hasattr(app.ctx, "solr_reindex") and app.ctx.solr_reindex:
+        if getattr(app.ctx, "solr_reindex", False):
             app.manager.manage("SolrReindex", solr_reindex, {"app_name": app.name}, transient=True)
 
     return app

--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
+from components.renku_data_services.search.reprovision import SearchReprovision
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
@@ -285,6 +286,7 @@ class Config:
     _event_repo: EventRepository | None = field(default=None, repr=False, init=False)
     _reprovisioning_repo: ReprovisioningRepository | None = field(default=None, repr=False, init=False)
     _search_updates_repo: SearchUpdatesRepo | None = field(default=None, repr=False, init=False)
+    _search_reprovisioning: SearchReprovision | None = field(default=None, repr=False, init=False)
     _session_repo: SessionRepository | None = field(default=None, repr=False, init=False)
     _user_preferences_repo: UserPreferencesRepository | None = field(default=None, repr=False, init=False)
     _kc_user_repo: KcUserRepo | None = field(default=None, repr=False, init=False)
@@ -399,6 +401,20 @@ class Config:
         if not self._search_updates_repo:
             self._search_updates_repo = SearchUpdatesRepo(session_maker=self.db.async_session_maker)
         return self._search_updates_repo
+
+    @property
+    def search_reprovisioning(self) -> SearchReprovision:
+        """The SearchReprovisioning class."""
+        if not self._search_reprovisioning:
+            self._search_reprovisioning = SearchReprovision(
+                search_updates_repo=self.search_updates_repo,
+                reprovisioning_repo=self.reprovisioning_repo,
+                solr_config=self.solr_config,
+                user_repo=self.kc_user_repo,
+                group_repo=self.group_repo,
+                project_repo=self.project_repo,
+            )
+        return self._search_reprovisioning
 
     @property
     def project_repo(self) -> ProjectRepository:

--- a/components/renku_data_services/app_config/config.py
+++ b/components/renku_data_services/app_config/config.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import Any, Optional
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
-from components.renku_data_services.search.reprovision import SearchReprovision
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
@@ -73,6 +72,7 @@ from renku_data_services.project.db import (
 )
 from renku_data_services.repositories.db import GitRepositoriesRepository
 from renku_data_services.search.db import SearchUpdatesRepo
+from renku_data_services.search.reprovision import SearchReprovision
 from renku_data_services.secrets.db import LowLevelUserSecretsRepo, UserSecretsRepo
 from renku_data_services.session import crs as session_crs
 from renku_data_services.session.db import SessionRepository

--- a/components/renku_data_services/search/blueprints.py
+++ b/components/renku_data_services/search/blueprints.py
@@ -2,19 +2,19 @@
 
 from dataclasses import dataclass
 
-from components.renku_data_services.solr.solr_client import SolrClientConfig
 from sanic import HTTPResponse, Request, json
 from sanic.response import JSONResponse
 
 import renku_data_services.base_models as base_models
 import renku_data_services.search.core as core
-from components.renku_data_services.search.reprovision import SearchReprovision
 from renku_data_services.authz.authz import Authz
 from renku_data_services.base_api.auth import authenticate, only_admins
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
 from renku_data_services.base_api.misc import validate_query
 from renku_data_services.search.apispec import SearchQuery
+from renku_data_services.search.reprovision import SearchReprovision
 from renku_data_services.search.user_query_parser import QueryParser
+from renku_data_services.solr.solr_client import SolrClientConfig
 
 
 @dataclass(kw_only=True)

--- a/components/renku_data_services/search/blueprints.py
+++ b/components/renku_data_services/search/blueprints.py
@@ -32,7 +32,7 @@ class SearchBP(CustomBlueprint):
         @authenticate(self.authenticator)
         @only_admins
         async def _post(request: Request, user: base_models.APIUser) -> HTTPResponse | JSONResponse:
-            reprovisioning = await self.search_reprovision.acquire_reprovsion()
+            reprovisioning = await self.search_reprovision.acquire_reprovision()
 
             request.app.add_task(
                 self.search_reprovision.init_reprovision(requested_by=user, reprovisioning=reprovisioning),

--- a/components/renku_data_services/search/reprovision.py
+++ b/components/renku_data_services/search/reprovision.py
@@ -1,0 +1,101 @@
+"""Code for reprovisioning the search index."""
+
+import asyncio
+from asyncio import Task
+from datetime import datetime
+
+from sanic.log import logger
+
+from renku_data_services.base_models.core import APIUser
+from renku_data_services.message_queue.db import ReprovisioningRepository
+from renku_data_services.message_queue.models import Reprovisioning
+from renku_data_services.namespace.db import GroupRepository
+from renku_data_services.project.db import ProjectRepository
+from renku_data_services.search.db import SearchUpdatesRepo
+from renku_data_services.solr.solr_client import DefaultSolrClient, SolrClientConfig
+from renku_data_services.users.db import UserRepo
+
+
+class SearchReprovision:
+    """Encapsulates routines to reprovision the index."""
+
+    def __init__(
+        self,
+        search_updates_repo: SearchUpdatesRepo,
+        reprovisioning_repo: ReprovisioningRepository,
+        solr_config: SolrClientConfig,
+        user_repo: UserRepo,
+        group_repo: GroupRepository,
+        project_repo: ProjectRepository,
+    ) -> None:
+        self.search_updates_repo = search_updates_repo
+        self.reprovisioning_repo = reprovisioning_repo
+        self.solr_config = solr_config
+        self.user_repo = user_repo
+        self.group_repo = group_repo
+        self.project_repo = project_repo
+
+    async def reprovision_task(self, requested_by: APIUser) -> Task:
+        """Creates a task that initiates reprovisioning."""
+        reprovision = await self.reprovisioning_repo.start()
+        task = asyncio.create_task(
+            self.init_reprovision(requested_by, reprovision), name=f"search-reprovision-{reprovision.id}"
+        )
+        return task
+
+    async def run_reprovision(self, requested_by: APIUser) -> None:
+        """Start a reprovisioning if not already running."""
+        reprovision = await self.reprovisioning_repo.start()
+        await self.init_reprovision(requested_by, reprovision)
+
+    async def acquire_reprovsion(self) -> Reprovisioning:
+        """Acquire a reprovisioning slot. Throws if already taken."""
+        return await self.reprovisioning_repo.start()
+
+    async def kill_reprovision_lock(self) -> None:
+        """Removes an existing reprovisioning lock."""
+        return await self.reprovisioning_repo.stop()
+
+    async def get_current_reprovision(self) -> Reprovisioning | None:
+        """Return the current reprovisioning lock."""
+        return await self.reprovisioning_repo.get_active_reprovisioning()
+
+    async def init_reprovision(self, requested_by: APIUser, reprovisioning: Reprovisioning) -> None:
+        """Initiates reprovisioning by inserting documents into the staging table."""
+
+        def log_counter(c: int) -> None:
+            if c % 50 == 0:
+                logger.info(f"Inserted {c}. entities into staging table...")
+
+        try:
+            logger.info(f"Starting reprovisioning with ID {reprovisioning.id}")
+            started = datetime.now()
+            await self.search_updates_repo.clear_all()
+            async with DefaultSolrClient(self.solr_config) as client:
+                await client.delete("_type:*")
+            counter = 0
+            all_users = self.user_repo.get_all_users(requested_by=requested_by)
+            async for user_entity in all_users:
+                await self.search_updates_repo.insert(user_entity, started)
+                counter += 1
+                log_counter(counter)
+
+            all_groups = self.group_repo.get_all_groups(requested_by=requested_by)
+            async for group_entity in all_groups:
+                await self.search_updates_repo.insert(group_entity, started)
+                counter += 1
+                log_counter(counter)
+
+            all_projects = self.project_repo.get_all_projects(requested_by=requested_by)
+            async for project_entity in all_projects:
+                await self.search_updates_repo.insert(project_entity, started)
+                counter += 1
+                log_counter(counter)
+
+            logger.info(f"Inserted {counter} entities into the staging table.")
+
+        except Exception as e:
+            logger.error("Error while reprovisioning entities!", exc_info=e)
+            ## TODO error handling. skip or fail?
+        finally:
+            await self.reprovisioning_repo.stop()

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,22 @@
           poetry run ruff check --fix
           poetry run ruff format
         '')
+        (
+          writeShellScriptBin "poetry-setup" ''
+            venv_path="$(poetry env info -p)"
+            if [ "$1" == "-c" ]; then
+               echo "Removing virtual env at $venv_path"
+               rm -rf "$venv_path"/*
+            fi
+            poetry install
+            if ! poetry self show --addons | grep poetry-multiproject-plugin > /dev/null; then
+                poetry self add poetry-multiproject-plugin
+            fi
+            if ! poetry self show --addons | grep poetry-polylith-plugin > /dev/null; then
+                poetry self add poetry-polylith-plugin
+            fi
+          ''
+        )
       ];
     in {
       formatter = pkgs.alejandra;


### PR DESCRIPTION
If a solr migration requires a reindex, a background task is started on startup that reprovisions the search index.


/deploy