### PR TITLE
Automatically log request_id obtained from sanic

### DIFF
--- a/bases/renku_data_services/data_api/config.py
+++ b/bases/renku_data_services/data_api/config.py
@@ -6,6 +6,7 @@ from typing import Self
 
 from renku_data_services import errors
 from renku_data_services.app_config.config import KeycloakConfig, PosthogConfig, SentryConfig, TrustedProxiesConfig
+from renku_data_services.app_config.logging import Config as LoggingConfig
 from renku_data_services.authz.config import AuthzConfig
 from renku_data_services.db_config.config import DBConfig
 from renku_data_services.message_queue.config import RedisConfig
@@ -37,6 +38,7 @@ class Config:
     user_preferences: UserPreferencesConfig
     server_options: ServerOptionsConfig
     gitlab_url: str | None
+    log_cfg: LoggingConfig
     version: str = "0.0.1"
 
     @classmethod
@@ -56,6 +58,7 @@ class Config:
         user_preferences_config = UserPreferencesConfig.from_env()
         nb_config = NotebooksConfig.from_env(db)
         server_options = ServerOptionsConfig.from_env()
+        log_cfg = LoggingConfig.from_env()
         if dummy_stores:
             redis = RedisConfig.fake()
             keycloak = None
@@ -86,4 +89,5 @@ class Config:
             user_preferences=user_preferences_config,
             server_options=server_options,
             gitlab_url=gitlab_url,
+            log_cfg=log_cfg,
         )

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -175,15 +175,13 @@ def create_app() -> Sanic:
             logger.info("Starting solr reindex, as required by migrations.")
             app.manager.manage("SolrReindex", solr_reindex, {"app_name": app.name}, transient=True)
 
-    log_cfg = logging.Config.from_env()
-
     @app.before_server_start
     async def logging_setup1(app: Sanic) -> None:
-        logging.configure_logging(log_cfg)
+        logging.configure_logging(dependency_manager.config.log_cfg)
 
     @app.main_process_ready
     async def logging_setup2(app: Sanic) -> None:
-        logging.configure_logging(log_cfg)
+        logging.configure_logging(dependency_manager.config.log_cfg)
 
     return app
 

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -15,7 +15,7 @@ from sentry_sdk.integrations.grpc import GRPCIntegration
 from sentry_sdk.integrations.sanic import SanicIntegration, _context_enter, _context_exit, _set_transaction
 
 import renku_data_services.solr.entity_schema as entity_schema
-from renku_data_services.app_config.logging import configure_logging, getLogger
+from renku_data_services.app_config import logging
 from renku_data_services.authz.admin_sync import sync_admins_from_keycloak
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.data_api.app import register_all_handlers
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     import sentry_sdk._types
 
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 async def _solr_reindex(app: Sanic) -> None:
@@ -131,6 +131,14 @@ def create_app() -> Sanic:
 
     app.register_middleware(validate_null_byte, "request")
 
+    @app.on_request
+    async def set_request_id(request: Request) -> None:
+        logging.set_request_id(str(request.id))
+
+    @app.middleware("response")
+    async def set_request_id_header(request: Request, response: BaseHTTPResponse) -> None:
+        response.headers["X-Request-ID"] = request.id
+
     @app.middleware("response")
     async def handle_head(request: Request, response: BaseHTTPResponse) -> None:
         """Make sure HEAD requests return an empty body."""
@@ -167,13 +175,15 @@ def create_app() -> Sanic:
             logger.info("Starting solr reindex, as required by migrations.")
             app.manager.manage("SolrReindex", solr_reindex, {"app_name": app.name}, transient=True)
 
+    log_cfg = logging.Config.from_env()
+
     @app.before_server_start
     async def logging_setup1(app: Sanic) -> None:
-        configure_logging()
+        logging.configure_logging(log_cfg)
 
     @app.main_process_ready
     async def logging_setup2(app: Sanic) -> None:
-        configure_logging()
+        logging.configure_logging(log_cfg)
 
     return app
 

--- a/bases/renku_data_services/secrets_storage_api/config.py
+++ b/bases/renku_data_services/secrets_storage_api/config.py
@@ -8,6 +8,7 @@ from typing import Any, Self
 from yaml import safe_load
 
 import renku_data_services.secrets
+from renku_data_services.app_config import logging
 from renku_data_services.app_config.config import KeycloakConfig
 from renku_data_services.db_config.config import DBConfig
 from renku_data_services.secrets.config import PrivateSecretsConfig
@@ -24,6 +25,7 @@ class Config:
     version: str = "0.0.1"
     dummy_stores: bool = False
     spec: dict[str, Any] = field(init=False, default_factory=dict)
+    log_cfg: logging.Config = field(default_factory=logging.Config.from_env)
 
     def __post_init__(self) -> None:
         spec_file = Path(renku_data_services.secrets.__file__).resolve().parent / "api.spec.yaml"
@@ -40,5 +42,13 @@ class Config:
         keycloak = None
         if not dummy_stores:
             keycloak = KeycloakConfig.from_env()
+        log_cfg = logging.Config.from_env()
 
-        return cls(db=db, secrets=secrets_config, version=version, keycloak=keycloak, dummy_stores=dummy_stores)
+        return cls(
+            db=db,
+            secrets=secrets_config,
+            version=version,
+            keycloak=keycloak,
+            dummy_stores=dummy_stores,
+            log_cfg=log_cfg,
+        )

--- a/bases/renku_data_services/secrets_storage_api/main.py
+++ b/bases/renku_data_services/secrets_storage_api/main.py
@@ -6,7 +6,8 @@ from os import environ
 from typing import Any
 
 from prometheus_sanic import monitor
-from sanic import Sanic
+from sanic import Request, Sanic
+from sanic.response import BaseHTTPResponse
 from sanic.worker.loader import AppLoader
 
 from renku_data_services.app_config import logging
@@ -23,6 +24,14 @@ def create_app() -> Sanic:
     if "COVERAGE_RUN" in environ:
         app.config.TOUCHUP = False
     app = register_all_handlers(app, dm)
+
+    @app.on_request
+    async def set_request_id(request: Request) -> None:
+        logging.set_request_id(str(request.id))
+
+    @app.middleware("response")
+    async def set_request_id_header(request: Request, response: BaseHTTPResponse) -> None:
+        response.headers["X-Request-ID"] = request.id
 
     @app.main_process_start
     def main_process_start(app: Sanic) -> None:

--- a/bases/renku_data_services/secrets_storage_api/main.py
+++ b/bases/renku_data_services/secrets_storage_api/main.py
@@ -36,11 +36,11 @@ def create_app() -> Sanic:
     @app.main_process_start
     def main_process_start(app: Sanic) -> None:
         app.shared_ctx.rotation_lock = Lock()
-        logging.configure_logging()
+        logging.configure_logging(dm.config.log_cfg)
 
     @app.before_server_start
     async def logging_setup1(app: Sanic) -> None:
-        logging.configure_logging()
+        logging.configure_logging(dm.config.log_cfg)
 
     # Setup prometheus
     monitor(app, endpoint_type="url", multiprocess_mode="all", is_middleware=True).expose_endpoint()


### PR DESCRIPTION
Removes the `LoggerAdapter` that could be used to wrap existing loggers and instead uses a `ContextVar` to track the request_id in a context sensitiv way. It is set from within a sanic on_request handler and retrieved right before the log record is emitted.

/deploy