### PR TITLE
chore: run secret storage as a single service

### DIFF
--- a/bases/renku_data_services/secrets_storage_api/main.py
+++ b/bases/renku_data_services/secrets_storage_api/main.py
@@ -1,6 +1,7 @@
 """The entrypoint for the secrets storage application."""
 
 import argparse
+import os
 from multiprocessing import Lock
 from os import environ
 from typing import Any
@@ -81,4 +82,8 @@ if __name__ == "__main__":
     loader = AppLoader(factory=create_app)
     app = loader.load()
     app.prepare(**args)
-    Sanic.serve(primary=app, app_loader=loader)
+    if os.name == "posix" and args.get("single_process", False):
+        Sanic.start_method = "fork"
+        Sanic.serve(primary=app)
+    else:
+        Sanic.serve(primary=app, app_loader=loader)

--- a/projects/secrets_storage/Dockerfile
+++ b/projects/secrets_storage/Dockerfile
@@ -39,4 +39,4 @@ RUN apt-get update && apt-get install -y \
 USER $USER_UID:$USER_GID
 WORKDIR /app
 COPY --from=builder /app/env ./env
-ENTRYPOINT ["tini", "-g", "--", "env/bin/python", "-m", "renku_data_services.secrets_storage_api.main"]
+ENTRYPOINT ["tini", "-g", "--", "env/bin/python", "-m", "renku_data_services.secrets_storage_api.main", "--single-process"]


### PR DESCRIPTION
This reduces memory consumption. K8s can scale up and down when needed.

/deploy

The same change as https://github.com/SwissDataScienceCenter/renku-data-services/pull/1008 but this is for the secret storage service.