### PR TITLE
fix: refactor get_all_project_copies for performance reasons

### DIFF
--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -11,7 +11,7 @@ from pathlib import PurePosixPath
 from typing import Concatenate, ParamSpec, TypeVar
 
 from cryptography.hazmat.primitives.asymmetric import rsa
-from sqlalchemy import Select, delete, func, or_, select, update
+from sqlalchemy import ColumnElement, Select, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import undefer
 from sqlalchemy.sql.functions import coalesce
@@ -140,7 +140,7 @@ class ProjectRepository:
             scope = Scope.WRITE if only_writable else Scope.NON_PUBLIC_READ
             project_ids = await self.authz.resources_with_permission(user, user.id, ResourceType.project, scope=scope)
 
-            cond = schemas.ProjectORM.id.in_(project_ids)
+            cond: ColumnElement[bool] = schemas.ProjectORM.id.in_(project_ids)
             if scope == Scope.NON_PUBLIC_READ:
                 cond = or_(cond, schemas.ProjectORM.visibility == Visibility.PUBLIC.value)
 

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -8,11 +8,10 @@ import string
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
-import time
 from typing import Concatenate, ParamSpec, TypeVar
 
 from cryptography.hazmat.primitives.asymmetric import rsa
-from sqlalchemy import Select, delete, func, select, update, or_
+from sqlalchemy import Select, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import undefer
 from sqlalchemy.sql.functions import coalesce


### PR DESCRIPTION
The implementation has several issues that make it very slow:

- It doesn't implement any paging, so we are potentially transporting
  a lot of data. This is not fixed in this PR.

- At very first, it retrieves *all* copied projects for a given
  template_id and then filters it in memory to retain only the
  accessible ones of the current user.

  This is done by next retrieving all project ids the user has access
  to, including all public ones. This is potentially returning a lot
  of data.

  The filtering then continues to loop through the database objects
  and checks each id for membership in the `project_ids` list. A
  python list has O(n) time for membership tests, so depending on the
  number of results this gets slow quite quickly.

Measuring this call shows that by far the longest time is spent
filtering:
```python
[p for p in project_orms if p.id in project_ids]
```
It can quickly get to multi-seconds response time, if the data is a
bit larger.

The improvements involve the following:

- Exchange order of retrieval: first get all accessible project ids,
  except those for public projects. This can reduce the resulting set of
  ids to check against as it doesn't contain public entities.

- With these ids, the SQL query is constructed to only return projects
  whose ids are in this set. If the scope is read, then the condition
  includes all public ones and the ones the user has more specific
  access to.

In my measurements on my machine with a generated data set of 2000
project copies, these changes resulted in 10x faster response times.

----
/deploy