### PR TITLE
Remove manifest from str representation

### DIFF
--- a/components/renku_data_services/k8s/models.py
+++ b/components/renku_data_services/k8s/models.py
@@ -85,7 +85,7 @@ class K8sObject(K8sObjectMeta):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(name={self.name}, namespace={self.namespace}, cluster={self.cluster}, "
-            f"gvk={self.gvk}, manifest={self.manifest}, user_id={self.user_id})"
+            f"gvk={self.gvk}, user_id={self.user_id})"
         )
 
     def to_api_object(self, api: Api) -> APIObject:

--- a/test/components/renku_data_services/k8s/test_models.py
+++ b/test/components/renku_data_services/k8s/test_models.py
@@ -1,0 +1,30 @@
+"""Tests for the k8s models."""
+
+from ulid import ULID
+
+from renku_data_services.k8s.constants import ClusterId
+from renku_data_services.k8s.models import GVK, K8sObject, K8sSecret
+
+
+def test_k8s_object_not_render_manifest():
+    obj = K8sObject(
+        name="hello",
+        namespace="ns1",
+        cluster=ClusterId(ULID()),
+        gvk=GVK(kind="kind", version="version1"),
+        user_id="abc-user1",
+        manifest={"not_a_real_manifest": "abd275c11ceb"},
+    )
+    sec = K8sSecret(
+        name="hello",
+        namespace="ns1",
+        cluster=ClusterId(ULID()),
+        gvk=GVK(kind="kind", version="version1"),
+        user_id="abc-user1",
+        manifest={"not_a_real_manifest": "abd275c11ceb"},
+    )
+
+    assert "abd275c11ceb" not in str(obj)
+    assert "abd275c11ceb" not in repr(obj)
+    assert "abd275c11ceb" not in str(sec)
+    assert "abd275c11ceb" not in repr(sec)


### PR DESCRIPTION
When logging/printing `K8sObject`s, the manifest was included which can result in very large strings, containing potential sensitive data. This string would be returned to clients inside an error message (see referenced issue). The name and namespace should be enough, so the manifest is now hidden - same as done already in `K8sSecret`.

Fixes: #1127

/deploy