### PR TITLE
fix: Skip authz if admin is requesting data connectors

### DIFF
--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -17,7 +17,6 @@ from sentry_sdk.integrations.sanic import SanicIntegration, _context_enter, _con
 import renku_data_services.solr.entity_schema as entity_schema
 from renku_data_services.app_config import logging
 from renku_data_services.authz.admin_sync import sync_admins_from_keycloak
-from renku_data_services.base_models.core import APIUser
 from renku_data_services.data_api.app import register_all_handlers
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.data_api.prometheus import setup_app_metrics, setup_prometheus
@@ -46,8 +45,7 @@ async def _solr_reindex(app: Sanic) -> None:
     """
     config = DependencyManager.from_env()
     reprovision = config.search_reprovisioning
-    admin = APIUser(is_admin=True)
-    await reprovision.run_reprovision(admin)
+    await reprovision.run_reprovision()
 
 
 def solr_reindex(app_name: str) -> None:

--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -17,6 +17,7 @@ from sentry_sdk.integrations.sanic import SanicIntegration, _context_enter, _con
 import renku_data_services.solr.entity_schema as entity_schema
 from renku_data_services.app_config import logging
 from renku_data_services.authz.admin_sync import sync_admins_from_keycloak
+from renku_data_services.base_models.core import InternalServiceAdmin, ServiceAdminId
 from renku_data_services.data_api.app import register_all_handlers
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.data_api.prometheus import setup_app_metrics, setup_prometheus
@@ -45,7 +46,8 @@ async def _solr_reindex(app: Sanic) -> None:
     """
     config = DependencyManager.from_env()
     reprovision = config.search_reprovisioning
-    await reprovision.run_reprovision()
+    admin = InternalServiceAdmin(id=ServiceAdminId.search_reprovision)
+    await reprovision.run_reprovision(admin)
 
 
 def solr_reindex(app_name: str) -> None:

--- a/components/renku_data_services/base_models/core.py
+++ b/components/renku_data_services/base_models/core.py
@@ -78,6 +78,7 @@ class ServiceAdminId(StrEnum):
     migrations = "migrations"
     secrets_rotation = "secrets_rotation"
     k8s_watcher = "k8s_watcher"
