### PR TITLE
fix: Make content_all search work with words containing dashes

### DIFF
--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -176,6 +176,7 @@ def create_app() -> Sanic:
     @app.after_server_start
     async def ready(app: Sanic) -> None:
         """Application ready event handler."""
+        logger.info(f">>>>>> SHOULD RUN RE-INDEX NOW. {getattr(app.ctx, "solr_reindex", False)}")
         if getattr(app.ctx, "solr_reindex", False):
             logger.info("Creating solr reindex task, as required by migrations.")
             app.add_task(solr_reindex(dependency_manager.search_reprovisioning))

--- a/components/renku_data_services/search/reprovision.py
+++ b/components/renku_data_services/search/reprovision.py
@@ -102,6 +102,9 @@ class SearchReprovision:
             logger.info(f"Starting reprovisioning with ID {reprovisioning.id}")
             started = datetime.now()
             await self._search_updates_repo.clear_all()
+            if migrate_solr_schema:
+                await migrator.migrate(entity_schema.all_migrations)
+
             async with DefaultSolrClient(self._solr_config) as client:
                 res = await client.delete("_type:*")
                 if res.status_code != 200:
@@ -118,9 +121,6 @@ class SearchReprovision:
                             f"status code: {res.status_code}",
                             exc_info=False,
                         )
-
-            if migrate_solr_schema:
-                await migrator.migrate(entity_schema.all_migrations)
 
             all_users = self._user_repo.get_all_users(requested_by=admin)
             counter = await self.__update_entities(all_users, "user", started, counter, log_counter)

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -187,7 +187,7 @@ def public_only() -> SolrToken:
 
 def content_all(text: str) -> SolrToken:
     """Search the content_all field with fuzzy searching each term."""
-    terms: list[SolrToken] = list(map(lambda s: SolrToken(__escape_query(s) + "~"), re.split("\\s+", text)))
+    terms: list[SolrToken] = list(map(lambda s: SolrToken(__escape_query(s)), re.split("\\s+", text)))
     terms_str = "(" + " ".join(terms) + ")"
     return SolrToken(f"{Fields.content_all}:{terms_str}")
 

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -186,7 +186,7 @@ def public_only() -> SolrToken:
 
 def content_all(text: str) -> SolrToken:
     """Search the content_all field."""
-    terms_str = "(" + __escape_query(text) + "~)"
+    terms_str = "(" + __escape_query(text) + ")"
     return SolrToken(f"{Fields.content_all}:{terms_str}")
 
 

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -1,6 +1,5 @@
 """Model for creating solr lucene queries."""
 
-import re
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import NewType
@@ -186,9 +185,8 @@ def public_only() -> SolrToken:
 
 
 def content_all(text: str) -> SolrToken:
-    """Search the content_all field with fuzzy searching each term."""
-    terms: list[SolrToken] = list(map(lambda s: SolrToken(__escape_query(s)), re.split("\\s+", text)))
-    terms_str = "(" + " ".join(terms) + ")"
+    """Search the content_all field."""
+    terms_str = "(" + __escape_query(text) + "~)"
     return SolrToken(f"{Fields.content_all}:{terms_str}")
 
 

