### PR TITLE
feat: handle testing data connector with OAuth 2.0

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -115,7 +115,12 @@ def register_all_handlers(app: Sanic, dm: DependencyManager) -> Sanic:
         storage_repo=dm.storage_repo,
         authenticator=dm.gitlab_authenticator,
     )
-    storage_schema = StorageSchemaBP(name="storage_schema", url_prefix=url_prefix)
+    storage_schema = StorageSchemaBP(
+        name="storage_schema",
+        url_prefix=url_prefix,
+        data_source_repo=dm.data_source_repo,
+        authenticator=dm.authenticator,
+    )
     user_preferences = UserPreferencesBP(
         name="user_preferences",
         url_prefix=url_prefix,

--- a/components/renku_data_services/storage/rclone.py
+++ b/components/renku_data_services/storage/rclone.py
@@ -23,6 +23,8 @@ from renku_data_services.storage.rclone_patches import (
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from renku_data_services import base_models
+    from renku_data_services.notebooks.data_sources import DataSourceRepository
     from renku_data_services.storage.models import RCloneConfig
 
 
@@ -88,7 +90,11 @@ class RCloneValidator:
         return real_config
 
     async def test_connection(
-        self, configuration: Union[RCloneConfig, dict[str, Any]], source_path: str
+        self,
+        configuration: Union[RCloneConfig, dict[str, Any]],
+        source_path: str,
+        user: base_models.APIUser | None = None,
+        data_source_repo: DataSourceRepository | None = None,
     ) -> ConnectionResult:
         """Tests connecting with an RClone config."""
         try:
@@ -100,6 +106,14 @@ class RCloneValidator:
         obscured_config = await self.obscure_config(self.get_real_configuration(configuration))
         transformed_config = self.inject_default_values(self.transform_polybox_switchdriver_config(obscured_config))
         transformed_config = self.transform_envidat_config(transformed_config)
+
+        # Handle testing with Renku integrations
+        if user is not None and data_source_repo is not None:
+            with_oauth2_config = await data_source_repo.handle_configuration_for_test(
+                user=user, configuration=transformed_config
+            )
+            if with_oauth2_config is not None:
+                transformed_config = with_oauth2_config
 
         with tempfile.NamedTemporaryFile(mode="w+", delete=False, encoding="utf-8") as f:
             config = "\n".join(f"{k}={v}" for k, v in transformed_config.items())


### PR DESCRIPTION
Update the "testing" endpoint to allow users to test the rclone connection with storage type "google" and "dropbox" which use OAuth 2.0 credentials.

The updated code performs the same configuration tweaking as is done for sessions.

PR stack:
* (base) #1201
  * (this, tip) #1200