### PR TITLE
fix: Catch invalid-token error and suggest to reconnect

### DIFF
--- a/components/renku_data_services/connected_services/oauth_http.py
+++ b/components/renku_data_services/connected_services/oauth_http.py
@@ -411,7 +411,7 @@ class DefaultOAuthHttpClientFactory(OAuthHttpClientFactory, _TokenCheck, _TokenC
                 token = self.decrypt_token_set(token=connection.token, user_id=user.id)
             except InvalidToken as e:
                 raise SecretDecryptionError(
-                    message="Decrypting the token failed. Please reconnect to the provider, obtaining a new token."
+                    message="Token decryption failed. Please reconnect to the provider to obtain a new one."
                 ) from e
 
         adapter = get_provider_adapter(client)


### PR DESCRIPTION
Sometimes the token decryption fails with a "bad signature" error, which indicates some corrupted state in our db 🫤 One way out is to reconnect, so a new token is fetched and this time correctly encrypted. This change only passes a error message suggesting to do this.

Refs: #1146