--- a/components/renku_data_services/solr/entity_schema.py
+++ b/components/renku_data_services/solr/entity_schema.py
@@ -60,10 +60,11 @@ class Analyzers:
     """A collection of analyzers."""
 
     text_index: Final[Analyzer] = Analyzer(
-        tokenizer=Tokenizers.uax29UrlEmail,
+        tokenizer=Tokenizers.whitespace,
         filters=[
+            Filters.word,
+            Filters.flattenGraph,
             Filters.lowercase,
-            Filters.stop,
             Filters.english_minimal_stem,
             Filters.ascii_folding,
             Filters.edgeNgram(2, 8, True),
@@ -71,10 +72,9 @@ class Analyzers:
     )
 
     text_query: Final[Analyzer] = Analyzer(
-        tokenizer=Tokenizers.uax29UrlEmail,
+        tokenizer=Tokenizers.whitespace,
         filters=[
             Filters.lowercase,
-            Filters.stop,
             Filters.english_minimal_stem,
             Filters.ascii_folding,
         ],
@@ -187,6 +187,11 @@ all_migrations: Final[list[SchemaMigration]] = [
         commands=[
             ReplaceCommand(Field.of(Fields.keywords, FieldTypes.keyword).make_multi_valued()),
         ],
+        requires_reindex=True,
+    ),
+    SchemaMigration(
+        version=15,
+        commands=[ReplaceCommand(FieldTypes.text), ReplaceCommand(FieldTypes.text_all)],
         requires_reindex=True,
     ),
 ]

--- a/components/renku_data_services/solr/solr_client.py
+++ b/components/renku_data_services/solr/solr_client.py
@@ -806,6 +806,6 @@ class DefaultSolrAdminClient(SolrAdminClient):
         """Reload a core with the given `core_name` or the name provided in the config object."""
         core = core_name or self.config.core
         return await self.delegate.post(
-            f"/v2/cores/{core}/reload",
+            f"/api/cores/{core}/reload",
             headers={"Content-Type": "application/json"},
         )

--- a/components/renku_data_services/solr/solr_schema.py
+++ b/components/renku_data_services/solr/solr_schema.py
@@ -80,6 +80,11 @@ class Filters:
     english_minimal_stem = Filter(name="englishMinimalStem")
     classic = Filter(name="classic")
     ngram = Filter(name="nGram")
+    flattenGraph = Filter(name="flattenGraph")
+    word = Filter(
+        name="wordDelimiterGraph",
+        settings={"splitOnCaseChange": "1", "catenateNumbers": "1", "catenateAll": "1", "preserveOriginal": "1"},
+    )
 
     @classmethod
     def edgeNgram(cls, min_gram_size: int = 3, maxGramSize: int = 6, preserve_original: bool = True) -> Filter:

--- a/components/renku_data_services/solr/solr_schema.py
+++ b/components/renku_data_services/solr/solr_schema.py
@@ -83,7 +83,13 @@ class Filters:
     flattenGraph = Filter(name="flattenGraph")
     word = Filter(
         name="wordDelimiterGraph",
-        settings={"splitOnCaseChange": "1", "catenateNumbers": "1", "catenateAll": "1", "preserveOriginal": "1"},
+        settings={
+            "splitOnCaseChange": "1",
+            "catenateNumbers": "1",
+            "catenateAll": "1",
+            "preserveOriginal": "1",
+            "splitOnNumerics": "0",
+        },
     )
 
     @classmethod

--- a/test/bases/renku_data_services/data_api/test_search_migrations.py
+++ b/test/bases/renku_data_services/data_api/test_search_migrations.py
@@ -81,10 +81,7 @@ def get_solr_schemas() -> Callable[[int | None], list[SchemaMigration]]:
 
 @pytest.mark.parametrize(
     ("start_solr_version", "end_solr_version"),
-    [
-        (12, 13),
-        (13, 14),
-    ],
+    [(12, 13), (13, 14), (14, 15)],
 )
 @pytest.mark.xdist_group("search")
 @pytest.mark.asyncio

--- a/test/components/renku_data_services/search/test_solr_token.py
+++ b/test/components/renku_data_services/search/test_solr_token.py
@@ -132,5 +132,5 @@ def test_created_by_exists() -> None:
 def test_content_all() -> None:
     assert st.content_all("abc") == "content_all:(abc~)"
     assert st.content_all("a+b+c") == "content_all:(a\\+b\\+c~)"
-    assert st.content_all("ab cd") == "content_all:(ab~ cd~)"
-    assert st.content_all("ab    cd") == "content_all:(ab~ cd~)"
+    assert st.content_all("ab cd") == "content_all:(ab\\ cd~)"
+    assert st.content_all("ab    cd") == "content_all:(ab\\ \\ \\ \\ cd~)"

--- a/test/components/renku_data_services/search/test_solr_token.py
+++ b/test/components/renku_data_services/search/test_solr_token.py
@@ -130,7 +130,7 @@ def test_created_by_exists() -> None:
 
 
 def test_content_all() -> None:
-    assert st.content_all("abc") == "content_all:(abc~)"
-    assert st.content_all("a+b+c") == "content_all:(a\\+b\\+c~)"
-    assert st.content_all("ab cd") == "content_all:(ab\\ cd~)"
-    assert st.content_all("ab    cd") == "content_all:(ab\\ \\ \\ \\ cd~)"
+    assert st.content_all("abc") == "content_all:(abc)"
+    assert st.content_all("a+b+c") == "content_all:(a\\+b\\+c)"
+    assert st.content_all("ab cd") == "content_all:(ab\\ cd)"
+    assert st.content_all("ab    cd") == "content_all:(ab\\ \\ \\ \\ cd)"


### PR DESCRIPTION
Changes the text fields `content_all`, `name` and `description` configuration. It uses a simple `whitespace` tokenizer and does the more complex splitting via the `wordDelimiterGraphFilter` ([docs](https://solr.apache.org/guide/solr/latest/indexing-guide/filters.html#word-delimiter-graph-filter)).

This adds more variants of concatenated and splitted phrases to the index (for example splits camelCase and hyphens but also includes the concatenated and original version).

While testing I noticed that the reindexing after a migration requiring it wouldn't happen anymore. I tried a lot of things but couldn't pass data from the `main_process_start` handler to the `after_server_start` handler - but only in the latter it is possible to submit tasks. This change now writes a temp file to communicate across these hooks.

/deploy extra-values=enableInternalGitlab=false
