### PR TITLE
Check for image_registry_url when getting GH installations

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -217,6 +217,7 @@ def register_all_handlers(app: Sanic, dm: DependencyManager) -> Sanic:
         internal_gitlab_authenticator=dm.gitlab_authenticator,
         metrics=dm.metrics,
         connected_svcs_repo=dm.connected_services_repo,
+        git_provider_helper=dm.git_provider_helper,
     )
     platform_config = PlatformConfigBP(
         name="platform_config",

--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -199,6 +199,7 @@ def register_all_handlers(app: Sanic, dm: DependencyManager) -> Sanic:
         rp_repo=dm.rp_repo,
         user_repo=dm.kc_user_repo,
         storage_repo=dm.storage_repo,
+        git_provider_helper=dm.git_provider_helper,
     )
     notebooks_new = NotebooksNewBP(
         name="notebooks",

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -238,7 +238,7 @@ class DependencyManager:
                 UnsavedUserInfo(id="user2", first_name="user2", last_name="doe", email="user2@doe.com"),
             ]
             kc_api = DummyKeycloakAPI(users=[i.to_keycloak_dict() for i in dummy_users])
-            git_provider_helper = DummyGitProviderHelper()
+            git_provider_helper: GitProviderHelperProto = DummyGitProviderHelper()
         else:
             git_provider_helper = GitProviderHelper2.create(connected_services_repo, config.enable_internal_gitlab)
             quota_repo = QuotaRepository(K8sCoreClient(), K8sSchedulingClient(), namespace=config.k8s_namespace)

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -51,7 +51,7 @@ from renku_data_services.message_queue.db import ReprovisioningRepository
 from renku_data_services.metrics.core import StagingMetricsService
 from renku_data_services.metrics.db import MetricsRepository
 from renku_data_services.namespace.db import GroupRepository
-from renku_data_services.notebooks.api.classes.data_service import DummyGitProviderHelper, GitProviderHelper2
+from renku_data_services.notebooks.api.classes.data_service import DummyGitProviderHelper, GitProviderHelper
 from renku_data_services.notebooks.config import GitProviderHelperProto, get_clusters
 from renku_data_services.notebooks.constants import AMALTHEA_SESSION_GVK, JUPYTER_SESSION_GVK
 from renku_data_services.platform.db import PlatformRepository, UrlRedirectRepository
@@ -240,7 +240,7 @@ class DependencyManager:
             kc_api = DummyKeycloakAPI(users=[i.to_keycloak_dict() for i in dummy_users])
             git_provider_helper: GitProviderHelperProto = DummyGitProviderHelper()
         else:
-            git_provider_helper = GitProviderHelper2.create(connected_services_repo, config.enable_internal_gitlab)
+            git_provider_helper = GitProviderHelper.create(connected_services_repo, config.enable_internal_gitlab)
             quota_repo = QuotaRepository(K8sCoreClient(), K8sSchedulingClient(), namespace=config.k8s_namespace)
             assert config.keycloak is not None
 

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -51,7 +51,8 @@ from renku_data_services.message_queue.db import ReprovisioningRepository
 from renku_data_services.metrics.core import StagingMetricsService
 from renku_data_services.metrics.db import MetricsRepository
 from renku_data_services.namespace.db import GroupRepository
-from renku_data_services.notebooks.config import get_clusters
+from renku_data_services.notebooks.api.classes.data_service import GitProviderHelper2
+from renku_data_services.notebooks.config import GitProviderHelperProto, get_clusters
 from renku_data_services.notebooks.constants import AMALTHEA_SESSION_GVK, JUPYTER_SESSION_GVK
 from renku_data_services.platform.db import PlatformRepository, UrlRedirectRepository
 from renku_data_services.project.db import (
@@ -141,6 +142,7 @@ class DependencyManager:
     metrics: StagingMetricsService
     shipwright_client: ShipwrightClient | None
     url_redirect_repo: UrlRedirectRepository
+    git_provider_helper: GitProviderHelperProto
 
     spec: dict[str, Any] = field(init=False, repr=False, default_factory=dict)
     app_name: str = "renku_data_services"
@@ -374,6 +376,7 @@ class DependencyManager:
             project_repo=project_repo,
             data_connector_repo=data_connector_repo,
         )
+        git_provider_helper = GitProviderHelper2.create(connected_services_repo, config.enable_internal_gitlab)
         metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
         metrics = StagingMetricsService(enabled=config.posthog.enabled, metrics_repo=metrics_repo)
         return cls(
@@ -411,4 +414,5 @@ class DependencyManager:
             authz=authz,
             low_level_user_secrets_repo=low_level_user_secrets_repo,
             url_redirect_repo=url_redirect_repo,
+            git_provider_helper=git_provider_helper,
         )

--- a/components/renku_data_services/connected_services/api.spec.yaml
+++ b/components/renku_data_services/connected_services/api.spec.yaml
@@ -188,6 +188,8 @@ paths:
           description: If deleted successfully
         default:
           $ref: "#/components/responses/Error"
