### PR TITLE
chore: Run solr migrations before reprovisioning

### DIFF
--- a/components/renku_data_services/solr/solr_migrate.py
+++ b/components/renku_data_services/solr/solr_migrate.py
@@ -33,8 +33,6 @@ from renku_data_services.solr.solr_schema import (
 
 logger = logging.getLogger(__name__)
 
-logger = logging.Logger(__name__)
-
 
 def _is_applied(schema: CoreSchema, cmd: SchemaCommand) -> bool:
     """Check whether a schema command is already applied to the given schema."""


### PR DESCRIPTION
This is in most cases a no-op, but sometimes necessary to fix the schema. It makes it possible to manually drop our schema and to let it re-create on a reprovisioning request.

This can be useful if things get messed up badly, using a mix of manual action (recreating the solr core, or dropping the schema) and a reprovisioning so the app doesn't need to be restarted.

/deploy