### PR TITLE
fix: Updating search documents without optimistic concurrency control

### DIFF
--- a/components/renku_data_services/search/core.py
+++ b/components/renku_data_services/search/core.py
@@ -26,7 +26,6 @@ from renku_data_services.solr.entity_documents import EntityDocReader, Group, Pr
 from renku_data_services.solr.entity_schema import Fields
 from renku_data_services.solr.solr_client import (
     DefaultSolrClient,
-    DocVersions,
     FacetTerms,
     RawDocument,
     SolrClient,
@@ -47,7 +46,7 @@ async def update_solr(search_updates_repo: SearchUpdatesRepo, solr_client: SolrC
 
         ids = [e.id for e in entries]
         try:
-            docs: list[SolrDocument] = [RawDocument.create(e.payload, DocVersions.off()) for e in entries]
+            docs: list[SolrDocument] = [RawDocument(e.payload) for e in entries]
             result = await solr_client.upsert(docs)
             if result == "VersionConflict":
                 await search_updates_repo.mark_reset(ids)

--- a/components/renku_data_services/search/db.py
+++ b/components/renku_data_services/search/db.py
@@ -18,6 +18,7 @@ from renku_data_services.search.orm import RecordState, SearchUpdatesORM
 from renku_data_services.solr.entity_documents import Group as GroupDoc
 from renku_data_services.solr.entity_documents import Project as ProjectDoc
 from renku_data_services.solr.entity_documents import User as UserDoc
+from renku_data_services.solr.solr_client import DocVersions
 from renku_data_services.users.models import UserInfo
 
 
@@ -27,11 +28,18 @@ def _user_to_entity_doc(user: UserInfo) -> UserDoc:
         id=user.id,
         firstName=user.first_name,
         lastName=user.last_name,
+        version=DocVersions.off(),
     )
 
 
 def _group_to_entity_doc(group: Group) -> GroupDoc:
-    return GroupDoc(namespace=Slug.from_name(group.slug), id=group.id, name=group.name, description=group.description)
+    return GroupDoc(
+        namespace=Slug.from_name(group.slug),
+        id=group.id,
+        name=group.name,
+        description=group.description,
+        version=DocVersions.off(),
+    )
 
 
 def _project_to_entity_doc(p: Project) -> ProjectDoc:
@@ -46,6 +54,7 @@ def _project_to_entity_doc(p: Project) -> ProjectDoc:
         repositories=p.repositories,
         description=p.description,
         keywords=p.keywords if p.keywords is not None else [],
+        version=DocVersions.off(),
     )
 
 

--- a/components/renku_data_services/solr/solr_client.py
+++ b/components/renku_data_services/solr/solr_client.py
@@ -481,6 +481,10 @@ class RawDocument(SolrDocument):
 
     data: dict[str, Any]
 
+    def set_version(self, v: DocVersion) -> None:
+        """Set the given document version."""
+        self.data.update(_version_=v)
+
     @property
     def id(self) -> str:
         """Return the document id."""
@@ -489,6 +493,13 @@ class RawDocument(SolrDocument):
     def to_dict(self) -> dict[str, Any]:
         """Return the data dictionary."""
         return self.data
+
+    @classmethod
+    def create(cls, payload: dict[str, Any], version: DocVersion) -> RawDocument:
+        """Create new RawDocument with the given version."""
+        d = RawDocument(payload)
+        d.set_version(version)
+        return d
 
 
 class ResponseBody(BaseModel):

--- a/components/renku_data_services/solr/solr_client.py
+++ b/components/renku_data_services/solr/solr_client.py
@@ -481,10 +481,6 @@ class RawDocument(SolrDocument):
 
     data: dict[str, Any]
 
-    def set_version(self, v: DocVersion) -> None:
-        """Set the given document version."""
-        self.data.update(_version_=v)
-
     @property
     def id(self) -> str:
         """Return the document id."""
@@ -493,13 +489,6 @@ class RawDocument(SolrDocument):
     def to_dict(self) -> dict[str, Any]:
         """Return the data dictionary."""
         return self.data
-
-    @classmethod
-    def create(cls, payload: dict[str, Any], version: DocVersion) -> RawDocument:
-        """Create new RawDocument with the given version."""
-        d = RawDocument(payload)
-        d.set_version(version)
-        return d
 
 
 class ResponseBody(BaseModel):

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,9 @@
           DB_NAME = "renku";
           DB_PASSWORD = "dev";
           PGPASSWORD = "dev";
+          PSQLRC = (pkgs.writeText "rsdrc.sql" ''
+            SET SEARCH_PATH TO authz,common,connected_services,events,platform,projects,public,resource_pools,secrets,sessions,storage,users
+          '');
           AUTHZ_DB_KEY = "dev";
           AUTHZ_DB_NO_TLS_CONNECTION = "true";
           AUTHZ_DB_GRPC_PORT = "50051";
@@ -111,6 +114,10 @@
         python313
         basedpyright
         rclone
+        (writeShellScriptBin "pg" ''
+          psql -h $DB_HOST -U dev renku
+        ''
+        )
         (writeShellScriptBin "pyfix" ''
           poetry run ruff check --fix
           poetry run ruff format


### PR DESCRIPTION
Fixes updates of search entries to always overwrite existing documents.

/deploy