### PR TITLE
feat: build from private repositories

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -221,6 +221,7 @@ def register_all_handlers(app: Sanic, dm: DependencyManager) -> Sanic:
         session_repo=dm.session_repo,
         storage_repo=dm.storage_repo,
         user_repo=dm.kc_user_repo,
+        git_repositories_repo=dm.git_repositories_repo,
     )
     platform_config = PlatformConfigBP(
         name="platform_config",

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -291,7 +291,6 @@ class DependencyManager:
             )
             if config.builds.enabled:
                 k8s_db_cache = K8sDbCache(config.db.async_session_maker)
-                default_kubeconfig = KubeConfigEnv()
                 shipwright_client = ShipwrightClient(
                     client=K8sClusterClientsPool(
                         lambda: get_clusters(
@@ -342,12 +341,21 @@ class DependencyManager:
             group_repo=group_repo,
             search_updates_repo=search_updates_repo,
         )
+
+        git_repositories_repo = GitRepositoriesRepository(
+            session_maker=config.db.async_session_maker,
+            oauth_client_factory=oauth_http_client_factory,
+            internal_gitlab_url=config.gitlab_url,
+            enable_internal_gitlab=config.enable_internal_gitlab,
+        )
+
         session_repo = SessionRepository(
             session_maker=config.db.async_session_maker,
             project_authz=authz,
             resource_pools=rp_repo,
             shipwright_client=shipwright_client,
             builds_config=config.builds,
+            git_repositories_repo=git_repositories_repo,
         )
         project_migration_repo = ProjectMigrationRepository(
             session_maker=config.db.async_session_maker,
@@ -377,12 +385,6 @@ class DependencyManager:
             low_level_repo=low_level_user_secrets_repo,
             user_repo=kc_user_repo,
             secret_service_public_key=config.secrets.public_key,
-        )
-        git_repositories_repo = GitRepositoriesRepository(
-            session_maker=config.db.async_session_maker,
-            oauth_client_factory=oauth_http_client_factory,
-            internal_gitlab_url=config.gitlab_url,
-            enable_internal_gitlab=config.enable_internal_gitlab,
         )
         platform_repo = PlatformRepository(
             session_maker=config.db.async_session_maker,

--- a/components/renku_data_services/authn/dummy.py
+++ b/components/renku_data_services/authn/dummy.py
@@ -46,6 +46,7 @@ class DummyAuthenticator:
     async def authenticate(self, access_token: str, request: Request) -> base_models.APIUser:
         """Indicates whether the user has successfully logged in."""
         access_token = request.headers.get(self.token_field) or ""
+
         if not access_token or len(access_token) == 0:
             # Try to get an anonymous user ID if the validation of keycloak credentials failed
             anon_id = request.headers.get(self.anon_id_header_key)
@@ -60,23 +61,17 @@ class DummyAuthenticator:
         with contextlib.suppress(Exception):
             user_props = json.loads(access_token)
 
-        is_set = bool(
-            user_props.get("id")
-            or user_props.get("full_name")
-            or user_props.get("is_admin") is not None
-            or user_props.get("first_name")
-            or user_props.get("last_name")
-            or user_props.get("email")
-        )
+        if user_props.get("id") is None:
+            return base_models.APIUser()
 
         return base_models.AuthenticatedAPIUser(
             is_admin=user_props.get("is_admin", False),
-            id=user_props.get("id", "some-id") if is_set else "",
+            id=user_props.get("id", ""),
             access_token=access_token,
-            first_name=user_props.get("first_name", "John") if is_set else None,
-            last_name=user_props.get("last_name", "Doe") if is_set else None,
-            email=user_props.get("email", "john.doe@gmail.com") if is_set else "",
-            full_name=user_props.get("full_name", "John Doe") if is_set else None,
+            first_name=user_props.get("first_name"),
+            last_name=user_props.get("last_name"),
+            email=user_props.get("email", ""),
+            full_name=user_props.get("full_name"),
             refresh_token=request.headers.get("Renku-Auth-Refresh-Token"),
             roles=user_props.get("roles", []),
         )

--- a/components/renku_data_services/authn/dummy.py
+++ b/components/renku_data_services/authn/dummy.py
@@ -69,13 +69,13 @@ class DummyAuthenticator:
             or user_props.get("email")
         )
 
-        return base_models.APIUser(
+        return base_models.AuthenticatedAPIUser(
             is_admin=user_props.get("is_admin", False),
-            id=user_props.get("id", "some-id") if is_set else None,
+            id=user_props.get("id", "some-id") if is_set else "",
             access_token=access_token,
             first_name=user_props.get("first_name", "John") if is_set else None,
             last_name=user_props.get("last_name", "Doe") if is_set else None,
-            email=user_props.get("email", "john.doe@gmail.com") if is_set else None,
+            email=user_props.get("email", "john.doe@gmail.com") if is_set else "",
             full_name=user_props.get("full_name", "John Doe") if is_set else None,
             refresh_token=request.headers.get("Renku-Auth-Refresh-Token"),
             roles=user_props.get("roles", []),

--- a/components/renku_data_services/capacity_reservation/apispec_base.py
+++ b/components/renku_data_services/capacity_reservation/apispec_base.py
@@ -2,17 +2,17 @@
 
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    # Enables orm mode for pydantic.
+    model_config = ConfigDict(
+        from_attributes=True,
+    )
 
     @field_validator("*", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/connected_services/apispec_base.py
+++ b/components/renku_data_services/connected_services/apispec_base.py
@@ -1,19 +1,19 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from ulid import ULID
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )
 
     @field_validator("id", mode="before", check_fields=False)
     @classmethod
@@ -25,10 +25,7 @@ class BaseAPISpec(BaseModel):
 class AuthorizeParams(BaseAPISpec):
     """The schema for the query parameters used in the authorize request."""
 
-    class Config:
-        """Configuration."""
-
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
     next_url: str = Field(default="")
 
@@ -36,9 +33,6 @@ class AuthorizeParams(BaseAPISpec):
 class CallbackParams(BaseAPISpec):
     """The schema for the query parameters used in the authorize callback request."""
 
-    class Config:
-        """Configuration."""
-
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
     state: str = Field(default="")

--- a/components/renku_data_services/crc/apispec.py
+++ b/components/renku_data_services/crc/apispec.py
@@ -250,6 +250,8 @@ class UsersUserIdResourcePoolsGetParametersQuery(BaseAPISpec):
     user_resource_params: Optional[UserResourceParams] = None
 
 
+config_name_pattern = r"^[a-zA-Z0-9._-]+(\.yaml)?$"
+
 class Cluster(BaseAPISpec):
     model_config = ConfigDict(
         extra="forbid",
@@ -264,7 +266,7 @@ class Cluster(BaseAPISpec):
         ...,
         description="The name of the Kubernetes configuration to use to connect to the remote cluster. This is currently used to find a file named `<KubeConfigRoot>/<config_name>`.\n\nThis configuration is expected to have a default namespace defined. It will be used for all remote operations requiring a namespace, as well for namespaced objects.\n",
         examples=["a-remote-cluster.yaml"],
-        pattern="^[a-zA-Z0-9._-]+[.]yaml$",
+        pattern=config_name_pattern,
     )
     session_protocol: Protocol
     session_host: str = Field(
@@ -301,7 +303,7 @@ class ClusterPatch(BaseAPISpec):
         None,
         description="The name of the Kubernetes configuration to use to connect to the remote cluster. This is currently used to find a file named `<KubeConfigRoot>/<config_name>`.\n\nThis configuration is expected to have a default namespace defined. It will be used for all remote operations requiring a namespace, as well for namespaced objects.\n",
         examples=["a-remote-cluster.yaml"],
-        pattern="^[a-zA-Z0-9._-]+[.]yaml$",
+        pattern=config_name_pattern,
     )
     session_protocol: Optional[Protocol] = None
     session_host: Optional[str] = Field(
@@ -338,7 +340,7 @@ class ClusterWithId(BaseAPISpec):
         ...,
         description="The name of the Kubernetes configuration to use to connect to the remote cluster. This is currently used to find a file named `<KubeConfigRoot>/<config_name>`.\n\nThis configuration is expected to have a default namespace defined. It will be used for all remote operations requiring a namespace, as well for namespaced objects.\n",
         examples=["a-remote-cluster.yaml"],
-        pattern="^[a-zA-Z0-9._-]+[.]yaml$",
+        pattern=config_name_pattern,
     )
     id: str = Field(
         ...,

--- a/components/renku_data_services/crc/apispec_base.py
+++ b/components/renku_data_services/crc/apispec_base.py
@@ -3,7 +3,7 @@
 from pathlib import PurePosixPath
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 from renku_data_services.session import models
@@ -12,10 +12,10 @@ from renku_data_services.session import models
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    # Enables orm mode for pydantic.
+    model_config = ConfigDict(
+        from_attributes=True,
+    )
 
     @field_validator("*", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/crc/server_options.py
+++ b/components/renku_data_services/crc/server_options.py
@@ -8,7 +8,7 @@ is added.
 from collections.abc import Generator
 from typing import Any, Union
 
-from pydantic import BaseModel, ByteSize, Field, validator
+from pydantic import BaseModel, ByteSize, ConfigDict, Field, validator
 
 from renku_data_services.crc import models
 from renku_data_services.crc.constants import DEFAULT_RUNTIME_PLATFORM
@@ -28,17 +28,13 @@ class ServerOptionsDefaults(BaseModel):
     disk_request: ByteSize
     gpu_request: int = Field(ge=0, default=0)
 
-    class Config:
-        """Configuration."""
-
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
 
 class _ServerOptionsCpu(BaseModel):
     options: list[float] = Field(min_length=1)
 
-    class Config:
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
     @validator("options", pre=False, each_item=True)
     def greater_than_zero(cls, val: Union[float, int]) -> Union[float, int]:
@@ -61,8 +57,7 @@ class _ServerOptionsGpu(BaseModel):
 class _ServerOptionsBytes(BaseModel):
     options: list[ByteSize] = Field(min_length=1)
 
-    class Config:
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
     @validator("options", pre=True)
     def convert_units(cls, vals: list[str]) -> list[str]:
@@ -84,10 +79,7 @@ class ServerOptions(BaseModel):
     disk_request: _ServerOptionsBytes
     gpu_request: _ServerOptionsGpu = Field(default_factory=lambda: _ServerOptionsGpu(options=[0]))
 
-    class Config:
-        """Configuration."""
-
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
     def find_largest_attribute(self) -> str:
         """Find the attribute with the largest number of choices."""

--- a/components/renku_data_services/data_connectors/apispec_base.py
+++ b/components/renku_data_services/data_connectors/apispec_base.py
@@ -1,19 +1,19 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )
 
     @field_validator("id", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/k8s/clients.py
+++ b/components/renku_data_services/k8s/clients.py
@@ -342,11 +342,22 @@ class K8sCachedClusterClient(K8sClusterClient):
 
     async def create(self, obj: K8sObject, refresh: bool) -> K8sObject:
         """Create the k8s object."""
-        if obj.gvk in self.__kinds_to_cache and not obj.namespaced():
-            raise NotImplementedError("Caching of cluster scoped K8s resources is not supported")
-        obj = await super().create(obj, refresh)
         if obj.gvk in self.__kinds_to_cache:
+            if not obj.namespaced():
+                raise NotImplementedError("Caching of cluster scoped K8s resources is not supported")
             await self.__cache.upsert(obj)
+
+        try:
+            obj = await super().create(obj, refresh)
+        except:
+            # if there was an error creating the k8s object, we delete it from the db again to not have ghost entries
+            if obj.gvk in self.__kinds_to_cache:
+                await self.__cache.delete(obj)
+            raise
+
+        if refresh and obj.gvk in self.__kinds_to_cache:
+            await self.__cache.upsert(obj)
+
         return obj
 
     async def patch(self, meta: K8sObjectMeta, patch: K8sPatches) -> K8sObject:

--- a/components/renku_data_services/k8s/clients.py
+++ b/components/renku_data_services/k8s/clients.py
@@ -342,17 +342,11 @@ class K8sCachedClusterClient(K8sClusterClient):
 
     async def create(self, obj: K8sObject, refresh: bool) -> K8sObject:
         """Create the k8s object."""
+        if obj.gvk in self.__kinds_to_cache and not obj.namespaced():
+            raise NotImplementedError("Caching of cluster scoped K8s resources is not supported")
+        obj = await super().create(obj, refresh)
         if obj.gvk in self.__kinds_to_cache:
-            if not obj.namespaced():
-                raise NotImplementedError("Caching of cluster scoped K8s resources is not supported")
             await self.__cache.upsert(obj)
-        try:
-            obj = await super().create(obj, refresh)
-        except:
-            # if there was an error creating the k8s object, we delete it from the db again to not have ghost entries
-            if obj.gvk in self.__kinds_to_cache:
-                await self.__cache.delete(obj)
-            raise
         return obj
 
     async def patch(self, meta: K8sObjectMeta, patch: K8sPatches) -> K8sObject:

--- a/components/renku_data_services/namespace/apispec_base.py
+++ b/components/renku_data_services/namespace/apispec_base.py
@@ -1,7 +1,7 @@
 """Base models for API specifications."""
 
 import pydantic
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 # NOTE: We are monkeypatching the regex engine for the root model because
@@ -15,13 +15,13 @@ pydantic.RootModel.model_config = {"regex_engine": "python-re"}
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )
 
     @field_validator("id", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/namespace/apispec_enhanced.py
+++ b/components/renku_data_services/namespace/apispec_enhanced.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pydantic import field_validator
+from pydantic import ConfigDict, field_validator
 
 from renku_data_services.namespace.apispec import GroupsGetParametersQuery as _GroupsGetParametersQuery
 from renku_data_services.namespace.apispec import NamespacesGetParametersQuery as _NamespacesGetParametersQuery
@@ -11,10 +11,7 @@ from renku_data_services.namespace.apispec import NamespacesGetParametersQuery a
 class NamespacesGetParametersQuery(_NamespacesGetParametersQuery):
     """The query parameters for listing namespaces."""
 
-    class Config(_NamespacesGetParametersQuery.Config):
-        """Pydantic configuration."""
-
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid") | _NamespacesGetParametersQuery.model_config
 
     @field_validator("kinds", mode="before")
     @classmethod
@@ -27,7 +24,4 @@ class NamespacesGetParametersQuery(_NamespacesGetParametersQuery):
 class GroupsGetParametersQuery(_GroupsGetParametersQuery):
     """The query parameters for listing groups."""
 
-    class Config(_GroupsGetParametersQuery.Config):
-        """Pydantic configuration."""
-
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid") | _GroupsGetParametersQuery.model_config

--- a/components/renku_data_services/notebooks/apispec_base.py
+++ b/components/renku_data_services/notebooks/apispec_base.py
@@ -1,15 +1,15 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -31,6 +31,7 @@ from renku_data_services.notebooks.core_sessions import (
 from renku_data_services.notebooks.data_sources import DataSourceRepository
 from renku_data_services.notebooks.image_check import ImageCheckRepository
 from renku_data_services.project.db import ProjectRepository, ProjectSessionSecretRepository
+from renku_data_services.repositories.db import GitRepositoriesRepository
 from renku_data_services.session.db import SessionRepository
 from renku_data_services.storage.db import StorageRepository
 from renku_data_services.users.db import UserRepo
@@ -59,6 +60,7 @@ class NotebooksNewBP(CustomBlueprint):
     storage_repo: StorageRepository
     user_repo: UserRepo
     metrics: MetricsService
+    git_repositories_repo: GitRepositoriesRepository
 
     def start(self) -> BlueprintFactoryResponse:
         """Start a session with the new operator."""
@@ -89,6 +91,7 @@ class NotebooksNewBP(CustomBlueprint):
                 metrics=self.metrics,
                 image_check_repo=self.image_check_repo,
                 data_source_repo=self.data_source_repo,
+                git_repositories_repo=self.git_repositories_repo,
             )
             status = 201 if created else 200
             return json(session.as_apispec().model_dump(exclude_none=True, mode="json"), status)

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -103,6 +103,8 @@ from renku_data_services.notebooks.utils import (
 )
 from renku_data_services.project.db import ProjectRepository, ProjectSessionSecretRepository
 from renku_data_services.project.models import Project, SessionSecret
+from renku_data_services.repositories.db import GitRepositoriesRepository
+from renku_data_services.repositories.models import Metadata as RepoMetadata
 from renku_data_services.session.db import SessionRepository
 from renku_data_services.session.models import SessionLauncher
 from renku_data_services.users.db import UserRepo
@@ -737,6 +739,7 @@ async def start_session(
     metrics: MetricsService,
     image_check_repo: ImageCheckRepository,
     data_source_repo: DataSourceRepository,
+    git_repositories_repo: GitRepositoriesRepository,
 ) -> tuple[AmaltheaSessionV1Alpha1, bool]:
     """Start an Amalthea session.
 
@@ -802,6 +805,16 @@ async def start_session(
         build_repository = environment.build_parameters.repository
         if build_repository not in [repository.url for repository in repositories]:
             raise errors.ValidationError(message="Image was not built from a repository in this project")
+
+        repo_data = await git_repositories_repo.get_repository(
+            repository_url=build_repository, user=user, etag=None, internal_gitlab_user=internal_gitlab_user
+        )
+        if repo_data.is_error:
+            raise errors.ValidationError(message=str(repo_data.error))
+        if isinstance(repo_data.metadata, RepoMetadata):
+            metadata: RepoMetadata = repo_data.metadata
+            if not metadata.pull_permission:
+                raise errors.ValidationError(message="User does not have access to image repository")
 
     # User secrets
     session_extras = SessionExtraResources()

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -798,6 +798,11 @@ async def start_session(
     git_providers = await git_provider_helper.get_providers(user=user)
     repositories = repositories_from_project(project, git_providers)
 
+    if environment.build_parameters is not None:
+        build_repository = environment.build_parameters.repository
+        if build_repository not in [repository.url for repository in repositories]:
+            raise errors.ValidationError(message="Image was not built from a repository in this project")
+
     # User secrets
     session_extras = SessionExtraResources()
     session_extras = session_extras.concat(

--- a/components/renku_data_services/notebooks/cr_base.py
+++ b/components/renku_data_services/notebooks/cr_base.py
@@ -1,12 +1,9 @@
 """Base models for K8s CRD specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseCRD(BaseModel):
     """Base CRD specification."""
 
-    class Config:
-        """Do not exclude unknown properties."""
-
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")

--- a/components/renku_data_services/notebooks/crs.py
+++ b/components/renku_data_services/notebooks/crs.py
@@ -10,7 +10,7 @@ from urllib.parse import urlunparse
 
 from kubernetes.utils import parse_duration, parse_quantity
 from kubernetes.utils.duration import format_duration
-from pydantic import BaseModel, Field, field_serializer, field_validator, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_serializer
 from pydantic.types import HashableItemType
 from ulid import ULID
 
@@ -86,10 +86,7 @@ from renku_data_services.notebooks.cr_base import BaseCRD
 class Metadata(BaseModel):
     """Basic k8s metadata spec."""
 
-    class Config:
-        """Do not exclude unknown properties."""
-
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
     name: str
     namespace: str | None = None

--- a/components/renku_data_services/notebooks/models.py
+++ b/components/renku_data_services/notebooks/models.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from kubernetes.client import V1ObjectMeta, V1Secret
-from pydantic import AliasGenerator, BaseModel, Field, Json
+from pydantic import AliasGenerator, BaseModel, ConfigDict, Field, Json
 from ulid import ULID
 
 from renku_data_services.data_connectors.models import DataConnectorSecret
@@ -40,11 +40,12 @@ class SessionUserSecrets:
 
 
 class _AmaltheaSessionAnnotations(BaseModel):
-    class Config:
-        extra = "allow"
-        alias_generator = AliasGenerator(
+    model_config = ConfigDict(
+        extra="allow",
+        alias_generator=AliasGenerator(
             alias=lambda field_name: f"renku.io/{field_name}",
-        )
+        ),
+    )
 
     session_launcher_id: str | None = None
     project_id: str | None = None
@@ -54,8 +55,7 @@ class _AmaltheaSessionAnnotations(BaseModel):
 
 
 class _MetadataValidation(BaseModel):
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
     name: str
     annotations: _AmaltheaSessionAnnotations

--- a/components/renku_data_services/notebooks/oci/base_model.py
+++ b/components/renku_data_services/notebooks/oci/base_model.py
@@ -1,15 +1,15 @@
 """Base model for generated classes."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseOciModel(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )

--- a/components/renku_data_services/notifications/apispec_base.py
+++ b/components/renku_data_services/notifications/apispec_base.py
@@ -2,17 +2,17 @@
 
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
+    )
 
     @field_validator("*", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/platform/apispec_base.py
+++ b/components/renku_data_services/platform/apispec_base.py
@@ -1,15 +1,15 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )

--- a/components/renku_data_services/project/apispec_base.py
+++ b/components/renku_data_services/project/apispec_base.py
@@ -2,20 +2,20 @@
 
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )
 
     @field_validator("*", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/repositories/apispec_base.py
+++ b/components/renku_data_services/repositories/apispec_base.py
@@ -2,20 +2,20 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field, HttpUrl, field_validator
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 from ulid import ULID
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
         # NOTE: By default the pydantic library does not use python for regex but a rust crate
         # this rust crate does not support lookahead regex syntax but we need it in this component
-        regex_engine = "python-re"
+        regex_engine="python-re",
+    )
 
     @field_validator("*", mode="before", check_fields=False)
     @classmethod
@@ -29,9 +29,6 @@ class BaseAPISpec(BaseModel):
 class RepositoryParams(BaseAPISpec):
     """The schema for the path parameters used in the repository requests."""
 
-    class Config:
-        """Configuration."""
-
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
     repository_url: HttpUrl = Field(...)

--- a/components/renku_data_services/repositories/db.py
+++ b/components/renku_data_services/repositories/db.py
@@ -1,7 +1,7 @@
 """Adapters for repositories database classes."""
 
 from collections.abc import Callable
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 import pydantic
@@ -53,6 +53,23 @@ class GitRepositoriesRepository:
             not github_type or github_type == GitHubProviderType.standard_app
         )
 
+    async def get_token(self, repository_url: str, user: base_models.APIUser) -> dict[str, Any] | None:
+        """Get token for repository provider."""
+        match GitUrl.parse(repository_url):
+            case GitUrlError():
+                return None
+            case url:
+                valid_url = url
+
+        provider = await self._find_client(valid_url)
+        if provider is None:
+            return None
+        connection = await self._find_connection(user, provider)
+        if connection is None:
+            return None
+        oauth_client = await self.oauth_client_factory.for_user_connection_raise(user, connection.id)
+        return await oauth_client.get_token()
+
     async def get_repository(
         self,
         repository_url: str,
@@ -61,6 +78,7 @@ class GitRepositoriesRepository:
         internal_gitlab_user: base_models.APIUser,
     ) -> models.RepositoryDataResult:
         """Get metadata about one repository."""
+
         match GitUrl.parse(repository_url):
             case GitUrlError() as err:
                 return models.RepositoryDataResult(error=err)

--- a/components/renku_data_services/resource_usage/apispec_base.py
+++ b/components/renku_data_services/resource_usage/apispec_base.py
@@ -1,12 +1,12 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
+    )

--- a/components/renku_data_services/search/apispec_base.py
+++ b/components/renku_data_services/search/apispec_base.py
@@ -1,12 +1,11 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+    )

--- a/components/renku_data_services/secrets/apispec_base.py
+++ b/components/renku_data_services/secrets/apispec_base.py
@@ -1,12 +1,12 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
+    )

--- a/components/renku_data_services/session/apispec_base.py
+++ b/components/renku_data_services/session/apispec_base.py
@@ -3,7 +3,7 @@
 from pathlib import PurePosixPath
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 from renku_data_services.session import models
@@ -12,10 +12,10 @@ from renku_data_services.session import models
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
+    )
 
     @field_validator("*", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/session/config.py
+++ b/components/renku_data_services/session/config.py
@@ -30,6 +30,7 @@ class BuildsConfig:
 
     enabled: bool = False
     build_output_image_prefix: str | None = None
+    build_output_private_image_prefix: str | None = None
     build_builder_image: str | None = None
     build_run_image: str | None = None
     build_strategy_name: str | None = None
@@ -46,6 +47,7 @@ class BuildsConfig:
         """Create a config from environment variables."""
         enabled = os.environ.get("IMAGE_BUILDERS_ENABLED", "false").lower() == "true"
         build_output_image_prefix = os.environ.get("BUILD_OUTPUT_IMAGE_PREFIX")
+        build_output_private_image_prefix = os.environ.get("BUILD_OUTPUT_PRIVATE_IMAGE_PREFIX")
         build_builder_image = os.environ.get("BUILD_BUILDER_IMAGE")
         build_run_image = os.environ.get("BUILD_RUN_IMAGE")
         build_strategy_name = os.environ.get("BUILD_STRATEGY_NAME")
@@ -116,6 +118,7 @@ class BuildsConfig:
         return cls(
             enabled=enabled or False,
             build_output_image_prefix=build_output_image_prefix or None,
+            build_output_private_image_prefix=build_output_private_image_prefix or None,
             build_builder_image=build_builder_image,
             build_run_image=build_run_image,
             build_strategy_name=build_strategy_name or None,

--- a/components/renku_data_services/session/config.py
+++ b/components/renku_data_services/session/config.py
@@ -36,6 +36,7 @@ class BuildsConfig:
     build_strategy_name: str | None = None
     build_platform_overrides: dict[str, BuildPlatformOverrides] | None = None
     push_secret_name: str | None = None
+    push_private_secret_name: str | None = None
     buildrun_retention_after_failed: timedelta | None = None
     buildrun_retention_after_succeeded: timedelta | None = None
     buildrun_build_timeout: timedelta | None = None
@@ -52,6 +53,7 @@ class BuildsConfig:
         build_run_image = os.environ.get("BUILD_RUN_IMAGE")
         build_strategy_name = os.environ.get("BUILD_STRATEGY_NAME")
         push_secret_name = os.environ.get("BUILD_PUSH_SECRET_NAME")
+        push_private_secret_name = os.environ.get("BUILD_PUSH_PRIVATE_SECRET_NAME")
         buildrun_retention_after_failed_seconds = int(os.environ.get("BUILD_RUN_RETENTION_AFTER_FAILED_SECONDS") or "0")
         buildrun_retention_after_failed = (
             timedelta(seconds=buildrun_retention_after_failed_seconds)
@@ -124,6 +126,7 @@ class BuildsConfig:
             build_strategy_name=build_strategy_name or None,
             build_platform_overrides=build_platform_overrides,
             push_secret_name=push_secret_name or None,
+            push_private_secret_name=push_private_secret_name or None,
             buildrun_retention_after_failed=buildrun_retention_after_failed,
             buildrun_retention_after_succeeded=buildrun_retention_after_succeeded,
             buildrun_build_timeout=buildrun_build_timeout,

--- a/components/renku_data_services/session/constants.py
+++ b/components/renku_data_services/session/constants.py
@@ -36,6 +36,9 @@ BUILD_DEFAULT_BUILD_STRATEGY_NAME: Final[str] = "renku-buildpacks-v3"
 BUILD_DEFAULT_PUSH_SECRET_NAME: Final[str] = "renku-build-secret"
 """The name of the default secret to use when pushing Renku builds."""
 
+BUILD_DEFAULT_PUSH_PRIVATE_SECRET_NAME: Final[str] = "renku-build-private-secret"
+"""The name of the default secret to use when pushing Renku builds to the private image registry."""
+
 BUILD_RUN_DEFAULT_RETENTION_AFTER_FAILED: Final[timedelta] = timedelta(minutes=5)
 """The default retention TTL for BuildRuns when in failed state."""
 

--- a/components/renku_data_services/session/constants.py
+++ b/components/renku_data_services/session/constants.py
@@ -11,6 +11,9 @@ from renku_data_services.k8s.models import GVK
 BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX: Final[str] = "harbor.dev.renku.ch/renku-builds/"
 """The default container image prefix for Renku builds."""
 
+BUILD_DEFAULT_OUTPUT_PRIVATE_IMAGE_PREFIX: Final[str] = "harbor.dev.renku.ch/renku-builds-private/"
+"""The default container image prefix for Renku private builds."""
+
 BUILD_OUTPUT_IMAGE_NAME: Final[str] = "renku-build"
 """The container image name created from Renku builds."""
 

--- a/components/renku_data_services/session/constants.py
+++ b/components/renku_data_services/session/constants.py
@@ -27,7 +27,7 @@ BUILD_URL_PATH_MAP: Final[dict[str, str]] = {
     "jupyterlab": "/lab",
 }
 
-BUILD_DEFAULT_BUILD_STRATEGY_NAME: Final[str] = "renku-buildpacks-v2"
+BUILD_DEFAULT_BUILD_STRATEGY_NAME: Final[str] = "renku-buildpacks-v3"
 """The name of the default build strategy."""
 
 BUILD_DEFAULT_PUSH_SECRET_NAME: Final[str] = "renku-build-secret"

--- a/components/renku_data_services/session/cr_base.py
+++ b/components/renku_data_services/session/cr_base.py
@@ -1,12 +1,12 @@
 """Base models for K8s CRD specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseCRD(BaseModel):
     """Base CRD specification."""
 
-    class Config:
-        """Do not exclude unknown properties."""
-
-        extra = "allow"
+    model_config = ConfigDict(
+        # Do not exclude unknown properties.
+        extra="allow"
+    )

--- a/components/renku_data_services/session/crs.py
+++ b/components/renku_data_services/session/crs.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 from renku_data_services.session.cr_shipwright_buildrun import Build, Git, ParamValue, Strategy, Toleration
 from renku_data_services.session.cr_shipwright_buildrun import Model as _BuildRun
@@ -17,10 +17,10 @@ from renku_data_services.session.cr_tekton_taskrun import TaskRunBase as _TaskRu
 class Metadata(BaseModel):
     """Basic k8s metadata spec."""
 
-    class Config:
-        """Do not exclude unknown properties."""
-
-        extra = "allow"
+    model_config = ConfigDict(
+        # Do not exclude unknown properties.
+        extra="allow",
+    )
 
     name: str
     namespace: str | None = None

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -18,6 +18,8 @@ from renku_data_services.authz.authz import Authz, ResourceType
 from renku_data_services.authz.models import Scope
 from renku_data_services.base_models.core import RESET
 from renku_data_services.crc.db import ResourcePoolRepository
+from renku_data_services.repositories.db import GitRepositoriesRepository
+from renku_data_services.repositories.models import RepositoryVisibility
 from renku_data_services.session import constants, models
 from renku_data_services.session import orm as schemas
 from renku_data_services.session.k8s_client import ShipwrightClient
@@ -52,12 +54,14 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
         resource_pools: ResourcePoolRepository,
         shipwright_client: ShipwrightClient | None,
         builds_config: BuildsConfig,
+        git_repositories_repo: GitRepositoriesRepository,
     ) -> None:
         self.session_maker = session_maker
         self.project_authz: Authz = project_authz
         self.resource_pools: ResourcePoolRepository = resource_pools
         self.shipwright_client = shipwright_client
         self.builds_config = builds_config
+        self.git_repositories_repo = git_repositories_repo
 
     async def get_environments(self, include_archived: bool = False) -> list[models.Environment]:
         """Get all global session environments from the database."""
@@ -937,7 +941,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
         launcher = launcher_orm.dump() if launcher_orm is not None else None
 
         if self.shipwright_client is not None:
-            params = self._get_buildrun_params(
+            params = await self._get_buildrun_params(
                 user=user, build=result, build_parameters=build_parameters, launcher=launcher
             )
             await self.shipwright_client.create_image_build(params=params, user_id=user.id)
@@ -1078,7 +1082,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
         await session.flush()
         await session.refresh(build)
 
-    def _get_buildrun_params(
+    async def _get_buildrun_params(
         self,
         user: base_models.APIUser,
         build: models.Build,
@@ -1130,6 +1134,24 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             annotations["renku.io/launcher_id"] = str(launcher.id)
             annotations["renku.io/project_id"] = str(launcher.project_id)
 
+        result = await self.git_repositories_repo.get_repository(
+            repository_url=git_repository,
+            user=user,
+            etag=None,
+            internal_gitlab_user=base_models.APIUser(),
+        )
+
+        if result.is_error:
+            raise errors.CannotStartBuildError(message=str(result.error))
+
+        authentication_secret: models.AuthenticationSecret | None = None
+        if result.metadata.visibility.value == RepositoryVisibility.private:
+            token = await self.git_repositories_repo.get_token(repository_url=git_repository, user=user)
+            authentication_secret = models.AuthenticationSecret(
+                username="token",
+                password=token.get("access_token", None),
+            )
+
         params = models.ShipwrightBuildRunParams(
             name=build.k8s_name,
             git_repository=git_repository,
@@ -1138,6 +1160,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             output_image=output_image,
             build_strategy_name=build_strategy_name,
             push_secret_name=push_secret_name,
+            authentication_secret=authentication_secret,
             retention_after_failed=retention_after_failed,
             retention_after_succeeded=retention_after_succeeded,
             build_timeout=build_timeout,

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager, nullcontext
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,7 +19,7 @@ from renku_data_services.authz.models import Scope
 from renku_data_services.base_models.core import RESET
 from renku_data_services.crc.db import ResourcePoolRepository
 from renku_data_services.repositories.db import GitRepositoriesRepository
-from renku_data_services.repositories.models import RepositoryVisibility
+from renku_data_services.repositories.models import Metadata, RepositoryVisibility
 from renku_data_services.session import constants, models
 from renku_data_services.session import orm as schemas
 from renku_data_services.session.k8s_client import ShipwrightClient
@@ -1142,11 +1142,17 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             self.builds_config.build_output_image_prefix or constants.BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX
         )
 
-        if result.metadata.visibility.value == RepositoryVisibility.private:
-            token = await self.git_repositories_repo.get_token(repository_url=git_repository, user=user)
+        visibility: RepositoryVisibility = RepositoryVisibility.public
+        if isinstance(result.metadata, Metadata):
+            visibility = result.metadata.visibility
+
+        if visibility == RepositoryVisibility.private:
+            token: dict[str, Any] | None = await self.git_repositories_repo.get_token(
+                repository_url=git_repository, user=user
+            )
             authentication_secret = models.AuthenticationSecret(
                 username="token",
-                password=token.get("access_token", None),
+                password=token.get("access_token", "") if token is not None else "",
             )
 
             output_image_prefix = (

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -1217,14 +1217,15 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
         project_authz: Authz,
     ) -> SessionEnvironmentRepositoryProtocol:
         """Create an instance of SessionEnvironmentRepositoryProtocol."""
-        # NOTE: resource_pools, shipwright_client and builds_config are set to None
-        # because the SessionEnvironmentRepositoryProtocol only exposes database
-        # operations for session environments.
+        # NOTE: resource_pools, shipwright_client, builds_config and git_repositories_repo
+        # are set to None because the SessionEnvironmentRepositoryProtocol only
+        # exposes database operations for session environments.
         instance = cls(
             session_maker,
             project_authz=project_authz,
             resource_pools=None,  # type: ignore
             shipwright_client=None,
             builds_config=None,  # type: ignore
+            git_repositories_repo=None,  # type: ignore
         )
         return instance

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -1100,13 +1100,6 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
         builder_image = self.builds_config.build_builder_image or constants.BUILD_DEFAULT_BUILDER_IMAGE
         run_image = self.builds_config.build_run_image or constants.BUILD_DEFAULT_RUN_IMAGE
 
-        output_image_prefix = (
-            self.builds_config.build_output_image_prefix or constants.BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX
-        )
-        output_image_name = constants.BUILD_OUTPUT_IMAGE_NAME
-        output_image_tag = build.k8s_name
-        output_image = f"{output_image_prefix}{output_image_name}:{output_image_tag}"
-
         # TODO: define the build strategy from `build_parameters`
         build_strategy_name = self.builds_config.build_strategy_name or constants.BUILD_DEFAULT_BUILD_STRATEGY_NAME
         push_secret_name = self.builds_config.push_secret_name or constants.BUILD_DEFAULT_PUSH_SECRET_NAME
@@ -1145,12 +1138,25 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             raise errors.CannotStartBuildError(message=str(result.error))
 
         authentication_secret: models.AuthenticationSecret | None = None
+        output_image_prefix = (
+            self.builds_config.build_output_image_prefix or constants.BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX
+        )
+
         if result.metadata.visibility.value == RepositoryVisibility.private:
             token = await self.git_repositories_repo.get_token(repository_url=git_repository, user=user)
             authentication_secret = models.AuthenticationSecret(
                 username="token",
                 password=token.get("access_token", None),
             )
+
+            output_image_prefix = (
+                self.builds_config.build_output_private_image_prefix
+                or constants.BUILD_DEFAULT_OUTPUT_PRIVATE_IMAGE_PREFIX
+            )
+
+        output_image_name = constants.BUILD_OUTPUT_IMAGE_NAME
+        output_image_tag = build.k8s_name
+        output_image = f"{output_image_prefix}{output_image_name}:{output_image_tag}"
 
         params = models.ShipwrightBuildRunParams(
             name=build.k8s_name,

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -1102,7 +1102,6 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
 
         # TODO: define the build strategy from `build_parameters`
         build_strategy_name = self.builds_config.build_strategy_name or constants.BUILD_DEFAULT_BUILD_STRATEGY_NAME
-        push_secret_name = self.builds_config.push_secret_name or constants.BUILD_DEFAULT_PUSH_SECRET_NAME
 
         node_selector = self.builds_config.node_selector
         tolerations = self.builds_config.tolerations
@@ -1141,6 +1140,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
         output_image_prefix = (
             self.builds_config.build_output_image_prefix or constants.BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX
         )
+        push_secret_name = self.builds_config.push_secret_name or constants.BUILD_DEFAULT_PUSH_SECRET_NAME
 
         visibility: RepositoryVisibility = RepositoryVisibility.public
         if isinstance(result.metadata, Metadata):
@@ -1158,6 +1158,10 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             output_image_prefix = (
                 self.builds_config.build_output_private_image_prefix
                 or constants.BUILD_DEFAULT_OUTPUT_PRIVATE_IMAGE_PREFIX
+            )
+
+            push_secret_name = (
+                self.builds_config.push_private_secret_name or constants.BUILD_DEFAULT_PUSH_PRIVATE_SECRET_NAME
             )
 
         output_image_name = constants.BUILD_OUTPUT_IMAGE_NAME

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -176,6 +176,7 @@ class ShipwrightClient:
                 "metadata": {
                     "name": metadata.name,
                     "labels": metadata.labels,
+                    "annotations": {"build.shipwright.io/referenced.secret": "true"},
                 },
                 "stringData": params.authentication_secret.to_string_data(),
             }

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -4,13 +4,15 @@ from collections.abc import AsyncIterable
 from typing import TYPE_CHECKING
 
 import httpx
+from box import Box
 from kr8s import NotFoundError, ServerError
 from kr8s.asyncio.objects import APIObject, Pod
 
 from renku_data_services import errors
 from renku_data_services.errors.errors import CannotStartBuildError
+from renku_data_services.k8s.clients import K8sSecretClient
 from renku_data_services.k8s.constants import ClusterId
-from renku_data_services.k8s.models import GVK, K8sObjectFilter, K8sObjectMeta
+from renku_data_services.k8s.models import GVK, K8sObjectFilter, K8sObjectMeta, K8sSecret
 from renku_data_services.notebooks.api.classes.k8s_client import DEFAULT_K8S_CLUSTER
 from renku_data_services.notebooks.util.retries import retry_with_exponential_backoff_async
 from renku_data_services.session import crs, models
@@ -63,6 +65,7 @@ class ShipwrightClient:
         namespace: str,
     ) -> None:
         self.client = client
+        self.secret_client = K8sSecretClient(client)
         self.namespace = namespace
 
     @staticmethod
@@ -105,13 +108,14 @@ class ShipwrightClient:
                 gvk=BUILD_RUN_GVK,
                 user_id=user_id,
             ).with_manifest(manifest=manifest.model_dump(exclude_none=True, mode="json")),
-            refresh=False,
+            refresh=True,
         )
         build_resource = await retry_with_exponential_backoff_async(lambda x: x is None)(self.get_build_run)(
             build_run_name, user_id
         )
         if build_resource is None:
             raise CannotStartBuildError(message=f"Cannot create the image build {build_run_name}")
+
         return build_resource
 
     async def delete_build_run(self, name: str, user_id: str) -> None:
@@ -166,6 +170,25 @@ class ShipwrightClient:
         if params.labels:
             metadata.labels = params.labels
 
+        secret: K8sSecret | None = None
+        if params.authentication_secret is not None:
+            manifest = {
+                "metadata": {
+                    "name": metadata.name,
+                    "labels": metadata.labels,
+                },
+                "stringData": params.authentication_secret.to_string_data(),
+            }
+            secret = await self.secret_client.create_secret(
+                K8sSecret(
+                    name=metadata.name,
+                    namespace=self.namespace,
+                    cluster=self.cluster_id(),
+                    manifest=Box(manifest),
+                    user_id=user_id,
+                )
+            )
+
         retention: crs.Retention | None = None
         if params.retention_after_failed or params.retention_after_succeeded:
             retention_after_failed = (
@@ -185,7 +208,11 @@ class ShipwrightClient:
                 build=crs.Build(
                     spec=crs.BuildSpec(
                         source=crs.GitSource(
-                            git=crs.Git(url=params.git_repository, revision=params.git_repository_revision),
+                            git=crs.Git(
+                                url=params.git_repository,
+                                revision=params.git_repository_revision,
+                                cloneSecret=secret.name if secret is not None else None,
+                            ),
                             contextDir=params.context_dir,
                         ),
                         strategy=crs.Strategy(kind="BuildStrategy", name=params.build_strategy_name),
@@ -206,7 +233,19 @@ class ShipwrightClient:
                 retention=retention,
             ),
         )
-        await self.create_build_run(build_run, user_id)
+
+        created = await self.create_build_run(build_run, user_id)
+
+        if secret is not None:
+            owner_reference = dict(
+                apiVersion=created.apiVersion,
+                kind=created.kind,
+                name=created.metadata.name,
+                uid=created.metadata.uid,
+                controller=True,
+            )
+            patch = [{"op": "replace", "path": "/metadata/ownerReferences", "value": [owner_reference]}]
+            await self.secret_client.patch_secret(secret, patch)
 
     async def update_image_build_status(self, buildrun_name: str, user_id: str) -> models.ShipwrightBuildStatusUpdate:
         """Update the status of a build by pulling the corresponding BuildRun from Shipwright."""

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -315,6 +315,22 @@ class BuildPatch:
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)
+class AuthenticationSecret:
+    """Model to represent the secret to be created/used for private repositories."""
+
+    username: str
+    password: str
+
+    def to_string_data(self) -> dict:
+        """Returns the raw data as is to be used as Secret stringData."""
+
+        return {
+            "username": self.username,
+            "password": self.password,
+        }
+
+
+@dataclass(frozen=True, eq=True, kw_only=True)
 class ShipwrightBuildRunParams:
     """Model to represent the parameters used to create a new Shipwright BuildRun."""
 
@@ -324,6 +340,7 @@ class ShipwrightBuildRunParams:
     output_image: str
     build_strategy_name: str
     push_secret_name: str
+    authentication_secret: AuthenticationSecret | None = None
     retention_after_failed: timedelta | None = None
     retention_after_succeeded: timedelta | None = None
     build_timeout: timedelta | None = None
@@ -346,6 +363,7 @@ class ShipwrightBuildRunParams:
             run_image=overrides.run_image or self.run_image,
             output_image=self.output_image,
             build_strategy_name=overrides.strategy_name or self.build_strategy_name,
+            authentication_secret=self.authentication_secret,
             push_secret_name=self.push_secret_name,
             retention_after_failed=self.retention_after_failed,
             retention_after_succeeded=self.retention_after_succeeded,

--- a/components/renku_data_services/storage/apispec_base.py
+++ b/components/renku_data_services/storage/apispec_base.py
@@ -1,16 +1,16 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from ulid import ULID
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
+    )
 
     @field_validator("storage_id", mode="before", check_fields=False)
     @classmethod

--- a/components/renku_data_services/users/apispec_base.py
+++ b/components/renku_data_services/users/apispec_base.py
@@ -1,12 +1,12 @@
 """Base models for API specifications."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class BaseAPISpec(BaseModel):
     """Base API specification."""
 
-    class Config:
-        """Enables orm mode for pydantic."""
-
-        from_attributes = True
+    model_config = ConfigDict(
+        # Enables orm mode for pydantic."""
+        from_attributes=True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,10 @@ exclude_dirs = [
 addopts = "--cov components/ --cov bases/ --cov-report=term-missing -v"
 doctest_optionflags = "ALLOW_UNICODE"
 testpaths = ["bases", "components", "test"]
-markers = ["integration: mark a test as a integration."]
+markers = [
+  "integration: mark a test as a integration.",
+  "sessions",
+]
 filterwarnings = [
   "ignore:<class 'pytest_black.BlackItem'> is not using a cooperative constructor:pytest.PytestDeprecationWarning",
   "ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning",

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -809,15 +809,6 @@ async def secrets_sanic_client(
         yield client
 
 
-def pytest_addoption(parser):
-    parser.addoption("--disable-cluster-creation", action="store_true", default=False, help="Disable cluster creation")
-
-
-@pytest_asyncio.fixture(scope="session")
-def disable_cluster_creation(request):
-    return request.config.getoption("--disable-cluster-creation")
-
-
 def __make_headers(user: UserInfo, admin: bool = False) -> dict[str, str]:
     access_token = json.dumps(
         {

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -742,7 +742,7 @@ async def create_session_secret_slot(sanic_client: SanicASGITestClient, user_hea
 
 
 @pytest_asyncio.fixture
-async def create_resource_pool(sanic_client, user_headers, admin_headers, valid_resource_pool_payload):
+async def create_resource_pool(cluster, sanic_client, user_headers, admin_headers, valid_resource_pool_payload):
     async def create_resource_pool_helper(admin: bool = False, **payload) -> dict[str, Any]:
         headers = admin_headers if admin else user_headers
         valid_resource_pool_payload.update(payload)

--- a/test/bases/renku_data_services/data_api/test_data_connectors.py
+++ b/test/bases/renku_data_services/data_api/test_data_connectors.py
@@ -445,20 +445,21 @@ async def test_post_data_connector_with_conflicting_slug(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("headers_and_error", [("unauthorized_headers", 401), ("member_1_headers", 403)])
+@pytest.mark.parametrize(
+    "headers_name,expected_status_code", [("unauthorized_headers", 401), ("member_1_headers", 403)]
+)
 async def test_post_data_connector_without_namespace_permission(
     # NOTE: dynamically requesting async fixtures with an already running event loop causes errors in pytest.
     # to prevent this, all used fixtures have to also be listed again, so they exist at test execution time and
     # are loaded from cache
     sanic_client: SanicASGITestClient,
     user_headers,
-    headers_and_error,
+    headers_name,
+    expected_status_code,
     unauthorized_headers,
     member_1_headers,
     request,
 ) -> None:
-    headers_name, status_code = headers_and_error
-
     _, response = await sanic_client.post(
         "/api/data/groups", headers=user_headers, json={"name": "My Group", "slug": "my-group"}
     )
@@ -477,9 +478,10 @@ async def test_post_data_connector_without_namespace_permission(
             "target_path": "my/target",
         },
     }
+
     _, response = await sanic_client.post("/api/data/data_connectors", headers=headers, json=payload)
 
-    assert response.status_code == status_code, response.text
+    assert response.status_code == expected_status_code, response.text
 
 
 @pytest.mark.asyncio

--- a/test/bases/renku_data_services/data_api/test_migrations.py
+++ b/test/bases/renku_data_services/data_api/test_migrations.py
@@ -314,8 +314,8 @@ async def test_migration_to_75c83dd9d619(app_manager_instance: DependencyManager
 
     def find_by_col(data: Sequence[sa.Row[Any]], id_value: Any, id_index: int) -> tuple | None:
         for row in data:
-            if row.tuple()[id_index] == id_value:
-                return cast(tuple, row.tuple())
+            if row._tuple()[id_index] == id_value:
+                return cast(tuple, row._tuple())
         return None
 
     run_migrations_for_app("common", "450ae3930996")
@@ -588,12 +588,12 @@ async def test_migration_to_dcb9648c3c15(app_manager_instance: DependencyManager
     async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
         k8s_objs = (await session.execute(sa.text('SELECT "group", version, kind FROM common.k8s_objects'))).all()
     assert len(k8s_objs) == 2
-    assert k8s_objs[0].tuple()[0] is None
-    assert k8s_objs[0].tuple()[1] == "v1"
-    assert k8s_objs[0].tuple()[2] == "pod"
-    assert k8s_objs[1].tuple()[0] == "amalthea.dev"
-    assert k8s_objs[1].tuple()[1] == "v1alpha1"
-    assert k8s_objs[1].tuple()[2] == "jupyterserver"
+    assert k8s_objs[0]._tuple()[0] is None
+    assert k8s_objs[0]._tuple()[1] == "v1"
+    assert k8s_objs[0]._tuple()[2] == "pod"
+    assert k8s_objs[1]._tuple()[0] == "amalthea.dev"
+    assert k8s_objs[1]._tuple()[1] == "v1alpha1"
+    assert k8s_objs[1]._tuple()[2] == "jupyterserver"
 
 
 @pytest.mark.asyncio
@@ -619,8 +619,8 @@ async def test_migration_to_c8061499b966(app_manager_instance: DependencyManager
         k8s_objs = (await session.execute(sa.text("SELECT name, cluster FROM common.k8s_objects"))).all()
     assert len(k8s_objs) == 2
     # Check that the cluster name was changed
-    assert k8s_objs[0].tuple()[1] == "0RENK1RENK2RENK3RENK4RENK5"
-    assert k8s_objs[1].tuple()[1] == "0RENK1RENK2RENK3RENK4RENK5"
+    assert k8s_objs[0]._tuple()[1] == "0RENK1RENK2RENK3RENK4RENK5"
+    assert k8s_objs[1]._tuple()[1] == "0RENK1RENK2RENK3RENK4RENK5"
     id = ULID()
     async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
         await session.execute(

--- a/test/bases/renku_data_services/data_api/test_resource_pools.py
+++ b/test/bases/renku_data_services/data_api/test_resource_pools.py
@@ -91,6 +91,7 @@ async def test_resource_pool_creation_with_cluster_ids(
     cluster: KindCluster,
     kubeconfig_path: Path,
     monkeypatch,
+    admin_headers,
 ) -> None:
     payload = deepcopy(payload)
     monkeypatch.setenv("ALWAYS_READ_CLUSTERS", "true")
@@ -107,7 +108,7 @@ async def test_resource_pool_creation_with_cluster_ids(
                 "session_ingress_annotations": {},
                 "session_tls_secret_name": "a-domain-name-tls",
             },
-            headers={"Authorization": 'Bearer {"is_admin": true}'},
+            headers=admin_headers,
         )
         assert res.status_code == 201, res.text
         payload["cluster_id"] = res.json["id"]

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -11,7 +11,6 @@ from sanic_testing.testing import SanicASGITestClient, TestingResponse
 from syrupy.filters import props
 
 from renku_data_services import errors
-from renku_data_services.crc.apispec import ResourcePool
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.session.constants import BUILD_RUN_GVK
 from renku_data_services.session.models import EnvVar
@@ -36,10 +35,10 @@ def launch_session(
     cluster: KindCluster,
 ):
     async def launch_session_helper(
-        payload: dict, headers: dict = None, user: UserInfo = regular_user
+        payload: dict, headers: dict = None, user: UserInfo = regular_user, cookies: dict = None
     ) -> TestingResponse:
         headers = headers or user_headers
-        _, res = await sanic_client.post("/api/data/sessions", headers=headers, json=payload)
+        _, res = await sanic_client.post("/api/data/sessions", headers=headers, json=payload, cookies=cookies)
         assert res.status_code == 201, res.text
         assert res.json is not None
         assert "name" in res.json
@@ -1400,11 +1399,11 @@ def anonymous_user_headers() -> dict[str, str]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Setup for testing sessions is not done yet.")  # TODO: enable in followup PR
 @pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_starting_session_anonymous(
     sanic_client: SanicASGITestClient,
     create_project,
+    create_resource_pool,
     create_session_launcher,
     user_headers,
     app_manager: DependencyManager,
@@ -1412,44 +1411,118 @@ async def test_starting_session_anonymous(
     launch_session,
     anonymous_user_headers,
 ) -> None:
-    _, res = await sanic_client.post(
-        "/api/data/resource_pools",
-        json=ResourcePool.model_validate(app_manager.default_resource_pool, from_attributes=True).model_dump(
-            mode="json", exclude_none=True
-        ),
-        headers=admin_headers,
-    )
-    assert res.status_code == 201, res.text
     project: dict[str, Any] = await create_project(
         sanic_client,
         "Some project",
         visibility="public",
         repositories=["https://github.com/SwissDataScienceCenter/renku-data-services"],
     )
+    resource_pool = await create_resource_pool(admin=True)
     launcher: dict[str, Any] = await create_session_launcher(
-        "Launcher 1",
+        name="Launcher 1",
         project_id=project["id"],
+        description="A session launcher",
+        resource_class_id=resource_pool["classes"][0]["id"],
+        disk_storage=42,
         environment={
             "container_image": "renku/renkulab-py:3.10-0.23.0-amalthea-sessions-3",
             "environment_kind": "CUSTOM",
             "name": "test",
             "port": 8888,
+            "environment_image_source": "image",
         },
         env_variables=[
             {"name": "TEST_ENV_VAR", "value": "some-random-value-1234"},
         ],
     )
+
     launcher_id = launcher["id"]
     project_id = project["id"]
     payload = {"project_id": project_id, "launcher_id": launcher_id}
-    session_res = await launch_session(payload, headers=anonymous_user_headers)
-    _, res = await sanic_client.get(f"/api/data/sessions/{session_res.json['name']}", headers=anonymous_user_headers)
+    cookies = {"_renku_session": "some content"}
+    session_res = await launch_session(payload, headers=anonymous_user_headers, cookies=cookies)
+    _, res = await sanic_client.get(
+        f"/api/data/sessions/{session_res.json['name']}", headers=anonymous_user_headers, cookies=cookies
+    )
     assert res.status_code == 200, res.text
     assert res.json["name"] == session_res.json["name"]
-    _, res = await sanic_client.get("/api/data/sessions", headers=anonymous_user_headers)
+    _, res = await sanic_client.get("/api/data/sessions", headers=anonymous_user_headers, cookies=cookies)
     assert res.status_code == 200, res.text
     assert len(res.json) > 0
     assert session_res.json["name"] in [i["name"] for i in res.json]
+
+
+@pytest.mark.parametrize(
+    "expected_status_code,build_git_repo,request_git_repo, is_private",
+    [
+        (
+            201,
+            "https://github.com/SwissDataScienceCenter/renku",
+            "https://github.com/SwissDataScienceCenter/renku",
+            False,
+        ),
+        (
+            422,
+            "https://github.com/SwissDataScienceCenter/renku",
+            "https://github.com/SwissDataScienceCenter/not-the same",
+            False,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
+async def test_starting_session_with_built_environment(
+    sanic_client: SanicASGITestClient,
+    create_project,
+    create_resource_pool,
+    create_session_launcher,
+    user_headers,
+    app_manager: DependencyManager,
+    admin_headers,
+    launch_session,
+    expected_status_code,
+    build_git_repo,
+    request_git_repo,
+    is_private,
+) -> None:
+    project: dict[str, Any] = await create_project(
+        sanic_client,
+        "Some project",
+        visibility="public",
+        repositories=[request_git_repo],
+    )
+    resource_pool = await create_resource_pool(admin=True)
+    launcher: dict[str, Any] = await create_session_launcher(
+        name="Launcher 1",
+        project_id=project["id"],
+        description="A session launcher",
+        resource_class_id=resource_pool["classes"][0]["id"],
+        environment={
+            "repository": build_git_repo,
+            "builder_variant": "python",
+            "frontend_variant": "vscodium",
+            "environment_image_source": "build",
+        },
+        env_variables=[
+            {"name": "TEST_ENV_VAR", "value": "some-random-value-1234"},
+        ],
+    )
+
+    launcher_id = launcher["id"]
+    project_id = project["id"]
+    payload = {"project_id": project_id, "launcher_id": launcher_id}
+
+    _, session_res = await sanic_client.post("/api/data/sessions", headers=user_headers, json=payload)
+    assert session_res.status_code == expected_status_code
+
+    if expected_status_code == 201:
+        _, res = await sanic_client.get(f"/api/data/sessions/{session_res.json['name']}", headers=user_headers)
+        assert res.status_code == 200, res.text
+        assert res.json["name"] == session_res.json["name"]
+        _, res = await sanic_client.get("/api/data/sessions", headers=user_headers)
+        assert res.status_code == 200, res.text
+        assert len(res.json) > 0
+        assert session_res.json["name"] in [i["name"] for i in res.json]
 
 
 @pytest.mark.asyncio

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -3,7 +3,9 @@
 from asyncio import AbstractEventLoop
 from typing import Any
 
+import kr8s
 import pytest
+from kr8s.objects import new_class
 from pytest import FixtureRequest
 from sanic_testing.testing import SanicASGITestClient, TestingResponse
 from syrupy.filters import props
@@ -11,9 +13,16 @@ from syrupy.filters import props
 from renku_data_services import errors
 from renku_data_services.crc.apispec import ResourcePool
 from renku_data_services.data_api.dependencies import DependencyManager
+from renku_data_services.session.constants import BUILD_RUN_GVK
 from renku_data_services.session.models import EnvVar
 from renku_data_services.users.models import UserInfo
 from test.utils import KindCluster
+
+BuildRun = new_class(
+    kind=BUILD_RUN_GVK.kind,
+    version=BUILD_RUN_GVK.group_version,
+    namespaced=True,
+)
 
 
 @pytest.fixture
@@ -459,28 +468,33 @@ async def test_post_session_launcher(
 
 
 @pytest.mark.parametrize(
-    "expected_status_code,git_repo",
+    "expected_status_code,git_repo,is_private",
     [
         (
             201,
             "https://github.com/SwissDataScienceCenter/renku",
+            False,
         ),
         (
             201,
             "https://github.com/SwissDataScienceCenter/private",
+            True,
         ),
-        (500, "https://github.com/some/repo"),
+        (500, "https://github.com/some/repo", False),
     ],
 )
 @pytest.mark.asyncio
 async def test_post_session_launcher_with_environment_build(
+    app_manager: DependencyManager,
     sanic_client,
-    admin_headers,
+    user_headers,
     create_project,
     create_resource_pool,
     expected_status_code,
     git_repo,
+    is_private,
     builds_enabled,
+    cluster,
 ) -> None:
     project = await create_project(sanic_client, "Some project")
 
@@ -496,7 +510,7 @@ async def test_post_session_launcher_with_environment_build(
         },
     }
 
-    _, response = await sanic_client.post("/api/data/session_launchers", headers=admin_headers, json=payload)
+    _, response = await sanic_client.post("/api/data/session_launchers", headers=user_headers, json=payload)
 
     if not builds_enabled:
         expected_status_code = 201
@@ -508,7 +522,8 @@ async def test_post_session_launcher_with_environment_build(
         assert response.json.get("project_id") == project["id"]
         assert response.json.get("description") == "A session launcher."
         environment = response.json.get("environment", {})
-        assert environment.get("id") is not None
+        environment_id = environment.get("id")
+        assert environment_id is not None
         assert environment.get("name") == "Launcher 1"
         assert environment.get("environment_kind") == "CUSTOM"
         assert environment.get("build_parameters") == {
@@ -519,6 +534,26 @@ async def test_post_session_launcher_with_environment_build(
         }
         assert environment.get("environment_image_source") == "build"
         assert environment.get("container_image") == "image:unknown-at-the-moment"
+
+        _, response = await sanic_client.get(
+            f"/api/data/environments/{environment_id}/builds",
+            headers=user_headers,
+        )
+        assert response.status_code == 200, response.text
+        build = response.json[0]
+        build_id = build["id"]
+
+        api = kr8s.api(kubeconfig=cluster.kubeconfig)
+        build_run = BuildRun.get(name=f"renku-{build_id.lower()}", api=api)
+
+        build_spec = build_run.spec.build.spec
+        if is_private:
+            assert build_spec.source.git.get("cloneSecret") is not None
+            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
+        else:
+            assert build_spec.source.git.get("cloneSecret") is None
+            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
+
     elif expected_status_code == 500:
         assert response.json is not None
         error = response.json.get("error")
@@ -526,27 +561,32 @@ async def test_post_session_launcher_with_environment_build(
 
 
 @pytest.mark.parametrize(
-    "expected_status_code,git_repo",
+    "expected_status_code,git_repo,is_private",
     [
         (
             201,
             "https://github.com/SwissDataScienceCenter/renku",
+            False,
         ),
         (
             201,
             "https://github.com/SwissDataScienceCenter/private",
+            True,
         ),
-        (500, "https://github.com/some/repo"),
+        (500, "https://github.com/some/repo", False),
     ],
 )
 @pytest.mark.asyncio
 async def test_post_session_launcher_with_advanced_environment_build(
+    app_manager: DependencyManager,
     sanic_client: SanicASGITestClient,
     user_headers: dict[str, str],
     create_project,
     expected_status_code,
     git_repo,
+    is_private,
     builds_enabled,
+    cluster,
 ) -> None:
     project = await create_project(sanic_client, "Some project")
 
@@ -576,7 +616,8 @@ async def test_post_session_launcher_with_advanced_environment_build(
         assert response.json.get("project_id") == project["id"]
         assert response.json.get("description") == "A session launcher."
         environment = response.json.get("environment", {})
-        assert environment.get("id") is not None
+        environment_id = environment.get("id")
+        assert environment_id is not None
         assert environment.get("name") == "Launcher 1"
         assert environment.get("environment_kind") == "CUSTOM"
         assert environment.get("build_parameters") == {
@@ -589,6 +630,26 @@ async def test_post_session_launcher_with_advanced_environment_build(
         }
         assert environment.get("environment_image_source") == "build"
         assert environment.get("container_image") == "image:unknown-at-the-moment"
+
+        _, response = await sanic_client.get(
+            f"/api/data/environments/{environment_id}/builds",
+            headers=user_headers,
+        )
+        assert response.status_code == 200, response.text
+        build = response.json[0]
+        build_id = build["id"]
+
+        api = kr8s.api(kubeconfig=cluster.kubeconfig)
+        build_run = BuildRun.get(name=f"renku-{build_id.lower()}", api=api)
+
+        build_spec = build_run.spec.build.spec
+        if is_private:
+            assert build_spec.source.git.get("cloneSecret") is not None
+            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
+        else:
+            assert build_spec.source.git.get("cloneSecret") is None
+            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
+
     elif expected_status_code == 500:
         assert response.json is not None
         error = response.json.get("error")

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -41,7 +41,7 @@ def launch_session(
                 app_manager.config.nb_config.k8s_v2_client.delete_session(session_id, user.id)
             )
 
-        # request.addfinalizer(cleanup)
+        request.addfinalizer(cleanup)
         return res
 
     return launch_session_helper
@@ -413,7 +413,12 @@ def test_env_variable_validation():
 @pytest.mark.asyncio
 @pytest.mark.xdist_group("sessions")
 async def test_post_session_launcher(
-    sanic_client, admin_headers, create_project, create_resource_pool, app_manager, cluster: KindCluster
+    sanic_client,
+    admin_headers,
+    create_project,
+    create_resource_pool,
+    app_manager,
+    cluster: KindCluster,
 ) -> None:
     project = await create_project(sanic_client, "Some project")
 
@@ -453,12 +458,29 @@ async def test_post_session_launcher(
     app_manager.metrics.session_launcher_created.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "expected_status_code,git_repo",
+    [
+        (
+            201,
+            "https://github.com/SwissDataScienceCenter/renku",
+        ),
+        (
+            201,
+            "https://github.com/SwissDataScienceCenter/private",
+        ),
+        (500, "https://github.com/some/repo"),
+    ],
+)
 @pytest.mark.asyncio
 async def test_post_session_launcher_with_environment_build(
     sanic_client,
     admin_headers,
     create_project,
     create_resource_pool,
+    expected_status_code,
+    git_repo,
+    builds_enabled,
 ) -> None:
     project = await create_project(sanic_client, "Some project")
 
@@ -467,7 +489,7 @@ async def test_post_session_launcher_with_environment_build(
         "project_id": project["id"],
         "description": "A session launcher.",
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": git_repo,
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "environment_image_source": "build",
@@ -476,30 +498,55 @@ async def test_post_session_launcher_with_environment_build(
 
     _, response = await sanic_client.post("/api/data/session_launchers", headers=admin_headers, json=payload)
 
-    assert response.status_code == 201, response.text
-    assert response.json is not None
-    assert response.json.get("name") == "Launcher 1"
-    assert response.json.get("project_id") == project["id"]
-    assert response.json.get("description") == "A session launcher."
-    environment = response.json.get("environment", {})
-    assert environment.get("id") is not None
-    assert environment.get("name") == "Launcher 1"
-    assert environment.get("environment_kind") == "CUSTOM"
-    assert environment.get("build_parameters") == {
-        "repository": "https://github.com/some/repo",
-        "platforms": ["linux/amd64"],
-        "builder_variant": "python",
-        "frontend_variant": "vscodium",
-    }
-    assert environment.get("environment_image_source") == "build"
-    assert environment.get("container_image") == "image:unknown-at-the-moment"
+    if not builds_enabled:
+        expected_status_code = 201
+
+    assert response.status_code == expected_status_code, response.text
+    if expected_status_code == 201:
+        assert response.json is not None
+        assert response.json.get("name") == "Launcher 1"
+        assert response.json.get("project_id") == project["id"]
+        assert response.json.get("description") == "A session launcher."
+        environment = response.json.get("environment", {})
+        assert environment.get("id") is not None
+        assert environment.get("name") == "Launcher 1"
+        assert environment.get("environment_kind") == "CUSTOM"
+        assert environment.get("build_parameters") == {
+            "repository": git_repo,
+            "platforms": ["linux/amd64"],
+            "builder_variant": "python",
+            "frontend_variant": "vscodium",
+        }
+        assert environment.get("environment_image_source") == "build"
+        assert environment.get("container_image") == "image:unknown-at-the-moment"
+    elif expected_status_code == 500:
+        assert response.json is not None
+        error = response.json.get("error")
+        assert error.get("message") == "Invalid path /some/repo"
 
 
+@pytest.mark.parametrize(
+    "expected_status_code,git_repo",
+    [
+        (
+            201,
+            "https://github.com/SwissDataScienceCenter/renku",
+        ),
+        (
+            201,
+            "https://github.com/SwissDataScienceCenter/private",
+        ),
+        (500, "https://github.com/some/repo"),
+    ],
+)
 @pytest.mark.asyncio
 async def test_post_session_launcher_with_advanced_environment_build(
     sanic_client: SanicASGITestClient,
     user_headers: dict[str, str],
     create_project,
+    expected_status_code,
+    git_repo,
+    builds_enabled,
 ) -> None:
     project = await create_project(sanic_client, "Some project")
 
@@ -508,7 +555,7 @@ async def test_post_session_launcher_with_advanced_environment_build(
         "project_id": project["id"],
         "description": "A session launcher.",
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": git_repo,
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "repository_revision": "some-branch",
@@ -519,25 +566,33 @@ async def test_post_session_launcher_with_advanced_environment_build(
 
     _, response = await sanic_client.post("/api/data/session_launchers", headers=user_headers, json=payload)
 
-    assert response.status_code == 201, response.text
-    assert response.json is not None
-    assert response.json.get("name") == "Launcher 1"
-    assert response.json.get("project_id") == project["id"]
-    assert response.json.get("description") == "A session launcher."
-    environment = response.json.get("environment", {})
-    assert environment.get("id") is not None
-    assert environment.get("name") == "Launcher 1"
-    assert environment.get("environment_kind") == "CUSTOM"
-    assert environment.get("build_parameters") == {
-        "repository": "https://github.com/some/repo",
-        "platforms": ["linux/amd64"],
-        "builder_variant": "python",
-        "frontend_variant": "vscodium",
-        "repository_revision": "some-branch",
-        "context_dir": "path/to/context",
-    }
-    assert environment.get("environment_image_source") == "build"
-    assert environment.get("container_image") == "image:unknown-at-the-moment"
+    if not builds_enabled:
+        expected_status_code = 201
+
+    assert response.status_code == expected_status_code, response.text
+    if expected_status_code == 201:
+        assert response.json is not None
+        assert response.json.get("name") == "Launcher 1"
+        assert response.json.get("project_id") == project["id"]
+        assert response.json.get("description") == "A session launcher."
+        environment = response.json.get("environment", {})
+        assert environment.get("id") is not None
+        assert environment.get("name") == "Launcher 1"
+        assert environment.get("environment_kind") == "CUSTOM"
+        assert environment.get("build_parameters") == {
+            "repository": git_repo,
+            "platforms": ["linux/amd64"],
+            "builder_variant": "python",
+            "frontend_variant": "vscodium",
+            "repository_revision": "some-branch",
+            "context_dir": "path/to/context",
+        }
+        assert environment.get("environment_image_source") == "build"
+        assert environment.get("container_image") == "image:unknown-at-the-moment"
+    elif expected_status_code == 500:
+        assert response.json is not None
+        error = response.json.get("error")
+        assert error.get("message") == "Invalid path /some/repo"
 
 
 @pytest.mark.asyncio
@@ -928,7 +983,11 @@ async def test_patch_session_launcher_environment_with_build_parameters(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("builder_variant, frontend_variant", [("conda", "vscodium"), ("python", "jupyter")])
 async def test_post_session_launcher_environment_with_invalid_build_parameters(
-    sanic_client, user_headers, create_project, builder_variant, frontend_variant
+    sanic_client,
+    user_headers,
+    create_project,
+    builder_variant,
+    frontend_variant,
 ) -> None:
     project = await create_project(sanic_client, "Project")
 
@@ -936,7 +995,7 @@ async def test_post_session_launcher_environment_with_invalid_build_parameters(
         "name": "Launcher 1",
         "project_id": project["id"],
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": "https://github.com/SwissDataScienceCenter/renku",
             "builder_variant": builder_variant,
             "frontend_variant": frontend_variant,
             "environment_image_source": "build",
@@ -960,7 +1019,7 @@ async def test_patch_session_launcher_environment_with_invalid_build_parameters(
         name="Launcher",
         project_id=project["id"],
         environment={
-            "repository": "https://github.com/some/repo",
+            "repository": "https://github.com/SwissDataScienceCenter/renku",
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "environment_image_source": "build",
@@ -1084,7 +1143,11 @@ async def test_patch_session_launcher_reset_fields(
 
 @pytest.mark.asyncio
 async def test_patch_session_launcher_keeps_unset_values(
-    sanic_client, user_headers, create_project, create_resource_pool, create_session_launcher
+    sanic_client,
+    user_headers,
+    create_project,
+    create_resource_pool,
+    create_session_launcher,
 ) -> None:
     project = await create_project(sanic_client, "Some project")
     resource_pool = await create_resource_pool(admin=True)
@@ -1131,12 +1194,13 @@ async def test_patch_session_launcher_with_advanced_environment_build(
 ) -> None:
     project = await create_project(sanic_client, "Some project")
 
+    repository = "https://github.com/SwissDataScienceCenter/renku"
     payload = {
         "name": "Launcher 1",
         "project_id": project["id"],
         "description": "A session launcher.",
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": repository,
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "environment_image_source": "build",
@@ -1158,7 +1222,7 @@ async def test_patch_session_launcher_with_advanced_environment_build(
     assert environment.get("name") == "Launcher 1"
     assert environment.get("environment_kind") == "CUSTOM"
     assert environment.get("build_parameters") == {
-        "repository": "https://github.com/some/repo",
+        "repository": repository,
         "platforms": ["linux/amd64"],
         "builder_variant": "python",
         "frontend_variant": "vscodium",
@@ -1189,7 +1253,7 @@ async def test_patch_session_launcher_with_advanced_environment_build(
     assert environment.get("name") == "Launcher 1"
     assert environment.get("environment_kind") == "CUSTOM"
     assert environment.get("build_parameters") == {
-        "repository": "https://github.com/some/repo",
+        "repository": repository,
         "platforms": ["linux/arm64"],
         "builder_variant": "python",
         "frontend_variant": "vscodium",
@@ -1221,7 +1285,7 @@ async def test_patch_session_launcher_with_advanced_environment_build(
     assert environment.get("name") == "Launcher 1"
     assert environment.get("environment_kind") == "CUSTOM"
     assert environment.get("build_parameters") == {
-        "repository": "https://github.com/some/repo",
+        "repository": repository,
         "platforms": ["linux/arm64"],
         "builder_variant": "python",
         "frontend_variant": "vscodium",
@@ -1254,7 +1318,7 @@ async def test_patch_session_launcher_with_advanced_environment_build(
     assert environment.get("name") == "Launcher 1"
     assert environment.get("environment_kind") == "CUSTOM"
     assert environment.get("build_parameters") == {
-        "repository": "https://github.com/some/repo",
+        "repository": repository,
         "platforms": ["linux/amd64"],
         "builder_variant": "python",
         "frontend_variant": "jupyterlab",
@@ -1322,14 +1386,19 @@ async def test_starting_session_anonymous(
 
 
 @pytest.mark.asyncio
-async def test_rebuild(sanic_client: SanicASGITestClient, user_headers, create_project) -> None:
+async def test_rebuild(
+    sanic_client: SanicASGITestClient,
+    user_headers,
+    create_project,
+    builds_enabled,
+) -> None:
     project = await create_project(sanic_client, "Some project")
     payload = {
         "name": "Launcher 1",
         "project_id": project["id"],
         "description": "A session launcher.",
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": "https://github.com/SwissDataScienceCenter/renku",
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "environment_image_source": "build",
@@ -1340,16 +1409,22 @@ async def test_rebuild(sanic_client: SanicASGITestClient, user_headers, create_p
     launcher = response.json
     environment_id = launcher["environment"]["id"]
 
-    # Trying to rebuild fails since a build is already in progress when session launcher is created
-    _, response = await sanic_client.post(f"/api/data/environments/{environment_id}/builds", headers=user_headers)
+    if not builds_enabled:
+        # If builds are enabled, the build will have failed due to the inaccessibility of the registry hence it can
+        # directly be restarted
+        # Trying to rebuild fails since a build is already in progress when session launcher is created
+        _, response = await sanic_client.post(f"/api/data/environments/{environment_id}/builds", headers=user_headers)
 
-    assert response.status_code == 409, response.text
-    assert "already has a build in progress." in response.text
+        assert response.status_code == 409, response.text
+        assert "already has a build in progress." in response.text
 
     # Cancel the build
     _, response = await sanic_client.get(f"/api/data/environments/{environment_id}/builds", headers=user_headers)
     assert response.status_code == 200, response.text
     build = response.json[0]
+
+    _, response = await sanic_client.get(f"/api/data/builds/{build['id']}", headers=user_headers)
+    assert response.status_code == 200, response.text
 
     _, response = await sanic_client.patch(
         f"/api/data/builds/{build['id']}", json={"status": "cancelled"}, headers=user_headers
@@ -1365,19 +1440,26 @@ async def test_rebuild(sanic_client: SanicASGITestClient, user_headers, create_p
     assert build.get("id") is not None
     assert build.get("environment_id") == environment_id
     assert build.get("created_at") is not None
-    assert build.get("status") == "in_progress"
+    if not builds_enabled:
+        assert build.get("status") == "in_progress"
+    else:
+        assert build.get("status") in ["failed", "in_progress"]
     assert build.get("result") is None
 
 
 @pytest.mark.asyncio
-async def test_get_build(sanic_client: SanicASGITestClient, user_headers, create_project) -> None:
+async def test_get_build(
+    sanic_client: SanicASGITestClient,
+    user_headers,
+    create_project,
+) -> None:
     project = await create_project(sanic_client, "Some project")
     payload = {
         "name": "Launcher 1",
         "project_id": project["id"],
         "description": "A session launcher.",
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": "https://github.com/SwissDataScienceCenter/renku",
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "environment_image_source": "build",
@@ -1411,14 +1493,18 @@ async def test_get_build(sanic_client: SanicASGITestClient, user_headers, create
 
 
 @pytest.mark.asyncio
-async def test_get_environment_builds(sanic_client: SanicASGITestClient, user_headers, create_project) -> None:
+async def test_get_environment_builds(
+    sanic_client: SanicASGITestClient,
+    user_headers,
+    create_project,
+) -> None:
     project = await create_project(sanic_client, "Some project")
     payload = {
         "name": "Launcher 1",
         "project_id": project["id"],
         "description": "A session launcher.",
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": "https://github.com/SwissDataScienceCenter/renku",
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "environment_image_source": "build",
@@ -1463,14 +1549,18 @@ async def test_get_environment_builds(sanic_client: SanicASGITestClient, user_he
 
 
 @pytest.mark.asyncio
-async def test_patch_build(sanic_client: SanicASGITestClient, user_headers, create_project) -> None:
+async def test_patch_build(
+    sanic_client: SanicASGITestClient,
+    user_headers,
+    create_project,
+) -> None:
     project = await create_project(sanic_client, "Some project")
     payload = {
         "name": "Launcher 1",
         "project_id": project["id"],
         "description": "A session launcher.",
         "environment": {
-            "repository": "https://github.com/some/repo",
+            "repository": "https://github.com/SwissDataScienceCenter/renku",
             "builder_variant": "python",
             "frontend_variant": "vscodium",
             "environment_image_source": "build",
@@ -1518,7 +1608,10 @@ async def test_patch_build(sanic_client: SanicASGITestClient, user_headers, crea
 
 @pytest.mark.asyncio
 async def test_patch_strip_prefix(
-    sanic_client: SanicASGITestClient, admin_headers, create_project, create_session_launcher
+    sanic_client: SanicASGITestClient,
+    admin_headers,
+    create_project,
+    create_session_launcher,
 ) -> None:
     project = await create_project(sanic_client, "Project 1")
     launcher = await create_session_launcher("Launcher 1", project_id=project["id"])

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -551,9 +551,11 @@ async def test_post_session_launcher_with_environment_build(
             if is_private:
                 assert build_spec.source.git.get("cloneSecret") is not None
                 assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
+                assert build_spec.output.pushSecret == app_manager.config.builds.push_private_secret_name
             else:
                 assert build_spec.source.git.get("cloneSecret") is None
                 assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
+                assert build_spec.output.pushSecret == app_manager.config.builds.push_secret_name
 
     elif expected_status_code == 500:
         assert response.json is not None
@@ -648,9 +650,11 @@ async def test_post_session_launcher_with_advanced_environment_build(
             if is_private:
                 assert build_spec.source.git.get("cloneSecret") is not None
                 assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
+                assert build_spec.output.pushSecret == app_manager.config.builds.push_private_secret_name
             else:
                 assert build_spec.source.git.get("cloneSecret") is None
                 assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
+                assert build_spec.output.pushSecret == app_manager.config.builds.push_secret_name
 
     elif expected_status_code == 500:
         assert response.json is not None

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -1462,10 +1462,22 @@ async def test_starting_session_anonymous(
             False,
         ),
         (
+            201,
+            "https://github.com/SwissDataScienceCenter/private",
+            "https://github.com/SwissDataScienceCenter/private",
+            True,
+        ),
+        (
             422,
             "https://github.com/SwissDataScienceCenter/renku",
             "https://github.com/SwissDataScienceCenter/not-the same",
             False,
+        ),
+        (
+            422,
+            "https://github.com/SwissDataScienceCenter/other-private",
+            "https://github.com/SwissDataScienceCenter/other-private",
+            True,
         ),
     ],
 )
@@ -1484,7 +1496,11 @@ async def test_starting_session_with_built_environment(
     build_git_repo,
     request_git_repo,
     is_private,
+    builds_enabled,
 ) -> None:
+    if not builds_enabled and is_private:
+        expected_status_code = 422
+
     project: dict[str, Any] = await create_project(
         sanic_client,
         "Some project",

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -557,7 +557,7 @@ async def test_post_session_launcher_with_environment_build(
     elif expected_status_code == 500:
         assert response.json is not None
         error = response.json.get("error")
-        assert error.get("message") == "Invalid path /some/repo"
+        assert error.get("message") == "no_git_repo"
 
 
 @pytest.mark.parametrize(
@@ -653,7 +653,7 @@ async def test_post_session_launcher_with_advanced_environment_build(
     elif expected_status_code == 500:
         assert response.json is not None
         error = response.json.get("error")
-        assert error.get("message") == "Invalid path /some/repo"
+        assert error.get("message") == "no_git_repo"
 
 
 @pytest.mark.asyncio

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -535,24 +535,25 @@ async def test_post_session_launcher_with_environment_build(
         assert environment.get("environment_image_source") == "build"
         assert environment.get("container_image") == "image:unknown-at-the-moment"
 
-        _, response = await sanic_client.get(
-            f"/api/data/environments/{environment_id}/builds",
-            headers=user_headers,
-        )
-        assert response.status_code == 200, response.text
-        build = response.json[0]
-        build_id = build["id"]
+        if builds_enabled:
+            _, response = await sanic_client.get(
+                f"/api/data/environments/{environment_id}/builds",
+                headers=user_headers,
+            )
+            assert response.status_code == 200, response.text
+            build = response.json[0]
+            build_id = build["id"]
 
-        api = kr8s.api(kubeconfig=cluster.kubeconfig)
-        build_run = BuildRun.get(name=f"renku-{build_id.lower()}", api=api)
+            api = kr8s.api(kubeconfig=cluster.kubeconfig)
+            build_run = BuildRun.get(name=f"renku-{build_id.lower()}", api=api)
 
-        build_spec = build_run.spec.build.spec
-        if is_private:
-            assert build_spec.source.git.get("cloneSecret") is not None
-            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
-        else:
-            assert build_spec.source.git.get("cloneSecret") is None
-            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
+            build_spec = build_run.spec.build.spec
+            if is_private:
+                assert build_spec.source.git.get("cloneSecret") is not None
+                assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
+            else:
+                assert build_spec.source.git.get("cloneSecret") is None
+                assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
 
     elif expected_status_code == 500:
         assert response.json is not None
@@ -631,24 +632,25 @@ async def test_post_session_launcher_with_advanced_environment_build(
         assert environment.get("environment_image_source") == "build"
         assert environment.get("container_image") == "image:unknown-at-the-moment"
 
-        _, response = await sanic_client.get(
-            f"/api/data/environments/{environment_id}/builds",
-            headers=user_headers,
-        )
-        assert response.status_code == 200, response.text
-        build = response.json[0]
-        build_id = build["id"]
+        if builds_enabled:
+            _, response = await sanic_client.get(
+                f"/api/data/environments/{environment_id}/builds",
+                headers=user_headers,
+            )
+            assert response.status_code == 200, response.text
+            build = response.json[0]
+            build_id = build["id"]
 
-        api = kr8s.api(kubeconfig=cluster.kubeconfig)
-        build_run = BuildRun.get(name=f"renku-{build_id.lower()}", api=api)
+            api = kr8s.api(kubeconfig=cluster.kubeconfig)
+            build_run = BuildRun.get(name=f"renku-{build_id.lower()}", api=api)
 
-        build_spec = build_run.spec.build.spec
-        if is_private:
-            assert build_spec.source.git.get("cloneSecret") is not None
-            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
-        else:
-            assert build_spec.source.git.get("cloneSecret") is None
-            assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
+            build_spec = build_run.spec.build.spec
+            if is_private:
+                assert build_spec.source.git.get("cloneSecret") is not None
+                assert build_spec.output.image.startswith(app_manager.config.builds.build_output_private_image_prefix)
+            else:
+                assert build_spec.source.git.get("cloneSecret") is None
+                assert build_spec.output.image.startswith(app_manager.config.builds.build_output_image_prefix)
 
     elif expected_status_code == 500:
         assert response.json is not None

--- a/test/bases/renku_data_services/data_api/utils.py
+++ b/test/bases/renku_data_services/data_api/utils.py
@@ -52,7 +52,7 @@ def create_dummy_oauth_client(
 async def create_rp(payload: dict[str, Any], test_client: SanicASGITestClient) -> tuple[Request, TestingResponse]:
     return await test_client.post(
         "/api/data/resource_pools",
-        headers={"Authorization": 'Bearer {"is_admin": true}'},
+        headers={"Authorization": 'Bearer {"id": "admin", "is_admin": true}'},
         data=json.dumps(payload),
     )
 

--- a/test/components/renku_data_services/connected_services/test_oauth_http.py
+++ b/test/components/renku_data_services/connected_services/test_oauth_http.py
@@ -92,7 +92,7 @@ async def test_lookup_token_on_error(app_manager_instance: DependencyManager) ->
 async def test_store_new_token(app_manager_instance: DependencyManager) -> None:
     new_token = {"access_token": "access_xyz", "refresh_token": "refresh_xyz"}
 
-    class TestTokenClient(_SafeAsyncOAuthClient):
+    class TokenClient(_SafeAsyncOAuthClient):
         async def refresh_token(self, url=None, refresh_token=None, body: str = "", auth=None, headers=None, **kwargs):
             return new_token
 
@@ -102,7 +102,7 @@ async def test_store_new_token(app_manager_instance: DependencyManager) -> None:
     factory = DefaultOAuthHttpClientFactory(deps.config.secrets.encryption_key, deps.config.db.async_session_maker)
     (client, conn) = await _setup_connection(deps, ConnectionStatus.connected)
 
-    oauth_client = TestTokenClient(
+    oauth_client = TokenClient(
         client.client_id,
         token={"expires_at": 1},
         connection_id=conn.id,

--- a/test/components/renku_data_services/resource_usage/test_core.py
+++ b/test/components/renku_data_services/resource_usage/test_core.py
@@ -28,7 +28,7 @@ from test.components.renku_data_services.resource_usage import test_db
 interval = timedelta(seconds=600)
 
 
-class TestResourceRequestsFetch(ResourceRequestsFetchProto):
+class ResourceRequestsFetcher(ResourceRequestsFetchProto):
     def __init__(self, data: list[ResourcesRequest]) -> None:
         self.data = data
 
@@ -46,7 +46,7 @@ class TestResourceRequestsFetch(ResourceRequestsFetchProto):
 async def test_record_empty_resource_requests(app_manager_instance: DependencyManager) -> None:
     run_migrations_for_app("common")
 
-    fetch = TestResourceRequestsFetch([])
+    fetch = ResourceRequestsFetcher([])
     repo = ResourceRequestsRepo(app_manager_instance.config.db.async_session_maker)
     recorder = DefaultResourcesRequestRecorder(repo, fetch)
     await recorder.record_resource_requests(interval)
@@ -122,7 +122,7 @@ async def test_record_resource_requests(app_manager_instance: DependencyManager)
         ),
     ]
 
-    fetch = TestResourceRequestsFetch(data)
+    fetch = ResourceRequestsFetcher(data)
     recorder = DefaultResourcesRequestRecorder(repo, fetch)
     await recorder.record_resource_requests(interval)
     all = [item async for item in repo.find_all()]

--- a/test/components/renku_data_services/search/test_solr_user_query.py
+++ b/test/components/renku_data_services/search/test_solr_user_query.py
@@ -38,7 +38,7 @@ ctx: Context = Context.for_anonymous(ref_date, UTC)
 
 
 @dataclass
-class TestAuthAccess(AuthAccess):
+class DummyAuthAccess(AuthAccess):
     result: list[str]
 
     async def get_ids_for_role(
@@ -48,7 +48,7 @@ class TestAuthAccess(AuthAccess):
 
     @classmethod
     def of(cls, *args: str) -> AuthAccess:
-        return TestAuthAccess(list(args))
+        return cls(list(args))
 
 
 def midnight(d: datetime) -> datetime:
@@ -96,10 +96,10 @@ async def test_from_term() -> None:
 
     assert await to_solr(ctx, S.role_is(Role.OWNER)) == st.empty()
     assert await to_solr(
-        ctx.with_user_role("user1").with_auth_access(TestAuthAccess.of("id1", "id2")), S.role_is(Role.OWNER)
+        ctx.with_user_role("user1").with_auth_access(DummyAuthAccess.of("id1", "id2")), S.role_is(Role.OWNER)
     ) == st.id_in(Nel.of("id1", "id2"))
     assert await to_solr(
-        ctx.with_admin_role("user1").with_auth_access(TestAuthAccess.of("id1", "id2")), S.role_is(Role.OWNER)
+        ctx.with_admin_role("user1").with_auth_access(DummyAuthAccess.of("id1", "id2")), S.role_is(Role.OWNER)
     ) == st.id_in(Nel.of("id1", "id2"))
 
 

--- a/test/components/renku_data_services/search/test_user_query.py
+++ b/test/components/renku_data_services/search/test_user_query.py
@@ -181,7 +181,7 @@ def test_resolve_date_calc() -> None:
     )
 
 
-class TestUserQueryTransform(EmptyUserQueryVisitor[UserQuery]):
+class UserQueryTransformer(EmptyUserQueryVisitor[UserQuery]):
     def __init__(self, to_add: Segment) -> None:
         self.segments: list[Segment] = []
         self.to_add = to_add
@@ -204,7 +204,8 @@ class TestUserQueryTransform(EmptyUserQueryVisitor[UserQuery]):
 async def test_transform() -> None:
     q0 = UserQuery.of(Segments.name_is("john"), Segments.text("help"))
     q = await q0.transform(
-        TestUserQueryTransform(Segments.type_is(EntityType.project)), TestUserQueryTransform(Segments.id_is("id-123"))
+        UserQueryTransformer(Segments.type_is(EntityType.project)),
+        UserQueryTransformer(Segments.id_is("id-123")),
     )
 
     assert q == UserQuery(q0.segments + [Segments.type_is(EntityType.project), Segments.id_is("id-123")])

--- a/test/components/renku_data_services/users/test_db.py
+++ b/test/components/renku_data_services/users/test_db.py
@@ -15,7 +15,7 @@ from renku_data_services.users.models import UserInfo
 
 
 @dataclass
-class TestUsernameResolver(DbUsernameResolver):
+class UsernameResolver(DbUsernameResolver):
     session_maker: Callable[..., AsyncSession]
 
     def make_session(self) -> AsyncSession:
@@ -35,7 +35,7 @@ async def test_username_resolve(app_manager_instance) -> None:
     user_info1 = cast(UserInfo, await user_repo.get_or_create_user(user1, str(user1.id)))
     user_info2 = cast(UserInfo, await user_repo.get_or_create_user(user2, str(user2.id)))
 
-    resolver = TestUsernameResolver(app_manager_instance.config.db.async_session_maker)
+    resolver = UsernameResolver(app_manager_instance.config.db.async_session_maker)
     data = await resolver.resolve_usernames(Nel.of("a.b", _username(user_info1), _username(user_info2)))
     assert data is not None
     assert data.get(_username(user_info1)) == user_info1.id

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -216,12 +216,18 @@ async def dummy_users():
 
 
 def pytest_addoption(parser):
+    parser.addoption("--disable-cluster-creation", action="store_true", default=False, help="Disable cluster creation")
     parser.addoption("--enable-builds", action="store_true", default=False, help="Enable builds")
 
 
 @pytest.fixture(scope="session")
 def builds_enabled(request):
     return request.config.getoption("--enable-builds")
+
+
+@pytest_asyncio.fixture(scope="session")
+def disable_cluster_creation(request):
+    return request.config.getoption("--disable-cluster-creation")
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -509,16 +509,20 @@ def cluster_name():
 
 
 @pytest.fixture(scope="session")
-def kubeconfig_path(monkeysession):
-    kconf = ".kind-kubeconfig.yaml"
+def kubeconfig_path(monkeysession, disable_cluster_creation):
+    kconf = str(Path("~/.kube/config").expanduser()) if disable_cluster_creation else ".kind-kubeconfig.yaml"
     monkeysession.setenv("KUBECONFIG", kconf)
     return Path(kconf)
 
 
 @pytest.fixture(scope="session")
-def cluster(cluster_name, kubeconfig_path: Path, monkeysession):
+def cluster(cluster_name, kubeconfig_path: Path, monkeysession, disable_cluster_creation, builds_enabled):
     # NOTE: The config_name of the cluster has to match the name of the
     # kubeconfig file in the K8S_CONFIGS_ROOT folder
     monkeysession.setenv("K8S_CONFIGS_ROOT", kubeconfig_path.parent.absolute().as_posix())
-    with KindCluster(cluster_name, kubeconfig=str(kubeconfig_path)) as cluster:
+    with KindCluster(
+        cluster_name,
+        kubeconfig=str(kubeconfig_path),
+        create_cluster=not disable_cluster_creation,
+    ) as cluster:
         yield cluster

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -530,9 +530,13 @@ def cluster_name():
 
 
 @pytest.fixture(scope="session")
-def kubeconfig_path(monkeysession, disable_cluster_creation):
-    kconf = str(Path("~/.kube/config").expanduser()) if disable_cluster_creation else ".kind-kubeconfig.yaml"
-    monkeysession.setenv("KUBECONFIG", kconf)
+def kubeconfig_path(monkeysession, disable_cluster_creation, tmpdir_factory):
+    if disable_cluster_creation:
+        kconf = Path("~/.kube/config").expanduser()
+    else:
+        tmp_path = tmpdir_factory.mktemp("kube")
+        kconf = tmp_path / ".kind-kubeconfig.yaml"
+    monkeysession.setenv("KUBECONFIG", str(kconf))
     return Path(kconf)
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -243,11 +243,14 @@ async def app_manager(
     monkeysession.setenv("DATA_DEPOSITS_JOB_IMAGE", "test-deposit-image")
     monkeysession.setenv("RENKU_URL", "http://test-renku-url.io")
     monkeysession.setenv("KUBERNETES_NAMESPACE", "default")
+    monkeysession.setenv("BUILD_PUSH_SECRET_NAME", constants.BUILD_DEFAULT_PUSH_SECRET_NAME)
 
     monkeysession.setenv("CREATE_BUILDS_CLIENT", str(builds_enabled))
     if builds_enabled:
         monkeysession.setenv("BUILD_OUTPUT_IMAGE_PREFIX", constants.BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX)
         monkeysession.setenv("BUILD_OUTPUT_PRIVATE_IMAGE_PREFIX", constants.BUILD_DEFAULT_OUTPUT_PRIVATE_IMAGE_PREFIX)
+        monkeysession.setenv("BUILD_OUTPUT_PRIVATE_IMAGE_PREFIX", constants.BUILD_DEFAULT_OUTPUT_PRIVATE_IMAGE_PREFIX)
+        monkeysession.setenv("BUILD_PUSH_PRIVATE_SECRET_NAME", constants.BUILD_DEFAULT_PUSH_PRIVATE_SECRET_NAME)
 
     dm = TestDependencyManager.from_env(dummy_users)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -214,9 +214,18 @@ async def dummy_users():
     ]
 
 
+def pytest_addoption(parser):
+    parser.addoption("--enable-builds", action="store_true", default=False, help="Enable builds")
+
+
+@pytest.fixture(scope="session")
+def builds_enabled(request):
+    return request.config.getoption("--enable-builds")
+
+
 @pytest_asyncio.fixture(scope="session")
 async def app_manager(
-    authz_setup, monkeysession, worker_id, secrets_key_pair, dummy_users, kubeconfig_path: Path
+    authz_setup, monkeysession, worker_id, secrets_key_pair, dummy_users, kubeconfig_path: Path, builds_enabled
 ) -> AsyncGenerator[DependencyManager, None]:
     monkeysession.setenv("DUMMY_STORES", "true")
     monkeysession.setenv("MAX_PINNED_PROJECTS", "5")
@@ -227,6 +236,7 @@ async def app_manager(
     monkeysession.setenv("DATA_DEPOSITS_JOB_IMAGE", "test-deposit-image")
     monkeysession.setenv("RENKU_URL", "http://test-renku-url.io")
     monkeysession.setenv("KUBERNETES_NAMESPACE", "default")
+    monkeysession.setenv("CREATE_BUILDS_CLIENT", str(builds_enabled))
 
     dm = TestDependencyManager.from_env(dummy_users)
 
@@ -524,5 +534,6 @@ def cluster(cluster_name, kubeconfig_path: Path, monkeysession, disable_cluster_
         cluster_name,
         kubeconfig=str(kubeconfig_path),
         create_cluster=not disable_cluster_creation,
+        setup_shipwright=builds_enabled,
     ) as cluster:
         yield cluster

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,6 +31,7 @@ from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.data_connectors.doi.models import DOIMetadata, SchemaOrgDataset
 from renku_data_services.db_config.config import DBConfig
 from renku_data_services.secrets_storage_api.dependencies import DependencyManager as SecretsDependencyManager
+from renku_data_services.session import constants
 from renku_data_services.solr import entity_schema
 from renku_data_services.solr.solr_client import SolrClientConfig
 from renku_data_services.solr.solr_migrate import SchemaMigrator
@@ -236,7 +237,11 @@ async def app_manager(
     monkeysession.setenv("DATA_DEPOSITS_JOB_IMAGE", "test-deposit-image")
     monkeysession.setenv("RENKU_URL", "http://test-renku-url.io")
     monkeysession.setenv("KUBERNETES_NAMESPACE", "default")
+
     monkeysession.setenv("CREATE_BUILDS_CLIENT", str(builds_enabled))
+    if builds_enabled:
+        monkeysession.setenv("BUILD_OUTPUT_IMAGE_PREFIX", constants.BUILD_DEFAULT_OUTPUT_IMAGE_PREFIX)
+        monkeysession.setenv("BUILD_OUTPUT_PRIVATE_IMAGE_PREFIX", constants.BUILD_DEFAULT_OUTPUT_PRIVATE_IMAGE_PREFIX)
 
     dm = TestDependencyManager.from_env(dummy_users)
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -230,8 +230,10 @@ class FakeGitRepositoriesRepository(GitRepositoriesRepository):
                         visibility=repositories_models.RepositoryVisibility.private,
                     )
                 )
+            case "/some/repo":
+                result = result.with_error(GitUrlError.no_git_repo)
             case _:
-                result = result.with_error(f"Invalid path {valid_url.parsed_url.path}")
+                result = await super().get_repository(repository_url, user, etag, internal_gitlab_user)
 
         return result
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -553,6 +553,7 @@ class KindCluster(AbstractContextManager):
         cluster_name: str,
         kubeconfig=".kind-kubeconfig.yaml",
         extra_images: list[str] | None = None,
+        create_cluster: bool = True,
     ):
         self.cluster_name = cluster_name
         if extra_images is None:
@@ -561,9 +562,13 @@ class KindCluster(AbstractContextManager):
         self.kubeconfig = kubeconfig
         self.env = os.environ.copy()
         self.env["KUBECONFIG"] = self.kubeconfig
+        self.create_cluster = create_cluster
 
     def __enter__(self):
         """create kind cluster"""
+
+        if not self.create_cluster:
+            return self
 
         create_cluster = [
             "kind",
@@ -589,7 +594,8 @@ class KindCluster(AbstractContextManager):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """delete kind cluster"""
 
-        self._delete_cluster()
+        if self.create_cluster:
+            self._delete_cluster()
         return False
 
     def _delete_cluster(self):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,15 +1,23 @@
 from __future__ import annotations
 
+import base64
+import json
 import os
 import subprocess
 import typing
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, Self
 from unittest.mock import MagicMock
 
+import yaml
 from authzed.api.v1 import AsyncClient, SyncClient
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
+from kubernetes import watch
+from kubernetes.client import V1ObjectMeta
 from sanic import Request
 from sanic_testing.testing import ASGI_HOST, ASGI_PORT, SanicASGITestClient, TestingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -545,6 +553,113 @@ async def create_user_preferences(
     return user_preferences
 
 
+def setup_shipwright(cluster: KindCluster) -> None:
+    """Setup shipwright and dependencies"""
+
+    shipwright_version = "v0.19.2"
+
+    root = Path(__file__).parents[1]
+
+    k8s_config.load_kube_config_from_dict(yaml.safe_load(cluster.config_yaml()))
+
+    core_api = k8s_client.CoreV1Api()
+
+    cmds = [
+        [
+            "curl",
+            "--silent",
+            "--location",
+            f"https://raw.githubusercontent.com/shipwright-io/build/{shipwright_version}/hack/install-tekton.sh",
+            "-O",
+        ],
+        ["bash", "install-tekton.sh"],
+        [
+            "kubectl",
+            "apply",
+            "--filename",
+            f"https://github.com/shipwright-io/build/releases/download/{shipwright_version}/release.yaml",
+            "--server-side",
+        ],
+        [
+            "kubectl",
+            "apply",
+            "--filename",
+            f"https://github.com/shipwright-io/build/releases/download/{shipwright_version}/sample-strategies.yaml",
+            "--server-side",
+        ],
+        [
+            "curl",
+            "--silent",
+            "--location",
+            f"https://raw.githubusercontent.com/shipwright-io/build/{shipwright_version}/hack/setup-webhook-cert.sh",
+            "-O",
+        ],
+        ["bash", "setup-webhook-cert.sh"],
+        [
+            "curl",
+            "--silent",
+            "--location",
+            "https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh",
+            "-O",
+        ],
+        ["bash", "storage-version-migration.sh"],
+        [
+            "kubectl",
+            "apply",
+            "--filename",
+            str(root / "components/renku_pack_builder/manifests/buildstrategy.yaml"),
+            "--server-side",
+        ],
+    ]
+
+    # Setup tekton and shipwright
+    for cmd in cmds[0:-1]:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=cluster.env, check=True)
+
+    watcher = watch.Watch()
+
+    for event in watcher.stream(
+        core_api.list_namespaced_pod,
+        label_selector="name=shipwright-build",
+        namespace="shipwright-build",
+        timeout_seconds=3 * 60,
+    ):
+        if event["object"].status.phase == "Running":
+            watcher.stop()
+            break
+    else:
+        raise AssertionError("Timeout waiting on shipwright to run") from None
+
+    for event in watcher.stream(
+        core_api.list_namespaced_pod,
+        label_selector="name=shp-build-webhook",
+        namespace="shipwright-build",
+        timeout_seconds=3 * 60,
+    ):
+        if event["object"].status.phase == "Running":
+            watcher.stop()
+            break
+    else:
+        raise AssertionError("Timeout waiting on shp-build-webhook to run") from None
+
+    # Add our build strategy
+    subprocess.run(cmds[-1], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=cluster.env, check=True)
+
+    # Create a dummy secret to push to registry (we wont in the tests, it's for the BuildRun registration)
+    docker_config = {
+        "auths": {
+            "https://registry.localhost/": {
+                "username": "test",
+                "password": "test",
+                "auth": base64.b64encode(b"test:test").decode(),
+            }
+        }
+    }
+    secret_data = {".dockerconfigjson": base64.b64encode(json.dumps(docker_config).encode()).decode()}
+    secret = k8s_client.V1Secret(metadata=V1ObjectMeta(name="renku-build-secret"), data=secret_data)
+    core_api.create_namespaced_secret(namespace="default", body=secret)
+
+
 class KindCluster(AbstractContextManager):
     """Context manager that will create and tear down a k3s cluster"""
 
@@ -554,6 +669,7 @@ class KindCluster(AbstractContextManager):
         kubeconfig=".kind-kubeconfig.yaml",
         extra_images: list[str] | None = None,
         create_cluster: bool = True,
+        setup_shipwright: bool = False,
     ):
         self.cluster_name = cluster_name
         if extra_images is None:
@@ -563,6 +679,7 @@ class KindCluster(AbstractContextManager):
         self.env = os.environ.copy()
         self.env["KUBECONFIG"] = self.kubeconfig
         self.create_cluster = create_cluster
+        self.setup_shipwright = setup_shipwright
 
     def __enter__(self):
         """create kind cluster"""
@@ -588,6 +705,9 @@ class KindCluster(AbstractContextManager):
             else:
                 print(err)
             raise
+
+        if self.setup_shipwright:
+            setup_shipwright(self)
 
         return self
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -230,6 +230,14 @@ class FakeGitRepositoriesRepository(GitRepositoriesRepository):
                         visibility=repositories_models.RepositoryVisibility.private,
                     )
                 )
+            case "/SwissDataScienceCenter/other-private":
+                result = result.with_metadata(
+                    repositories_models.Metadata(
+                        git_url=valid_url.render(),
+                        pull_permission=False,
+                        visibility=repositories_models.RepositoryVisibility.private,
+                    )
+                )
             case "/some/repo":
                 result = result.with_error(GitUrlError.no_git_repo)
             case _:

--- a/test/utils.py
+++ b/test/utils.py
@@ -274,6 +274,7 @@ class TestDependencyManager(DependencyManager):
         secret_client = K8sSecretClient(client)
 
         shipwright_client = None
+        gitrepositoriesrepository_class = GitRepositoriesRepository
 
         if os.environ.get("CREATE_BUILDS_CLIENT", "false").lower() == "true":
             shipwright_client = ShipwrightClient(
@@ -288,6 +289,8 @@ class TestDependencyManager(DependencyManager):
                 ),
                 namespace=config.k8s_namespace,
             )
+
+            gitrepositoriesrepository_class = FakeGitRepositoriesRepository
 
         quota_repo = QuotaRepository(K8sResourceQuotaClient(client), K8sPriorityClassClient(client))
 
@@ -337,11 +340,6 @@ class TestDependencyManager(DependencyManager):
             group_repo=group_repo,
             search_updates_repo=search_updates_repo,
         )
-
-        if config.builds.enabled:
-            gitrepositoriesrepository_class = FakeGitRepositoriesRepository
-        else:
-            gitrepositoriesrepository_class = GitRepositoriesRepository
 
         git_repositories_repo = gitrepositoriesrepository_class(
             session_maker=config.db.async_session_maker,

--- a/test/utils.py
+++ b/test/utils.py
@@ -734,6 +734,8 @@ def setup_shipwright(cluster: KindCluster) -> None:
     secret_data = {".dockerconfigjson": base64.b64encode(json.dumps(docker_config).encode()).decode()}
     secret = k8s_client.V1Secret(metadata=V1ObjectMeta(name="renku-build-secret"), data=secret_data)
     core_api.create_namespaced_secret(namespace="default", body=secret)
+    secret = k8s_client.V1Secret(metadata=V1ObjectMeta(name="renku-build-private-secret"), data=secret_data)
+    core_api.create_namespaced_secret(namespace="default", body=secret)
 
 
 class KindCluster(AbstractContextManager):

--- a/test/utils.py
+++ b/test/utils.py
@@ -62,7 +62,9 @@ from renku_data_services.project.db import (
     ProjectRepository,
     ProjectSessionSecretRepository,
 )
+from renku_data_services.repositories import models as repositories_models
 from renku_data_services.repositories.db import GitRepositoriesRepository
+from renku_data_services.repositories.git_url import GitUrl, GitUrlError
 from renku_data_services.resource_usage.core import ResourceUsageService
 from renku_data_services.resource_usage.db import ResourceRequestsRepo
 from renku_data_services.search.db import SearchUpdatesRepo
@@ -70,6 +72,7 @@ from renku_data_services.search.reprovision import SearchReprovision
 from renku_data_services.secrets.db import LowLevelUserSecretsRepo, UserSecretsRepo
 from renku_data_services.session.constants import BUILD_RUN_GVK, TASK_RUN_GVK
 from renku_data_services.session.db import SessionRepository
+from renku_data_services.session.k8s_client import ShipwrightClient
 from renku_data_services.storage import models as storage_models
 from renku_data_services.storage.db import StorageRepository
 from renku_data_services.users import models as user_preferences_models
@@ -187,6 +190,52 @@ class NonCachingAuthz(Authz):
         return self.authz_config.authz_async_client()
 
 
+class FakeGitRepositoriesRepository(GitRepositoriesRepository):
+    """Test class to simulate repository visibility checks and token retrieval"""
+
+    async def get_token(self, repository_url, user) -> dict[str, Any] | None:
+        """Get token for repository provider."""
+        return {"access_token": "dummy token"}
+
+    async def get_repository(
+        self,
+        repository_url,
+        user,
+        etag,
+        internal_gitlab_user,
+    ) -> repositories_models.RepositoryDataResult:
+        """Get metadata about one repository."""
+
+        match GitUrl.parse(repository_url):
+            case GitUrlError() as err:
+                return repositories_models.RepositoryDataResult(error=err)
+            case url:
+                valid_url = url
+                result = repositories_models.RepositoryDataResult()
+
+        match valid_url.parsed_url.path:
+            case "/SwissDataScienceCenter/renku":
+                result = result.with_metadata(
+                    repositories_models.Metadata(
+                        git_url=valid_url.render(),
+                        pull_permission=True,
+                        visibility=repositories_models.RepositoryVisibility.public,
+                    )
+                )
+            case "/SwissDataScienceCenter/private":
+                result = result.with_metadata(
+                    repositories_models.Metadata(
+                        git_url=valid_url.render(),
+                        pull_permission=True,
+                        visibility=repositories_models.RepositoryVisibility.private,
+                    )
+                )
+            case _:
+                result = result.with_error(f"Invalid path {valid_url.parsed_url.path}")
+
+        return result
+
+
 @dataclass
 class TestDependencyManager(DependencyManager):
     """Test class that can handle isolated dbs and authz instances."""
@@ -218,8 +267,26 @@ class TestDependencyManager(DependencyManager):
                 kinds_to_cache=[AMALTHEA_SESSION_GVK, JUPYTER_SESSION_GVK, BUILD_RUN_GVK, TASK_RUN_GVK],
             ),
         )
+
         job_client = DepositUploadJobClient(client)
         secret_client = K8sSecretClient(client)
+
+        shipwright_client = None
+
+        if os.environ.get("CREATE_BUILDS_CLIENT", "false").lower() == "true":
+            shipwright_client = ShipwrightClient(
+                client=K8sClusterClientsPool(
+                    lambda: get_clusters(
+                        kube_conf_root_dir=config.k8s_config_root,
+                        default_kubeconfig=default_kubeconfig,
+                        cluster_repo=cluster_repo,
+                        cache=k8s_db_cache,
+                        kinds_to_cache=[AMALTHEA_SESSION_GVK, JUPYTER_SESSION_GVK, BUILD_RUN_GVK, TASK_RUN_GVK],
+                    ),
+                ),
+                namespace=config.k8s_namespace,
+            )
+
         quota_repo = QuotaRepository(K8sResourceQuotaClient(client), K8sPriorityClassClient(client))
 
         authenticator = DummyAuthenticator()
@@ -268,12 +335,26 @@ class TestDependencyManager(DependencyManager):
             group_repo=group_repo,
             search_updates_repo=search_updates_repo,
         )
+
+        if config.builds.enabled:
+            gitrepositoriesrepository_class = FakeGitRepositoriesRepository
+        else:
+            gitrepositoriesrepository_class = GitRepositoriesRepository
+
+        git_repositories_repo = gitrepositoriesrepository_class(
+            session_maker=config.db.async_session_maker,
+            internal_gitlab_url=config.gitlab_url,
+            enable_internal_gitlab=config.enable_internal_gitlab,
+            oauth_client_factory=oauth_client_factory,
+        )
+
         session_repo = SessionRepository(
             session_maker=config.db.async_session_maker,
             project_authz=authz,
             resource_pools=rp_repo,
-            shipwright_client=None,
+            shipwright_client=shipwright_client,
             builds_config=config.builds,
+            git_repositories_repo=git_repositories_repo,
         )
         project_migration_repo = ProjectMigrationRepository(
             session_maker=config.db.async_session_maker,
@@ -307,12 +388,6 @@ class TestDependencyManager(DependencyManager):
         connected_services_repo = ConnectedServicesRepository(
             session_maker=config.db.async_session_maker,
             encryption_key=config.secrets.encryption_key,
-            oauth_client_factory=oauth_client_factory,
-        )
-        git_repositories_repo = GitRepositoriesRepository(
-            session_maker=config.db.async_session_maker,
-            internal_gitlab_url=config.gitlab_url,
-            enable_internal_gitlab=config.enable_internal_gitlab,
             oauth_client_factory=oauth_client_factory,
         )
         platform_repo = PlatformRepository(
@@ -361,6 +436,7 @@ class TestDependencyManager(DependencyManager):
         occurrence_repo = OccurrenceRepository(session_maker=config.db.async_session_maker)
         resource_requests_repo = ResourceRequestsRepo(session_maker=config.db.async_session_maker)
         resource_usage_service = ResourceUsageService(resource_requests_repo)
+
         return cls(
             config=config,
             k8s_client=client,
@@ -395,7 +471,7 @@ class TestDependencyManager(DependencyManager):
             image_check_repo=image_check_repo,
             metrics_repo=metrics_repo,
             metrics=metrics_mock,
-            shipwright_client=None,
+            shipwright_client=shipwright_client,
             authz=authz,
             low_level_user_secrets_repo=low_level_user_secrets_repo,
             url_redirect_repo=url_redirect_repo,


### PR DESCRIPTION
## Describe your changes

This PR implements building images from private repositories.

### Breakdown

- Launcher creation for build environment will now support private repositories
- Logic for passing credentials to Shipwright on a per build basis
- Public repositories will not use credentials
- Updated tests to also be able to validate build features
- Refactored caching logic client side
- Session starting with a custom built image will now:
  - ensure that the repo of the project matches the one used to build the image
  - ensure that the user can pull the repository

---

<code>
/deploy #notest renku=feat/private-repository-build extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.outputPrivateImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user
</code>