### PR TITLE
fix: get updated k8s state when creating objects in k8s cache

### DIFF
--- a/components/renku_data_services/k8s/clients.py
+++ b/components/renku_data_services/k8s/clients.py
@@ -265,6 +265,7 @@ class K8sClusterClient:
         """Create the k8s object."""
 
         api_obj = obj.to_api_object(self.__cluster.api)
+
         await api_obj.create()
         # if refresh isn't called, status and timestamp will be blank
         await api_obj.refresh()

--- a/components/renku_data_services/k8s/clients.py
+++ b/components/renku_data_services/k8s/clients.py
@@ -265,7 +265,6 @@ class K8sClusterClient:
         """Create the k8s object."""
 
         api_obj = obj.to_api_object(self.__cluster.api)
-
         await api_obj.create()
         # if refresh isn't called, status and timestamp will be blank
         await api_obj.refresh()


### PR DESCRIPTION
related to #792 

we had this [in the old code](https://github.com/SwissDataScienceCenter/renku-data-services/blob/0caedf776c7a69fcd61e230775b69455e59a5976/components/renku_data_services/notebooks/api/classes/k8s_client.py#L127-L135) but it was missed when implementing the new cache