### PR TITLE
fix: Return proper unprocessable entity response when repo url is not provided

### DIFF
--- a/components/renku_data_services/repositories/blueprints.py
+++ b/components/renku_data_services/repositories/blueprints.py
@@ -10,6 +10,7 @@ from renku_data_services.base_api.auth import authenticate_2
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
 from renku_data_services.base_api.etag import extract_if_none_match
 from renku_data_services.base_models.validation import validated_json
+from renku_data_services.errors.errors import ValidationError
 from renku_data_services.repositories import apispec, models
 from renku_data_services.repositories.db import GitRepositoriesRepository
 from renku_data_services.repositories.git_url import GitUrlError
@@ -37,7 +38,7 @@ class RepositoriesBP(CustomBlueprint):
             query_args: dict[str, str] = req.get_args() or {}
             repository_url = query_args.get("url")
             if repository_url is None:
-                return HTTPResponse(status=422)
+                raise ValidationError(message="A repository url is required")
 
             result = await self.git_repositories_repo.get_repository(
                 repository_url=repository_url,

--- a/test/bases/renku_data_services/data_api/test_repositories.py
+++ b/test/bases/renku_data_services/data_api/test_repositories.py
@@ -150,6 +150,19 @@ async def test_get_one_repository_not_found(
 
 
 @pytest.mark.asyncio
+async def test_get_one_repository_no_url(
+    oauth2_test_client: SanicASGITestClient, user_headers, create_oauth2_connection
+):
+    _, res = await oauth2_test_client.get("/api/data/repository?url=", headers=user_headers)
+
+    assert res.status_code == 422, res.text
+    assert res.json is not None
+    result = res.json
+    assert result.get("error", {}).get("message") == "A repository url is required"
+    assert result.get("error", {}).get("code") == 1422
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "repository_url,error_code",
     [


### PR DESCRIPTION
It should follow the other endpoints and return json. Instead of creating the response, an exception is thrown and then handled somewhere central. It is converted into the proper (json) response.

/deploy renku-ui=lorenzo/code-intergations renku=build/code-integrations

Fixup for #1095 