### PR TITLE
fix: improve efficiency of the K8s Entity Cache

### DIFF
--- a/components/renku_data_services/k8s/clients.py
+++ b/components/renku_data_services/k8s/clients.py
@@ -318,17 +318,17 @@ class CachedK8sClient(K8sClient):
     def __init__(self, clusters: dict[ClusterId, Cluster], cache: K8sDbCache, kinds_to_cache: list[str]) -> None:
         super().__init__(clusters)
         self.cache = cache
-        self.__kinds_to_cache = [k.lower() for k in kinds_to_cache]
+        self.__kinds_to_cache = set(k.lower() for k in kinds_to_cache)
 
     async def create(self, obj: K8sObject) -> K8sObject:
         """Create the k8s object."""
-        if obj.meta.kind.lower() in self.__kinds_to_cache:
+        if obj.meta.singular in self.__kinds_to_cache:
             await self.cache.upsert(obj)
         try:
             obj = await super().create(obj)
         except:
             # if there was an error creating the k8s object, we delete it from the db again to not have ghost entries
-            if obj.meta.kind.lower() in self.__kinds_to_cache:
+            if obj.meta.singular in self.__kinds_to_cache:
                 await self.cache.delete(obj)
             raise
         return obj
@@ -336,19 +336,19 @@ class CachedK8sClient(K8sClient):
     async def patch(self, meta: K8sObjectMeta, patch: dict[str, Any] | list[dict[str, Any]]) -> K8sObject:
         """Patch a k8s object."""
         obj = await super().patch(meta, patch)
-        if meta.kind.lower() in self.__kinds_to_cache:
+        if meta.singular in self.__kinds_to_cache:
             await self.cache.upsert(obj)
         return obj
 
     async def delete(self, meta: K8sObjectMeta) -> None:
         """Delete a k8s object."""
         await super().delete(meta)
-        if meta.kind.lower() in self.__kinds_to_cache:
+        if meta.singular in self.__kinds_to_cache:
             await self.cache.delete(meta)
 
     async def get(self, meta: K8sObjectMeta) -> K8sObject | None:
         """Get a specific k8s object, None is returned if the object does not exist."""
-        if meta.kind.lower() in self.__kinds_to_cache:
+        if meta.singular in self.__kinds_to_cache:
             res = await self.cache.get(meta)
         else:
             res = await super().get(meta)

--- a/components/renku_data_services/k8s/models.py
+++ b/components/renku_data_services/k8s/models.py
@@ -203,7 +203,7 @@ class APIObjectInCluster:
 
 def user_id_from_api_object(obj: APIObject) -> str | None:
     """Get the user id from an api object."""
-    match obj.kind.lower():
+    match obj.singular:
         case "jupyterserver":
             return cast(str, obj.metadata.labels["renku.io/userId"])
         case "amaltheasession":

--- a/components/renku_data_services/k8s_watcher/db.py
+++ b/components/renku_data_services/k8s_watcher/db.py
@@ -27,7 +27,7 @@ class K8sDbCache:
             .where(K8sObjectORM.name == meta.name)
             .where(K8sObjectORM.namespace == meta.namespace)
             .where(K8sObjectORM.cluster == meta.cluster)
-            .where(K8sObjectORM.kind == meta.kind.lower())
+            .where(K8sObjectORM.kind == meta.singular)
             .where(K8sObjectORM.version == meta.version)
         )
         if meta.user_id is not None:
@@ -52,7 +52,7 @@ class K8sDbCache:
             obj_orm = K8sObjectORM(
                 name=obj.name,
                 namespace=obj.namespace or "default",
-                kind=obj.kind.lower(),
+                kind=obj.singular,
                 version=obj.version,
                 manifest=obj.manifest.to_dict(),
                 cluster=obj.cluster,


### PR DESCRIPTION
Avoid one or more call to `lower()` on each K8s API call.

We cannot rely on just using `kind`, as the K8s API sometimes returns it in lower case and sometimes requires the exact case to be used.

Instead, we use `singular` which is set and initiaized as `kind` in lower case, thus calling `lower()` only on instantation of objects.

Also switch from a list of kinds to cache to a set.