### PR TITLE
chore: add Salim and Samuel to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-*           @SwissDataScienceCenter/renku-python-maintainers
+*	@SwissDataScienceCenter/renku-python-maintainers
+*	@sgaist
+*	@SalimKayal


### PR DESCRIPTION
This allows their reviews on PRs to protected branches to count.

I cannot add them to the python maintainers group because then I will have to add them to the SDSC org fully. And I think that causes other permissions to be assigned to them - i.e. like k8s access.