+      tags:
+        - oauth2
   /oauth2/connections/{connection_id}/account:
     get:
       summary: Get the account information for this OAuth2 connection for the currently authenticated user if their account is connected

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -466,7 +466,7 @@ class ConnectedServicesRepository:
             #       if no image_registry_url is specified
             if (
                 connection.client.kind == models.ProviderKind.github
-                and connection.client.url == "https://github.com"
+                and not connection.client.image_registry_url
                 and isinstance(adapter, GitHubAdapter)
             ):
                 request_url = urljoin(adapter.api_url, "user/installations")

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -466,7 +466,7 @@ class ConnectedServicesRepository:
             #       if no image_registry_url is specified
             if (
                 connection.client.kind == models.ProviderKind.github
-                and not connection.client.image_registry_url
+                and connection.client.url == "https://github.com"
                 and isinstance(adapter, GitHubAdapter)
             ):
                 request_url = urljoin(adapter.api_url, "user/installations")

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -474,7 +474,7 @@ class ConnectedServicesRepository:
                 try:
                     response = await oauth2_client.get(request_url, params=params, headers=adapter.api_common_headers)
                 except OAuthError as err:
-                    logger.warning(f"Error getting installations: {err}")
+                    logger.warning(f"Error getting installations at {request_url}: {err}")
                     if err.error == "bad_refresh_token":
                         raise errors.InvalidTokenError(
                             message="The refresh token for the connected service has expired or is invalid.",
@@ -484,7 +484,9 @@ class ConnectedServicesRepository:
                     raise
 
                 if response.status_code > 200:
-                    logger.warning(f"Could not get installations: {response.status_code} - {response.text}")
+                    logger.warning(
+                        f"Could not get installations at {request_url}: {response.status_code} - {response.text}"
+                    )
                     raise errors.UnauthorizedError(message="Could not get installation information.")
 
                 return adapter.api_validate_app_installations_response(response)

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -24,7 +24,11 @@ from renku_data_services.connected_services.provider_adapters import (
     ProviderAdapter,
     get_provider_adapter,
 )
-from renku_data_services.connected_services.utils import generate_code_verifier
+from renku_data_services.connected_services.utils import (
+    GitHubProviderType,
+    generate_code_verifier,
+    get_github_provider_type,
+)
 from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDockerAPI
 from renku_data_services.users.db import APIUser
 from renku_data_services.utils.cryptography import decrypt_string, encrypt_string
@@ -462,11 +466,9 @@ class ConnectedServicesRepository:
             adapter,
         ):
             # NOTE: App installations are only available from GitHub when using a "GitHub App"
-            #       it doesn't work for "OAuth App". Currently we guess handling a "Github App"
-            #       if no image_registry_url is specified
             if (
                 connection.client.kind == models.ProviderKind.github
-                and not connection.client.image_registry_url
+                and get_github_provider_type(connection.client) == GitHubProviderType.standard_app
                 and isinstance(adapter, GitHubAdapter)
             ):
                 request_url = urljoin(adapter.api_url, "user/installations")

--- a/components/renku_data_services/connected_services/dummy_async_oauth2_client.py
+++ b/components/renku_data_services/connected_services/dummy_async_oauth2_client.py
@@ -26,10 +26,10 @@ class DummyAsyncOAuth2Client(AsyncOAuth2Client):  # type: ignore[misc]
         if parsed.path == "/api/v4/projects/username%2Fmy_repo":
             return self._get_repository_response()
 
-        if parsed.path == "/api/v3/user/installations":
+        if parsed.path == "/api/v3/user/installations" or parsed.path == "/user/installations":
             return self._get_installations_response()
 
-        return Response(500, json=dict())
+        return Response(500, json={"error": f"path is not expected: {parsed.path}"})
 
     @staticmethod
     def _get_account_response() -> Response:

--- a/components/renku_data_services/connected_services/provider_adapters.py
+++ b/components/renku_data_services/connected_services/provider_adapters.py
@@ -83,6 +83,11 @@ class GitLabAdapter(ProviderAdapter):
 class GitHubAdapter(ProviderAdapter):
     """Adapter for GitHub OAuth2 clients."""
 
+    def __init__(self, client_url: str, **kwargs: Any) -> None:
+        if client_url == "https://ghcr.io":
+            client_url = "https://github.com"
+        super().__init__(client_url, **kwargs)
+
     @property
     def authorization_url(self) -> str:
         """The authorization URL for the OAuth2 protocol."""

--- a/components/renku_data_services/connected_services/provider_adapters.py
+++ b/components/renku_data_services/connected_services/provider_adapters.py
@@ -83,11 +83,6 @@ class GitLabAdapter(ProviderAdapter):
 class GitHubAdapter(ProviderAdapter):
     """Adapter for GitHub OAuth2 clients."""
 
-    def __init__(self, client_url: str, **kwargs: Any) -> None:
-        if client_url == "https://ghcr.io":
-            client_url = "https://github.com"
-        super().__init__(client_url, **kwargs)
-
     @property
     def authorization_url(self) -> str:
         """The authorization URL for the OAuth2 protocol."""

--- a/components/renku_data_services/connected_services/utils.py
+++ b/components/renku_data_services/connected_services/utils.py
@@ -2,9 +2,40 @@
 
 import base64
 import random
+from enum import StrEnum
 
+from renku_data_services.connected_services.apispec import Provider
+from renku_data_services.connected_services.apispec import ProviderKind as ApiProviderKind
+from renku_data_services.connected_services.models import OAuth2Client, ProviderKind
+from renku_data_services.connected_services.orm import OAuth2ClientORM
+from renku_data_services.app_config import logging
+
+logger = logging.getLogger(__name__)
 
 def generate_code_verifier(size: int = 48) -> str:
     """Returns a randomly generated code for use in PKCE."""
     rand = random.SystemRandom()
     return base64.b64encode(rand.randbytes(size)).decode()
