### PR TITLE
feat: add  new env vars in sessions

### DIFF
--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -797,6 +797,10 @@ async def start_session(
         SessionEnvItem(name="RENKU_SESSION_IP", value="0.0.0.0"),  # nosec B104
         SessionEnvItem(name="RENKU_SESSION_PORT", value=f"{environment.port}"),
         SessionEnvItem(name="RENKU_WORKING_DIR", value=work_dir.as_posix()),
+        SessionEnvItem(name="RENKU_SECRETS_PATH", value=project.secrets_mount_directory.as_posix()),
+        SessionEnvItem(name="RENKU_PROJECT_ID", value=str(project.id)),
+        SessionEnvItem(name="RENKU_PROJECT_PATH", value=project.path.serialize()),
+        SessionEnvItem(name="RENKU_LAUNCHER_ID", value=str(launcher.id)),
     ]
     launcher_env_variables = get_launcher_env_variables(launcher, body)
     if launcher_env_variables:


### PR DESCRIPTION
Closes #899.

Adds:
* RENKU_SECRETS_PATH -> folder where user secrets are mounted
* RENKU_PROJECT_ID -> the project ID
* RENKU_PROJECT_PATH -> the full project path (namespace + slug)
* RENKU_LAUNCHER_ID -> the launcher ID

/deploy