### PR TITLE
feat: configure the builder and run image

### DIFF
--- a/components/renku_data_services/session/config.py
+++ b/components/renku_data_services/session/config.py
@@ -18,7 +18,8 @@ class BuildsConfig:
 
     enabled: bool = False
     build_output_image_prefix: str | None = None
-    vscodium_python_run_image: str | None = None
+    build_builder_image: str | None = None
+    build_run_image: str | None = None
     build_strategy_name: str | None = None
     push_secret_name: str | None = None
     buildrun_retention_after_failed: timedelta | None = None
@@ -32,7 +33,8 @@ class BuildsConfig:
         """Create a config from environment variables."""
         enabled = os.environ.get("IMAGE_BUILDERS_ENABLED", "false").lower() == "true"
         build_output_image_prefix = os.environ.get("BUILD_OUTPUT_IMAGE_PREFIX")
-        vscodium_python_run_image = os.environ.get("BUILD_VSCODIUM_PYTHON_RUN_IMAGE")
+        build_builder_image = os.environ.get("BUILD_BUILDER_IMAGE")
+        build_run_image = os.environ.get("BUILD_RUN_IMAGE")
         build_strategy_name = os.environ.get("BUILD_STRATEGY_NAME")
         push_secret_name = os.environ.get("BUILD_PUSH_SECRET_NAME")
         buildrun_retention_after_failed_seconds = int(os.environ.get("BUILD_RUN_RETENTION_AFTER_FAILED_SECONDS") or "0")
@@ -76,7 +78,8 @@ class BuildsConfig:
         return cls(
             enabled=enabled or False,
             build_output_image_prefix=build_output_image_prefix or None,
-            vscodium_python_run_image=vscodium_python_run_image or None,
+            build_builder_image=build_builder_image,
+            build_run_image=build_run_image,
             build_strategy_name=build_strategy_name or None,
             push_secret_name=push_secret_name or None,
             buildrun_retention_after_failed=buildrun_retention_after_failed,

--- a/components/renku_data_services/session/constants.py
+++ b/components/renku_data_services/session/constants.py
@@ -14,16 +14,16 @@ BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX: Final[str] = "harbor.dev.renku.ch/renku-build
 BUILD_OUTPUT_IMAGE_NAME: Final[str] = "renku-build"
 """The container image name created from Renku builds."""
 
-BUILD_BUILDER_IMAGE: Final[str] = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/selector:0.1.0"
+BUILD_DEFAULT_BUILDER_IMAGE: Final[str] = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/selector:0.1.0"
 
-BUILD_RUN_IMAGE: Final[str] = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.1.0"
+BUILD_DEFAULT_RUN_IMAGE: Final[str] = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.1.0"
 BUILD_MOUNT_DIRECTORY: Final[PurePosixPath] = PurePosixPath("/home/renku/work")
 BUILD_WORKING_DIRECTORY: Final[PurePosixPath] = BUILD_MOUNT_DIRECTORY
 BUILD_UID: Final[int] = 1000
 BUILD_GID: Final[int] = 1000
 BUILD_PORT: Final[int] = 8888
-DEFAULT_URLS: Final[dict[str, str]] = {
-    "vscodium": "/",
+BUILD_DEFAULT_URL_PATH: Final[str] = "/"
+BUILD_URL_PATH_MAP: Final[dict[str, str]] = {
     "jupyterlab": "/lab",
 }
 

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -435,7 +435,9 @@ class SessionRepository:
                     created_by_id=user.id,
                     description=f"Generated environment for {launcher.name}",
                     container_image="image:unknown-at-the-moment",  # TODO: This should come from the build
-                    default_url=constants.DEFAULT_URLS.get(launcher.environment.frontend_variant, "/"),
+                    default_url=constants.BUILD_URL_PATH_MAP.get(
+                        launcher.environment.frontend_variant, constants.BUILD_DEFAULT_URL_PATH
+                    ),
                     port=constants.BUILD_PORT,  # TODO: This should come from the build
                     working_directory=constants.BUILD_WORKING_DIRECTORY,  # TODO: This should come from the build
                     mount_directory=constants.BUILD_MOUNT_DIRECTORY,  # TODO: This should come from the build
@@ -1087,8 +1089,8 @@ class SessionRepository:
         return models.ShipwrightBuildRunParams(
             name=build.k8s_name,
             git_repository=git_repository,
-            build_image=constants.BUILD_BUILDER_IMAGE,
-            run_image=constants.BUILD_RUN_IMAGE,
+            build_image=self.builds_config.build_builder_image or constants.BUILD_DEFAULT_BUILDER_IMAGE,
+            run_image=self.builds_config.build_run_image or constants.BUILD_DEFAULT_RUN_IMAGE,
             output_image=output_image,
             build_strategy_name=build_strategy_name,
             push_secret_name=push_secret_name,


### PR DESCRIPTION
Allows the builder image and the run image to be configured from environment variables (which means they can be configured from the helm chart values).

See chart changes here: https://github.com/SwissDataScienceCenter/renku/pull/4229

/deploy #notest renku=leafty/configure-buildpacks extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user