+
+
+class GitHubProviderType(StrEnum):
+    """Distinguish between the two possible authentication features at GitHub."""
+
+    oauth_app = "oauth_app"
+    standard_app = "standard_app"
+
+
+def get_github_provider_type(c: OAuth2Client | OAuth2ClientORM | Provider) -> GitHubProviderType | None:
+    """GitHub may use two different auth features: "oauth app" and "github app".
+
+    Currently these two are defined as ProviderKind.github and can be
+    distinguished by looking at the `image_registry_url`. If this url
+    is set, it is the "oauth app" type and otherwise the standard
+    "github app".
+    """
+    if c.kind == ProviderKind.github or c.kind == ApiProviderKind.github:
+        result = GitHubProviderType.oauth_app if c.image_registry_url else GitHubProviderType.standard_app
+        logger.debug(f"Using github provider type: {result} for {c.kind}/{c.image_registry_url}")
+        return result
+    else:
+        return None

--- a/components/renku_data_services/connected_services/utils.py
+++ b/components/renku_data_services/connected_services/utils.py
@@ -26,6 +26,7 @@ class GitHubProviderType(StrEnum):
     standard_app = "standard_app"
 
 
+# TODO: add a new type of integration 'github_oauth' instead of running this logic
 def get_github_provider_type(c: OAuth2Client | OAuth2ClientORM | Provider) -> GitHubProviderType | None:
     """GitHub may use two different auth features: "oauth app" and "github app".
 

--- a/components/renku_data_services/connected_services/utils.py
+++ b/components/renku_data_services/connected_services/utils.py
@@ -4,13 +4,14 @@ import base64
 import random
 from enum import StrEnum
 
+from renku_data_services.app_config import logging
 from renku_data_services.connected_services.apispec import Provider
 from renku_data_services.connected_services.apispec import ProviderKind as ApiProviderKind
 from renku_data_services.connected_services.models import OAuth2Client, ProviderKind
 from renku_data_services.connected_services.orm import OAuth2ClientORM
-from renku_data_services.app_config import logging
 
 logger = logging.getLogger(__name__)
+
 
 def generate_code_verifier(size: int = 48) -> str:
     """Returns a randomly generated code for use in PKCE."""

--- a/components/renku_data_services/notebooks/api/classes/data_service.py
+++ b/components/renku_data_services/notebooks/api/classes/data_service.py
@@ -149,7 +149,7 @@ class DummyCRCValidator:
         return self.options
 
 
-class GitProviderHelper2:
+class GitProviderHelper:
     """Gets the list of providers."""
 
     def __init__(
@@ -205,12 +205,12 @@ class GitProviderHelper2:
         return providers_list
 
     @classmethod
-    def create(cls, csr: ConnectedServicesRepository, enable_internal_gitlab: bool) -> GitProviderHelper2:
+    def create(cls, csr: ConnectedServicesRepository, enable_internal_gitlab: bool) -> GitProviderHelper:
         """Create an instance."""
         sessions_config = _SessionConfig.from_env()
         git_config = _GitConfig.from_env(enable_internal_gitlab=enable_internal_gitlab)
         data_service_url = os.environ.get("NB_DATA_SERVICE_URL", "http://127.0.0.1:8000")
-        return GitProviderHelper2(
+        return GitProviderHelper(
             connected_services_repo=csr,
             service_url=data_service_url,
             renku_url=f"http://{sessions_config.ingress.host}",

--- a/components/renku_data_services/notebooks/api/classes/data_service.py
+++ b/components/renku_data_services/notebooks/api/classes/data_service.py
@@ -1,23 +1,27 @@
 """Helpers for interacting wit the data service."""
 
+from __future__ import annotations
+
+import os
 from dataclasses import dataclass, field
 from typing import Optional
 from urllib.parse import urljoin, urlparse
 
-import httpx
-
+from renku_data_services.app_config import logging
 from renku_data_services.base_models import APIUser
+from renku_data_services.connected_services.db import ConnectedServicesRepository
+from renku_data_services.connected_services.utils import GitHubProviderType, get_github_provider_type
 from renku_data_services.crc.db import ResourcePoolRepository
 from renku_data_services.crc.models import ResourceClass, ResourcePool
 from renku_data_services.notebooks.api.classes.repository import (
     INTERNAL_GITLAB_PROVIDER,
     GitProvider,
-    OAuth2Connection,
-    OAuth2Provider,
 )
 from renku_data_services.notebooks.api.schemas.server_options import ServerOptions
-from renku_data_services.notebooks.errors.intermittent import IntermittentError
+from renku_data_services.notebooks.config.dynamic import _GitConfig, _SessionConfig
 from renku_data_services.notebooks.errors.user import InvalidComputeResourceError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -145,38 +149,44 @@ class DummyCRCValidator:
         return self.options
 
 
-@dataclass
-class GitProviderHelper:
-    """Calls to the data service to configure git providers."""
+class GitProviderHelper2:
+    """Gets the list of providers."""
 
-    service_url: str
-    renku_url: str
-    internal_gitlab_url: str
-    enable_internal_gitlab: bool
-
-    def __post_init__(self) -> None:
-        self.service_url = self.service_url.rstrip("/")
-        self.renku_url = self.renku_url.rstrip("/")
+    def __init__(
+        self,
+        connected_services_repo: ConnectedServicesRepository,
+        service_url: str,
+        renku_url: str,
+        internal_gitlab_url: str,
+        enable_internal_gitlab: bool,
+    ) -> None:
+        self.connected_services_repo = connected_services_repo
+        self.renku_url = renku_url.rstrip("/")
+        self.service_url = service_url.rstrip("/")
+        self.internal_gitlab_url: str = internal_gitlab_url
+        self.enable_internal_gitlab: bool = enable_internal_gitlab
 
     async def get_providers(self, user: APIUser) -> list[GitProvider]:
         """Get the providers for the specific user."""
         if user is None or user.access_token is None:
             return []
-        connections = await self.get_oauth2_connections(user=user)
+
+        logger.debug(f"Get git providers for user {user.id}")
+
+        connections = await self.connected_services_repo.get_oauth2_connections(user)
         providers: dict[str, GitProvider] = dict()
         for c in connections:
             if c.provider_id in providers:
                 continue
-            provider = await self.get_oauth2_provider(c.provider_id)
+            provider = await self.connected_services_repo.get_oauth2_client(c.provider_id, user)
+            if get_github_provider_type(provider) == GitHubProviderType.oauth_app:
+                continue
             access_token_url = urljoin(
                 self.renku_url,
                 urlparse(f"{self.service_url}/oauth2/connections/{c.id}/token").path,
             )
             providers[c.provider_id] = GitProvider(
-                id=c.provider_id,
-                url=provider.url,
-                connection_id=c.id,
-                access_token_url=access_token_url,
+                id=c.provider_id, url=provider.url, connection_id=str(c.id), access_token_url=access_token_url
             )
 
         providers_list = list(providers.values())
@@ -194,29 +204,19 @@ class GitProviderHelper:
             )
         return providers_list
 
-    async def get_oauth2_connections(self, user: APIUser | None = None) -> list[OAuth2Connection]:
-        """Get oauth2 connections."""
-        if user is None or user.access_token is None:
-            return []
-        request_url = f"{self.service_url}/oauth2/connections"
-        headers = {"Authorization": f"bearer {user.access_token}"}
-        async with httpx.AsyncClient(timeout=10) as client:
-            res = await client.get(request_url, headers=headers)
-        if res.status_code != 200:
-            raise IntermittentError(message="The data service sent an unexpected response, please try again later")
-        connections = res.json()
-        connections = [OAuth2Connection.from_dict(c) for c in connections if c["status"] == "connected"]
-        return connections
-
-    async def get_oauth2_provider(self, provider_id: str) -> OAuth2Provider:
-        """Get a specific provider."""
-        request_url = f"{self.service_url}/oauth2/providers/{provider_id}"
-        async with httpx.AsyncClient(timeout=10) as client:
-            res = await client.get(request_url)
-        if res.status_code != 200:
-            raise IntermittentError(message="The data service sent an unexpected response, please try again later")
-        provider = res.json()
-        return OAuth2Provider.from_dict(provider)
+    @classmethod
+    def create(cls, csr: ConnectedServicesRepository, enable_internal_gitlab: bool) -> GitProviderHelper2:
+        """Create an instance."""
+        sessions_config = _SessionConfig.from_env()
+        git_config = _GitConfig.from_env(enable_internal_gitlab=enable_internal_gitlab)
+        data_service_url = os.environ.get("NB_DATA_SERVICE_URL", "http://127.0.0.1:8000")
+        return GitProviderHelper2(
+            connected_services_repo=csr,
+            service_url=data_service_url,
+            renku_url=f"http://{sessions_config.ingress.host}",
+            internal_gitlab_url=git_config.url,
+            enable_internal_gitlab=enable_internal_gitlab,
+        )
 
 
 @dataclass

--- a/components/renku_data_services/notebooks/api/classes/server.py
+++ b/components/renku_data_services/notebooks/api/classes/server.py
@@ -21,6 +21,7 @@ from renku_data_services.notebooks.api.amalthea_patches import inject_certificat
 from renku_data_services.notebooks.api.amalthea_patches import jupyter_server as jupyter_server_patches
 from renku_data_services.notebooks.api.amalthea_patches import ssh as ssh_patches
 from renku_data_services.notebooks.api.classes.cloud_storage import ICloudStorageRequest
+from renku_data_services.notebooks.api.classes.data_service import GitProviderHelper2
 from renku_data_services.notebooks.api.classes.k8s_client import NotebookK8sClient
 from renku_data_services.notebooks.api.classes.repository import GitProvider, Repository
 from renku_data_services.notebooks.api.schemas.secrets import K8sUserSecrets
@@ -54,6 +55,7 @@ class UserServer:
         internal_gitlab_user: APIUser,
         host: str,
         namespace: str,
+        git_provider_helper: GitProviderHelper2,
         using_default_image: bool = False,
         is_image_private: bool = False,
         repositories: list[Repository] | None = None,
@@ -74,6 +76,7 @@ class UserServer:
         self.host = host
         self.__namespace = namespace
         self.config = config
+        self.git_provider_helper = git_provider_helper
         self.internal_gitlab_user = internal_gitlab_user
 
         if self.server_options.idle_threshold_seconds is not None:
@@ -130,7 +133,7 @@ class UserServer:
     async def git_providers(self) -> list[GitProvider]:
         """The list of git providers."""
         if self._git_providers is None:
-            self._git_providers = await self.config.git_provider_helper.get_providers(user=self.user)
+            self._git_providers = await self.git_provider_helper.get_providers(user=self.user)
         return self._git_providers
 
     async def required_git_providers(self) -> list[GitProvider]:
@@ -411,6 +414,7 @@ class Renku1UserServer(UserServer):
         config: NotebooksConfig,
         host: str,
         namespace: str,
+        git_provider_helper: GitProviderHelper2,
         gitlab_project: Project | None,
         internal_gitlab_user: APIUser,
         using_default_image: bool = False,
@@ -439,6 +443,7 @@ class Renku1UserServer(UserServer):
             k8s_client=k8s_client,
             workspace_mount_path=workspace_mount_path,
             work_dir=work_dir,
+            git_provider_helper=git_provider_helper,
             using_default_image=using_default_image,
             is_image_private=is_image_private,
             repositories=repositories,

--- a/components/renku_data_services/notebooks/api/classes/server.py
+++ b/components/renku_data_services/notebooks/api/classes/server.py
@@ -21,12 +21,11 @@ from renku_data_services.notebooks.api.amalthea_patches import inject_certificat
 from renku_data_services.notebooks.api.amalthea_patches import jupyter_server as jupyter_server_patches
 from renku_data_services.notebooks.api.amalthea_patches import ssh as ssh_patches
 from renku_data_services.notebooks.api.classes.cloud_storage import ICloudStorageRequest
-from renku_data_services.notebooks.api.classes.data_service import GitProviderHelper2
 from renku_data_services.notebooks.api.classes.k8s_client import NotebookK8sClient
 from renku_data_services.notebooks.api.classes.repository import GitProvider, Repository
 from renku_data_services.notebooks.api.schemas.secrets import K8sUserSecrets
 from renku_data_services.notebooks.api.schemas.server_options import ServerOptions
-from renku_data_services.notebooks.config import NotebooksConfig
+from renku_data_services.notebooks.config import GitProviderHelperProto, NotebooksConfig
 from renku_data_services.notebooks.constants import JUPYTER_SESSION_GVK
 from renku_data_services.notebooks.cr_amalthea_session import TlsSecret
 from renku_data_services.notebooks.crs import JupyterServerV1Alpha1
@@ -55,7 +54,7 @@ class UserServer:
         internal_gitlab_user: APIUser,
         host: str,
         namespace: str,
-        git_provider_helper: GitProviderHelper2,
+        git_provider_helper: GitProviderHelperProto,
         using_default_image: bool = False,
         is_image_private: bool = False,
         repositories: list[Repository] | None = None,
@@ -414,7 +413,7 @@ class Renku1UserServer(UserServer):
         config: NotebooksConfig,
         host: str,
         namespace: str,
-        git_provider_helper: GitProviderHelper2,
+        git_provider_helper: GitProviderHelperProto,
         gitlab_project: Project | None,
         internal_gitlab_user: APIUser,
         using_default_image: bool = False,

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -330,7 +330,12 @@ class NotebooksNewBP(CustomBlueprint):
             query: apispec.SessionsImagesGetParametersQuery,
         ) -> JSONResponse:
             image = Image.from_path(query.image_url)
-            result = await image_check.check_image(image, user, self.connected_svcs_repo)
+            result = await image_check.check_image(
+                image,
+                user,
+                self.connected_svcs_repo,
+                image_check.InternalGitLabConfig(internal_gitlab_user, self.nb_config),
+            )
             logger.info(f"Checked image {query.image_url}: {result}")
             conn = None
             if result.connection:

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -24,7 +24,7 @@ from renku_data_services.notebooks import apispec, core, image_check
 from renku_data_services.notebooks.api.classes.image import Image
 from renku_data_services.notebooks.api.schemas.config_server_options import ServerOptionsEndpointResponse
 from renku_data_services.notebooks.api.schemas.logs import ServerLogs
-from renku_data_services.notebooks.config import NotebooksConfig
+from renku_data_services.notebooks.config import GitProviderHelperProto, NotebooksConfig
 from renku_data_services.notebooks.core_sessions import (
     patch_session,
     start_session,
@@ -204,6 +204,7 @@ class NotebooksNewBP(CustomBlueprint):
     metrics: MetricsService
     cluster_repo: ClusterRepository
     connected_svcs_repo: ConnectedServicesRepository
+    git_provider_helper: GitProviderHelperProto
 
     def start(self) -> BlueprintFactoryResponse:
         """Start a session with the new operator."""
@@ -222,6 +223,7 @@ class NotebooksNewBP(CustomBlueprint):
                 user=user,
                 internal_gitlab_user=internal_gitlab_user,
                 nb_config=self.nb_config,
+                git_provider_helper=self.git_provider_helper,
                 cluster_repo=self.cluster_repo,
                 data_connector_secret_repo=self.data_connector_secret_repo,
                 project_repo=self.project_repo,
@@ -291,6 +293,7 @@ class NotebooksNewBP(CustomBlueprint):
                 user=user,
                 internal_gitlab_user=internal_gitlab_user,
                 nb_config=self.nb_config,
+                git_provider_helper=self.git_provider_helper,
                 project_repo=self.project_repo,
                 project_session_secret_repo=self.project_session_secret_repo,
                 rp_repo=self.rp_repo,

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -48,6 +48,7 @@ class NotebooksBP(CustomBlueprint):
     rp_repo: ResourcePoolRepository
     user_repo: UserRepo
     storage_repo: StorageRepository
+    git_provider_helper: GitProviderHelperProto
 
     def version(self) -> BlueprintFactoryResponse:
         """Return notebook services version."""
@@ -100,6 +101,7 @@ class NotebooksBP(CustomBlueprint):
                 body,
                 user_repo=self.user_repo,
                 storage_repo=self.storage_repo,
+                git_provider_helper=self.git_provider_helper,
             )
             return core.serialize_v1_server(server, self.nb_config, status_code)
 

--- a/components/renku_data_services/notebooks/config/__init__.py
+++ b/components/renku_data_services/notebooks/config/__init__.py
@@ -116,7 +116,6 @@ class NotebooksConfig:
     cloud_storage: _CloudStorage
     user_secrets: _UserSecrets
     crc_validator: CRCValidatorProto
-    #   git_provider_helper: GitProviderHelperProto
     k8s_client: NotebookK8sClient[JupyterServerV1Alpha1]
     k8s_v2_client: NotebookK8sClient[AmaltheaSessionV1Alpha1]
     cluster_rp: ClusterRepository
@@ -216,7 +215,6 @@ class NotebooksConfig:
             data_service_url=data_service_url,
             dummy_stores=dummy_stores,
             crc_validator=crc_validator,
-            #            git_provider_helper=git_provider_helper,
             k8s_client=k8s_client,
             k8s_v2_client=k8s_v2_client,
             k8s_db_cache=k8s_db_cache,

--- a/components/renku_data_services/notebooks/config/__init__.py
+++ b/components/renku_data_services/notebooks/config/__init__.py
@@ -23,8 +23,6 @@ from renku_data_services.k8s.db import K8sDbCache, QuotaRepository
 from renku_data_services.notebooks.api.classes.data_service import (
     CRCValidator,
     DummyCRCValidator,
-    DummyGitProviderHelper,
-    GitProviderHelper,
 )
 from renku_data_services.notebooks.api.classes.k8s_client import NotebookK8sClient
 from renku_data_services.notebooks.api.classes.repository import GitProvider
@@ -118,7 +116,7 @@ class NotebooksConfig:
     cloud_storage: _CloudStorage
     user_secrets: _UserSecrets
     crc_validator: CRCValidatorProto
-    git_provider_helper: GitProviderHelperProto
+    #   git_provider_helper: GitProviderHelperProto
     k8s_client: NotebookK8sClient[JupyterServerV1Alpha1]
     k8s_v2_client: NotebookK8sClient[AmaltheaSessionV1Alpha1]
     cluster_rp: ClusterRepository
@@ -148,7 +146,6 @@ class NotebooksConfig:
         data_service_url = os.environ.get("NB_DATA_SERVICE_URL", "http://127.0.0.1:8000")
         server_options = ServerOptionsConfig.from_env()
         crc_validator: CRCValidatorProto
-        git_provider_helper: GitProviderHelperProto
         k8s_namespace = os.environ.get("K8S_NAMESPACE", "default")
         kube_config_root = os.environ.get("K8S_CONFIGS_ROOT", "/secrets/kube_configs")
         v1_sessions_enabled = _parse_str_as_bool(os.environ.get("V1_SESSIONS_ENABLED", False))
@@ -158,7 +155,6 @@ class NotebooksConfig:
             rp_repo = ResourcePoolRepository(db_config.async_session_maker, quota_repo)
             crc_validator = DummyCRCValidator()
             sessions_config = _SessionConfig._for_testing()
-            git_provider_helper = DummyGitProviderHelper()
             git_config = _GitConfig("http://not.specified", "registry.not.specified")
             kr8s_api = Kr8sApiStack()  # type: ignore[assignment]
         else:
@@ -167,12 +163,6 @@ class NotebooksConfig:
             crc_validator = CRCValidator(rp_repo)
             sessions_config = _SessionConfig.from_env()
             git_config = _GitConfig.from_env(enable_internal_gitlab=enable_internal_gitlab)
-            git_provider_helper = GitProviderHelper(
-                service_url=data_service_url,
-                renku_url=f"http://{sessions_config.ingress.host}",
-                internal_gitlab_url=git_config.url,
-                enable_internal_gitlab=enable_internal_gitlab,
-            )
             # NOTE: we need to get an async client as a sync client can't be used in an async way
             # But all the config code is not async, so we need to drop into the running loop, if there is one
             kr8s_api = KubeConfigEnv().api()
@@ -226,7 +216,7 @@ class NotebooksConfig:
             data_service_url=data_service_url,
             dummy_stores=dummy_stores,
             crc_validator=crc_validator,
-            git_provider_helper=git_provider_helper,
+            #            git_provider_helper=git_provider_helper,
             k8s_client=k8s_client,
             k8s_v2_client=k8s_v2_client,
             k8s_db_cache=k8s_db_cache,

--- a/components/renku_data_services/notebooks/core.py
+++ b/components/renku_data_services/notebooks/core.py
@@ -30,7 +30,7 @@ from renku_data_services.notebooks.api.schemas.secrets import K8sUserSecrets
 from renku_data_services.notebooks.api.schemas.server_options import ServerOptions
 from renku_data_services.notebooks.api.schemas.servers_get import NotebookResponse
 from renku_data_services.notebooks.api.schemas.servers_patch import PatchServerStatusEnum
-from renku_data_services.notebooks.config import NotebooksConfig
+from renku_data_services.notebooks.config import GitProviderHelperProto, NotebooksConfig
 from renku_data_services.notebooks.constants import JUPYTER_SESSION_GVK
 from renku_data_services.notebooks.errors import intermittent
 from renku_data_services.notebooks.errors import user as user_errors
@@ -332,6 +332,7 @@ async def launch_notebook_helper(
     internal_gitlab_user: APIUser,
     user_repo: UserRepo,
     storage_repo: StorageRepository,
+    git_provider_helper: GitProviderHelperProto,
 ) -> tuple[UserServerManifest, int]:
     """Helper function to launch a Jupyter server."""
 
@@ -519,6 +520,7 @@ async def launch_notebook_helper(
         config=nb_config,
         host=host,
         namespace=session_namespace,
+        git_provider_helper=git_provider_helper,
         **extra_kwargs,
     )
 
@@ -594,6 +596,7 @@ async def launch_notebook(
     launch_request: apispec.LaunchNotebookRequestOld,
     user_repo: UserRepo,
     storage_repo: StorageRepository,
+    git_provider_helper: GitProviderHelperProto,
 ) -> tuple[UserServerManifest, int]:
     """Starts a server using the old operator."""
 
@@ -652,6 +655,7 @@ async def launch_notebook(
         internal_gitlab_user=internal_gitlab_user,
         user_repo=user_repo,
         storage_repo=storage_repo,
+        git_provider_helper=git_provider_helper,
     )
 
 

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -551,7 +551,7 @@ async def __get_connected_services_image_pull_secret(
 ) -> ExtraSecret | None:
     """Return a secret for accessing the image if one is available for the given user."""
     image_parsed = Image.from_path(image)
-    image_check_result = await ic.check_image(image_parsed, user, connected_svcs_repo)
+    image_check_result = await ic.check_image(image_parsed, user, connected_svcs_repo, None)
     logger.debug(f"Set pull secret for {image} to connection {image_check_result.image_provider}")
     if not image_check_result.token:
         return None

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -37,7 +37,7 @@ from renku_data_services.notebooks.api.amalthea_patches.init_containers import u
 from renku_data_services.notebooks.api.classes.image import Image
 from renku_data_services.notebooks.api.classes.repository import GitProvider, Repository
 from renku_data_services.notebooks.api.schemas.cloud_storage import RCloneStorage
-from renku_data_services.notebooks.config import NotebooksConfig
+from renku_data_services.notebooks.config import GitProviderHelperProto, NotebooksConfig
 from renku_data_services.notebooks.cr_amalthea_session import TlsSecret
 from renku_data_services.notebooks.crs import (
     AmaltheaSessionSpec,
@@ -603,6 +603,7 @@ async def start_session(
     user: AnonymousAPIUser | AuthenticatedAPIUser,
     internal_gitlab_user: APIUser,
     nb_config: NotebooksConfig,
+    git_provider_helper: GitProviderHelperProto,
     cluster_repo: ClusterRepository,
     data_connector_secret_repo: DataConnectorSecretRepository,
     project_repo: ProjectRepository,
@@ -663,7 +664,7 @@ async def start_session(
         user=user, project_id=project.id
     )
     data_connectors_stream = data_connector_secret_repo.get_data_connectors_with_secrets(user, project.id)
-    git_providers = await nb_config.git_provider_helper.get_providers(user=user)
+    git_providers = await git_provider_helper.get_providers(user=user)
     repositories = repositories_from_project(project, git_providers)
 
     # User secrets
@@ -887,6 +888,7 @@ async def patch_session(
     user: AnonymousAPIUser | AuthenticatedAPIUser,
     internal_gitlab_user: APIUser,
     nb_config: NotebooksConfig,
+    git_provider_helper: GitProviderHelperProto,
     project_repo: ProjectRepository,
     project_session_secret_repo: ProjectSessionSecretRepository,
     rp_repo: ResourcePoolRepository,
@@ -982,7 +984,7 @@ async def patch_session(
     session_secrets = await project_session_secret_repo.get_all_session_secrets_from_project(
         user=user, project_id=project.id
     )
-    git_providers = await nb_config.git_provider_helper.get_providers(user=user)
+    git_providers = await git_provider_helper.get_providers(user=user)
     repositories = repositories_from_project(project, git_providers)
 
     # User secrets

--- a/components/renku_data_services/notebooks/image_check.py
+++ b/components/renku_data_services/notebooks/image_check.py
@@ -124,6 +124,7 @@ async def check_image(
         and image.hostname == intern_gl_cfg.nb_config.git.registry
         and intern_gl_cfg.gitlab_user.access_token
     ):
+        logger.debug(f"Using internal gitlab at {intern_gl_cfg.nb_config.git.registry}")
         reg_api = reg_api.with_oauth2_token(intern_gl_cfg.gitlab_user.access_token)
 
     try:

--- a/components/renku_data_services/notebooks/image_check.py
+++ b/components/renku_data_services/notebooks/image_check.py
@@ -26,6 +26,7 @@ from renku_data_services.connected_services.db import ConnectedServicesRepositor
 from renku_data_services.connected_services.models import ImageProvider, OAuth2Client, OAuth2Connection
 from renku_data_services.errors import errors
 from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDockerAPI
+from renku_data_services.notebooks.config import NotebooksConfig
 
 logger = logging.getLogger(__name__)
 
@@ -76,15 +77,31 @@ class CheckResult:
         return self.image_provider.connected_user.user
 
 
+@dataclass
+class InternalGitLabConfig:
+    """Required for internal gitlab, which will be shut down soon."""
+
+    gitlab_user: APIUser
+    nb_config: NotebooksConfig
+
+
 async def check_image_path(
-    image_path: str, user: APIUser, connected_services: ConnectedServicesRepository
+    image_path: str,
+    user: APIUser,
+    connected_services: ConnectedServicesRepository,
+    internal_gitlab_config: InternalGitLabConfig | None,
 ) -> CheckResult:
     """Check access to the given image."""
     image = Image.from_path(image_path)
-    return await check_image(image, user, connected_services)
+    return await check_image(image, user, connected_services, internal_gitlab_config)
 
 
-async def check_image(image: Image, user: APIUser, connected_services: ConnectedServicesRepository) -> CheckResult:
+async def check_image(
+    image: Image,
+    user: APIUser,
+    connected_services: ConnectedServicesRepository,
+    intern_gl_cfg: InternalGitLabConfig | None,
+) -> CheckResult:
     """Check access to the given image."""
 
     reg_api: ImageRepoDockerAPI = image.repo_api()  # public images
@@ -102,6 +119,12 @@ async def check_image(image: Image, user: APIUser, connected_services: Connected
             logger.info(f"Error getting image repo client for image {image}: {e}")
             unauth_error = errors.UnauthorizedError(message=f"OAuth error when getting repo client for image: {image}")
             unauth_error.__cause__ = e
+    elif (
+        intern_gl_cfg
+        and image.hostname == intern_gl_cfg.nb_config.git.registry
+        and intern_gl_cfg.gitlab_user.access_token
+    ):
+        reg_api = reg_api.with_oauth2_token(intern_gl_cfg.gitlab_user.access_token)
 
     try:
         result = await reg_api.image_check(image)

--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,7 @@
         basedpyright
         rclone-sdsc
         azure-cli
+        k3d
         (
           writeShellScriptBin "pg" ''
             psql -h $DB_HOST -p $DB_PORT -U dev $DB_NAME

--- a/test/bases/renku_data_services/data_api/test_connected_services.py
+++ b/test/bases/renku_data_services/data_api/test_connected_services.py
@@ -433,7 +433,7 @@ async def test_get_installations_github(
 async def test_get_no_installations_ghcrio(
     oauth2_test_client: SanicASGITestClient, user_headers, create_oauth2_connection
 ):
-    connection = await create_oauth2_connection("provider_1", kind="github", url="https://ghcr.io")
+    connection = await create_oauth2_connection("provider_1", kind="github", image_registry_url="https://ghcr.io")
     connection_id = connection["id"]
 
     _, res = await oauth2_test_client.get(

--- a/test/bases/renku_data_services/data_api/test_connected_services.py
+++ b/test/bases/renku_data_services/data_api/test_connected_services.py
@@ -406,7 +406,7 @@ async def test_get_installations_gitlab(
 async def test_get_installations_github(
     oauth2_test_client: SanicASGITestClient, user_headers, create_oauth2_connection
 ):
-    connection = await create_oauth2_connection("provider_1", kind="github")
+    connection = await create_oauth2_connection("provider_1", kind="github", url="https://github.com")
     connection_id = connection["id"]
 
     _, res = await oauth2_test_client.get(
@@ -427,3 +427,20 @@ async def test_get_installations_github(
     assert res.headers.get("per-page") == "20"
     assert res.headers.get("total") == "1"
     assert res.headers.get("total-pages") == "1"
+
+
+@pytest.mark.asyncio
+async def test_get_no_installations_ghcrio(
+    oauth2_test_client: SanicASGITestClient, user_headers, create_oauth2_connection
+):
+    connection = await create_oauth2_connection("provider_1", kind="github", url="https://ghcr.io")
+    connection_id = connection["id"]
+
+    _, res = await oauth2_test_client.get(
+        f"/api/data/oauth2/connections/{connection_id}/installations", headers=user_headers
+    )
+
+    assert res.status_code == 200, res.text
+    assert res.json is not None
+    installations_list = res.json
+    assert len(installations_list) == 0

--- a/test/utils.py
+++ b/test/utils.py
@@ -30,7 +30,7 @@ from renku_data_services.k8s.db import QuotaRepository
 from renku_data_services.message_queue.db import ReprovisioningRepository
 from renku_data_services.metrics.db import MetricsRepository
 from renku_data_services.namespace.db import GroupRepository
-from renku_data_services.notebooks.api.classes.data_service import GitProviderHelper2
+from renku_data_services.notebooks.api.classes.data_service import GitProviderHelper
 from renku_data_services.platform.db import PlatformRepository, UrlRedirectRepository
 from renku_data_services.project.db import (
     ProjectMemberRepository,
@@ -298,7 +298,7 @@ class TestDependencyManager(DependencyManager):
         cluster_repo = ClusterRepository(session_maker=config.db.async_session_maker)
         metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
         metrics_mock = MagicMock(spec=MetricsService)
-        git_provider_helper = GitProviderHelper2(connected_services_repo, "", "", "", config.enable_internal_gitlab)
+        git_provider_helper = GitProviderHelper(connected_services_repo, "", "", "", config.enable_internal_gitlab)
         return cls(
             config=config,
             authenticator=authenticator,


### PR DESCRIPTION
Also add some logging if things go wrong.

This adds a quick fix to allow private images from GitHub container registry. Unfortunately, GitHub doesn't allow access via tokens generated by "GitHub App". See details [here](https://github.com/orgs/community/discussions/24636) and the corresponding [open issue](https://github.com/github/roadmap/issues/558). Luckily it does work using a "GitHub OAuth App". The solution will be to add two integrations for GitHub - one is the GitHub App we are already using for accessing repositories. Then there is one GitHub OAuth App for accessing (private) images. In order to make this work, the user must still connect at github - so in case an integration is added with the ghcr.io domain, we must configure the provider adapter to connect to github.com for authorization. Additionally, there is no notion of "installations" for GitHub OAuth Apps, so the if is amended to check whether we have the "GitHub App" otherwise there will be an error returned from GitHub.

Implications for adding integrations:
- one with `url=https://github.com` which *must be* a GitHub App, no `image_registry_url`
- one with `url=https://github.com` which *must be* an _GitHub OAuth App_ with an `image_registry_url`

---

/deploy renku-ui=lorenzo/connected-private-images renku=ciyer/redirect-test-fixes