### PR TITLE
fix: apply memory limits when patching

### DIFF
--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -359,7 +359,7 @@ def resources_from_resource_class(resource_class: ResourceClass) -> Resources:
         "cpu": str(round(resource_class.cpu * 1000)) + "m",
         "memory": f"{resource_class.memory}Gi",
     }
-    limits: dict[str, str | int] = {}
+    limits: dict[str, str | int] = {"memory": f"{resource_class.memory}Gi"}
     if resource_class.gpu > 0:
         gpu_name = GpuKind.NVIDIA.value + "/gpu"
         requests[gpu_name] = resource_class.gpu


### PR DESCRIPTION
This adresses an issue reported by a user on discourse. Since we were updating the limits only on start - but not when patching, the session can fail to resume if you switch the resource class with one with a larger memory. This is because the patching was not updating the memory limit and the request would be > the limit after patching.

/deploy