### PR TITLE
fix: set default cluster name back to renkulab

### DIFF
--- a/components/renku_data_services/k8s/constants.py
+++ b/components/renku_data_services/k8s/constants.py
@@ -7,7 +7,7 @@ from typing import Final, NewType
 # LSA Not enough time: Adapt this to be an alias to ULID
 ClusterId = NewType("ClusterId", str)
 
-DEFAULT_K8S_CLUSTER: Final[ClusterId] = ClusterId("0RENK1RENK2RENK3RENK4RENK5")  # This has to be a valid ULID
+DEFAULT_K8S_CLUSTER: Final[ClusterId] = ClusterId("renkulab")
 
 DUMMY_TASK_RUN_USER_ID: Final[str] = "DummyTaskRunUser"
 """The user id to use for TaskRuns in the k8s cache.


### PR DESCRIPTION
/deploy

Note: the target branch is not master. This is just to fix the problem with conflicting names in the k8s objects table. The bug occurs because we updated the cluster name but did not migrate the postgres table. And the k8s objects table requires the name of all resources objects to be unique (regardless of which cluster they belong to). So when we changed the default cluster name without migrating the existing (old) cluster name we have a conflict when we try to upgrade existing resources that are in the db table with the old cluster name.