### PR TITLE
fix: Fix url used to patch schemathesis

### DIFF
--- a/test/bases/renku_data_services/data_api/test_schemathesis.py
+++ b/test/bases/renku_data_services/data_api/test_schemathesis.py
@@ -121,7 +121,7 @@ async def test_api_schemathesis(
         # schemathesis does not currently allow accepting status 204 for negative data, so we ignore that check
         checks = tuple(c for c in checks if c.__name__ != "negative_data_rejection")
 
-    if req_kwargs.get("url") == "/api/data/repositories" and res.status_code == 200:
+    if req_kwargs.get("url") == "/api/data/repository" and res.status_code == 200:
         # schemathesis constructs invalid negative cases affecting the /repositories endpoint
         checks = tuple(c for c in checks if c.__name__ != "negative_data_rejection")
 


### PR DESCRIPTION
I'm sorry - I missed to update this place. Tests do sometimes still randomly succeed.