+    search_reprovision = "search_reprovision"
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/components/renku_data_services/data_connectors/db.py
+++ b/components/renku_data_services/data_connectors/db.py
@@ -20,6 +20,7 @@ from renku_data_services.base_models.core import (
     DataConnectorInProjectPath,
     DataConnectorPath,
     DataConnectorSlug,
+    InternalServiceAdmin,
     NamespacePath,
     NamespaceSlug,
     ProjectPath,
@@ -70,7 +71,7 @@ class DataConnectorRepository:
         """Get multiple data connectors from the database."""
 
         async def restrict_by_read(stmt: Select) -> Select:
-            if user.is_admin:
+            if isinstance(user, InternalServiceAdmin):
                 return stmt
             else:
                 dc_ids = await self.authz.resources_with_permission(

--- a/components/renku_data_services/search/blueprints.py
+++ b/components/renku_data_services/search/blueprints.py
@@ -40,7 +40,7 @@ class SearchBP(CustomBlueprint):
             reprovisioning = await self.search_reprovision.acquire_reprovision()
 
             request.app.add_task(
-                self.search_reprovision.init_reprovision(reprovisioning=reprovisioning),
+                self.search_reprovision.init_reprovision(user, reprovisioning=reprovisioning),
                 name=f"reprovisioning-{reprovisioning.id}",
             )
 

--- a/components/renku_data_services/search/blueprints.py
+++ b/components/renku_data_services/search/blueprints.py
@@ -40,7 +40,7 @@ class SearchBP(CustomBlueprint):
             reprovisioning = await self.search_reprovision.acquire_reprovision()
 
             request.app.add_task(
-                self.search_reprovision.init_reprovision(requested_by=user, reprovisioning=reprovisioning),
+                self.search_reprovision.init_reprovision(reprovisioning=reprovisioning),
                 name=f"reprovisioning-{reprovisioning.id}",
             )
 

--- a/components/renku_data_services/search/reprovision.py
+++ b/components/renku_data_services/search/reprovision.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from renku_data_services.app_config import logging
 from renku_data_services.base_api.pagination import PaginationRequest
-from renku_data_services.base_models.core import APIUser
+from renku_data_services.base_models.core import APIUser, InternalServiceAdmin, ServiceAdminId
 from renku_data_services.data_connectors.db import DataConnectorRepository
 from renku_data_services.data_connectors.models import DataConnector, GlobalDataConnector
 from renku_data_services.message_queue.db import ReprovisioningRepository
@@ -43,10 +43,10 @@ class SearchReprovision:
         self._project_repo = project_repo
         self._data_connector_repo = data_connector_repo
 
-    async def run_reprovision(self, requested_by: APIUser) -> int:
+    async def run_reprovision(self) -> int:
         """Start a reprovisioning if not already running."""
         reprovision = await self.acquire_reprovision()
-        return await self.init_reprovision(requested_by, reprovision)
+        return await self.init_reprovision(reprovision)
 
     async def acquire_reprovision(self) -> Reprovisioning:
         """Acquire a reprovisioning slot. Throws if already taken."""
@@ -74,7 +74,7 @@ class SearchReprovision:
             for dc in result[0]:
                 yield dc
 
-    async def init_reprovision(self, requested_by: APIUser, reprovisioning: Reprovisioning) -> int:
+    async def init_reprovision(self, reprovisioning: Reprovisioning) -> int:
         """Initiates reprovisioning by inserting documents into the staging table.
 
         Deletes all renku entities in the solr core. Then it goes
@@ -89,6 +89,7 @@ class SearchReprovision:
                 logger.info(f"Inserted {c}. entities into staging table...")
 
         counter = 0
+        admin = InternalServiceAdmin(id=ServiceAdminId.search_reprovision)
         try:
             logger.info(f"Starting reprovisioning with ID {reprovisioning.id}")
             started = datetime.now()
@@ -96,19 +97,19 @@ class SearchReprovision:
             async with DefaultSolrClient(self._solr_config) as client:
                 await client.delete("_type:*")
 
-            all_users = self._user_repo.get_all_users(requested_by=requested_by)
+            all_users = self._user_repo.get_all_users(requested_by=admin)
             counter = await self.__update_entities(all_users, "user", started, counter, log_counter)
             logger.info(f"Done adding user entities to search_updates table. Record count: {counter}.")
 
-            all_groups = self._group_repo.get_all_groups(requested_by=requested_by)
+            all_groups = self._group_repo.get_all_groups(requested_by=admin)
             counter = await self.__update_entities(all_groups, "group", started, counter, log_counter)
             logger.info(f"Done adding group entities to search_updates table. Record count: {counter}")
 
-            all_projects = self._project_repo.get_all_projects(requested_by=requested_by)
+            all_projects = self._project_repo.get_all_projects(requested_by=admin)
             counter = await self.__update_entities(all_projects, "project", started, counter, log_counter)
             logger.info(f"Done adding project entities to search_updates table. Record count: {counter}")
 
-            all_dcs = self._get_all_data_connectors(requested_by, per_page=20)
+            all_dcs = self._get_all_data_connectors(admin, per_page=20)
             counter = await self.__update_entities(all_dcs, "data connector", started, counter, log_counter)
             logger.info(f"Done adding dataconnector entities to search_updates table. Record count: {counter}")
 

--- a/components/renku_data_services/search/reprovision.py
+++ b/components/renku_data_services/search/reprovision.py
@@ -98,18 +98,19 @@ class SearchReprovision:
 
             all_users = self._user_repo.get_all_users(requested_by=requested_by)
             counter = await self.__update_entities(all_users, "user", started, counter, log_counter)
-            logger.info("Done adding user entities to search_updates table.")
+            logger.info(f"Done adding user entities to search_updates table. Record count: {counter}.")
 
             all_groups = self._group_repo.get_all_groups(requested_by=requested_by)
             counter = await self.__update_entities(all_groups, "group", started, counter, log_counter)
-            logger.info("Done adding group entities to search_updates table.")
+            logger.info(f"Done adding group entities to search_updates table. Record count: {counter}")
 
             all_projects = self._project_repo.get_all_projects(requested_by=requested_by)
             counter = await self.__update_entities(all_projects, "project", started, counter, log_counter)
-            logger.info("Done adding project entities to search_updates table.")
+            logger.info(f"Done adding project entities to search_updates table. Record count: {counter}")
 
             all_dcs = self._get_all_data_connectors(requested_by, per_page=20)
             counter = await self.__update_entities(all_dcs, "data connector", started, counter, log_counter)
+            logger.info(f"Done adding dataconnector entities to search_updates table. Record count: {counter}")
 
             logger.info(f"Inserted {counter} entities into the staging table.")
         except Exception as e:

--- a/components/renku_data_services/search/reprovision.py
+++ b/components/renku_data_services/search/reprovision.py
@@ -86,7 +86,7 @@ class SearchReprovision:
         """
 
         if not admin.is_admin:
-            raise ForbiddenError()
+            raise ForbiddenError(message="Only Renku administrators are allowed to start search reprovisioning.")
 
         def log_counter(c: int) -> None:
             if c % 50 == 0:

--- a/components/renku_data_services/solr/solr_client.py
+++ b/components/renku_data_services/solr/solr_client.py
@@ -655,6 +655,7 @@ class DefaultSolrClient(SolrClient):
     async def query_raw(self, query: SolrQuery) -> Response:
         """Query documents and return the http response."""
         try:
+            logger.debug(f"Running solr query: {self.config.base_url}/solr/{self.config.core}")
             return await self.delegate.post("/query", params={"wt": "json"}, json=query.to_dict())
         except ConnectError as e:
             raise SolrClientConnectException(e) from e

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -15,7 +15,7 @@ import renku_data_services.search.core as search_core
 from renku_data_services.authz.admin_sync import sync_admins_from_keycloak
 from renku_data_services.authz.authz import _AuthzConverter
 from renku_data_services.base_models import Slug
-from renku_data_services.base_models.core import NamespacePath
+from renku_data_services.base_models.core import InternalServiceAdmin, NamespacePath, ServiceAdminId
 from renku_data_services.data_api.app import register_all_handlers
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
@@ -261,8 +261,10 @@ async def sanic_client_with_solr(sanic_client: SanicASGITestClient, app_manager)
 
 @pytest_asyncio.fixture
 async def search_reprovision(app_manager_instance: DependencyManager, search_push_updates):
+    admin = InternalServiceAdmin(id=ServiceAdminId.search_reprovision)
+
     async def search_reprovision_helper() -> None:
-        await app_manager_instance.search_reprovisioning.run_reprovision()
+        await app_manager_instance.search_reprovisioning.run_reprovision(admin)
         await search_push_updates(clear_index=False)
 
     return search_reprovision_helper

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -15,7 +15,7 @@ import renku_data_services.search.core as search_core
 from renku_data_services.authz.admin_sync import sync_admins_from_keycloak
 from renku_data_services.authz.authz import _AuthzConverter
 from renku_data_services.base_models import Slug
-from renku_data_services.base_models.core import APIUser, NamespacePath
+from renku_data_services.base_models.core import NamespacePath
 from renku_data_services.data_api.app import register_all_handlers
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
@@ -262,8 +262,7 @@ async def sanic_client_with_solr(sanic_client: SanicASGITestClient, app_manager)
 @pytest_asyncio.fixture
 async def search_reprovision(app_manager_instance: DependencyManager, search_push_updates):
     async def search_reprovision_helper() -> None:
-        user = APIUser(is_admin=True)
-        await app_manager_instance.search_reprovisioning.run_reprovision(user)
+        await app_manager_instance.search_reprovisioning.run_reprovision()
         await search_push_updates(clear_index=False)
 
     return search_reprovision_helper

--- a/test/components/renku_data_services/search/test_reprovision.py
+++ b/test/components/renku_data_services/search/test_reprovision.py
@@ -161,14 +161,14 @@ async def test_get_data_connectors(app_manager_instance) -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_reprovision(app_manager_instance, solr_search) -> None:
+async def test_run_reprovision(app_manager_instance, solr_search, admin_user) -> None:
     setup = make_setup(app_manager_instance, solr_search)
     dcs = await make_data_connectors(setup, 5)
     groups = await make_groups(setup, 4)
     projects = await make_projects(setup, 3)
     users = [item async for item in setup.user_repo.get_all_users(admin)]
 
-    count = await setup.search_reprovision.run_reprovision()
+    count = await setup.search_reprovision.run_reprovision(admin_user)
 
     next = await setup.search_update_repo.select_next(20)
 

--- a/test/components/renku_data_services/search/test_reprovision.py
+++ b/test/components/renku_data_services/search/test_reprovision.py
@@ -168,7 +168,7 @@ async def test_run_reprovision(app_manager_instance, solr_search) -> None:
     projects = await make_projects(setup, 3)
     users = [item async for item in setup.user_repo.get_all_users(admin)]
 
-    count = await setup.search_reprovision.run_reprovision(admin)
+    count = await setup.search_reprovision.run_reprovision()
 
     next = await setup.search_update_repo.select_next(20)
 


### PR DESCRIPTION
For reprovisioning it is necessary to get all entities. When selecting data connectors from the db, there was always a call to authz to first get all identifiers of resources the requesting user has read access to. For internal service admins, this doesn't work, because they are not modelled in authz. For admins in general the call should be prevented, because admins can see everything. 

This change skips the authz call if the requesting user is an admin. Additionally the search reprovisioning code uses an internal service admin for doing its work and not the user passed through from the endpoint call. 

/deploy