### PR TITLE
feat: update to rclone v1.69.2+renku-1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,7 @@
 		"ghcr.io/devcontainers/features/go:1": {},
 		"./rclone": {
 			"rclone_repository": "https://github.com/SwissDataScienceCenter/rclone.git",
-			"rclone_ref": "v1.69.1+renku-1"
+			"rclone_ref": "v1.69.2+renku-1"
 		}
 	},
 	"overrideFeatureInstallOrder": [

--- a/flake.nix
+++ b/flake.nix
@@ -61,11 +61,11 @@
       devshellToolsPkgs = devshell-tools.packages.${system};
 
       rclone = pkgs.rclone.overrideAttrs (old: {
-        version = "v1.69.1";
+        version = "v1.69.2";
         src = pkgs.fetchFromGitHub {
           owner = "SwissDataScienceCenter";
           repo = "rclone";
-          rev = "v1.69.1+renku-1";
+          rev = "v1.69.2+renku-1";
           sha256 = "sha256-AaQnLRAyBSHZFXmpOnPl1Af04YesR+HZd/BVw4zNW+E=";
         };
       });

--- a/projects/renku_data_service/Dockerfile
+++ b/projects/renku_data_service/Dockerfile
@@ -1,5 +1,5 @@
 ARG RCLONE_IMAGE_REPOSITORY="ghcr.io/swissdatasciencecenter/rclone"
-ARG RCLONE_IMAGE_TAG="sha-7975d7a"
+ARG RCLONE_IMAGE_TAG="sha-1f5fcf2"
 FROM ${RCLONE_IMAGE_REPOSITORY}:${RCLONE_IMAGE_TAG} AS rclone
 
 FROM python:3.13-bookworm AS builder


### PR DESCRIPTION
Related PR: https://github.com/SwissDataScienceCenter/csi-rclone/pull/58

/deploy extra-values=global.csi-rclone.install=true,notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-doi-zenodo,csi-rclone.storageClassName=csi-rclone-doi-zenodo,global.rcloneStorageClass=csi-rclone-doi-zenodo,amalthea-sessions.rcloneStorageClass=csi-rclone-doi-zenodo-secret-annotation,csi-rclone.csiNodepluginRclone.tolerations[0].key=renku.io/dedicated,csi-rclone.csiNodepluginRclone.tolerations[0].operator=Equal,csi-rclone.csiNodepluginRclone.tolerations[0].value=user,csi-rclone.csiNodepluginRclone.tolerations[0].effect=NoSchedule,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=renku.io/node-purpose,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In,csi-rclone.csiNodepluginRclone.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=user,csi-rclone.csiControllerRclone.rclone.image.repository=ghcr.io/swissdatasciencecenter/csi-rclone,csi-rclone.csiControllerRclone.rclone.image.tag=sha-5996bec,csi-rclone.csiNodepluginRclone.rclone.image.repository=ghcr.io/swissdatasciencecenter/csi-rclone,csi-rclone.csiNodepluginRclone.rclone.image.tag=sha-5996bec