### PR TITLE
Feat: authz resource pools feature parity

### DIFF
--- a/bases/renku_data_services/data_api/config.py
+++ b/bases/renku_data_services/data_api/config.py
@@ -65,7 +65,7 @@ class Config:
             else:
                 gitlab_url = None
 
-        nb_config=NotebooksConfig.from_env(db, authz_config, enable_internal_gitlab=enable_internal_gitlab)
+        nb_config = NotebooksConfig.from_env(db, authz_config, enable_internal_gitlab=enable_internal_gitlab)
         return cls(
             enable_internal_gitlab=enable_internal_gitlab,
             version=os.environ.get("VERSION", "0.0.1"),

--- a/bases/renku_data_services/data_api/config.py
+++ b/bases/renku_data_services/data_api/config.py
@@ -51,6 +51,8 @@ class Config:
         if db is None:
             db = DBConfig.from_env()
 
+        authz_config = AuthzConfig.from_env()
+
         if dummy_stores:
             keycloak = None
             gitlab_url = None
@@ -63,7 +65,7 @@ class Config:
             else:
                 gitlab_url = None
 
-        nb_config = NotebooksConfig.from_env(db, enable_internal_gitlab=enable_internal_gitlab)
+        nb_config=NotebooksConfig.from_env(db, authz_config, enable_internal_gitlab=enable_internal_gitlab)
         return cls(
             enable_internal_gitlab=enable_internal_gitlab,
             version=os.environ.get("VERSION", "0.0.1"),
@@ -76,7 +78,7 @@ class Config:
             secrets=PublicSecretsConfig.from_env(),
             sentry=SentryConfig.from_env(),
             posthog=PosthogConfig.from_env(),
-            authz_config=AuthzConfig.from_env(),
+            authz_config=authz_config,
             solr=SolrClientConfig.from_env(),
             trusted_proxies=TrustedProxiesConfig.from_env(),
             keycloak=keycloak,

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -326,8 +326,11 @@ class DependencyManager:
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
+            authz=authz,
         )
-        rp_repo = ResourcePoolRepository(session_maker=config.db.async_session_maker, quotas_repo=quota_repo)
+        rp_repo = ResourcePoolRepository(
+            session_maker=config.db.async_session_maker, quotas_repo=quota_repo, authz=authz
+        )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,
             gitlab_client=gitlab_client,

--- a/bases/renku_data_services/k8s_cache/config.py
+++ b/bases/renku_data_services/k8s_cache/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from renku_data_services.app_config.config import SentryConfig
+from renku_data_services.authz.config import AuthzConfig
 from renku_data_services.db_config.config import DBConfig
 
 
@@ -74,6 +75,7 @@ class Config:
     metrics: _MetricsConfig
     image_builders: _ImageBuilderConfig
     v1_services: _V1ServicesConfig
+    authz: AuthzConfig
     sentry: SentryConfig
 
     @classmethod
@@ -84,6 +86,7 @@ class Config:
         metrics = _MetricsConfig.from_env()
         image_builders = _ImageBuilderConfig.from_env()
         v1_services = _V1ServicesConfig.from_env()
+        authz = AuthzConfig.from_env()
         sentry = SentryConfig.from_env()
         return cls(
             db=db,
@@ -91,5 +94,6 @@ class Config:
             metrics=metrics,
             image_builders=image_builders,
             v1_services=v1_services,
+            authz=authz,
             sentry=sentry,
         )

--- a/bases/renku_data_services/k8s_cache/dependencies.py
+++ b/bases/renku_data_services/k8s_cache/dependencies.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 
+from renku_data_services.authz.authz import Authz
 from renku_data_services.crc.db import ClusterRepository, QuotaRepository, ResourcePoolRepository
 from renku_data_services.k8s.clients import DummyPriorityClassClient, DummyResourceQuotaClient
 from renku_data_services.k8s.db import K8sDbCache
@@ -20,6 +21,7 @@ class DependencyManager:
     _k8s_cache: K8sDbCache | None = field(default=None, repr=False, init=False)
     _metrics_repo: MetricsRepository | None = field(default=None, repr=False, init=False)
     _metrics: StagingMetricsService | None = field(default=None, repr=False, init=False)
+    _authz: Authz | None = field(default=None, repr=False, init=False)
     _rp_repo: ResourcePoolRepository | None = field(default=None, repr=False, init=False)
     _cluster_repo: ClusterRepository | None = field(default=None, repr=False, init=False)
 
@@ -35,11 +37,17 @@ class DependencyManager:
             self._metrics = StagingMetricsService(enabled=self.config.metrics.enabled, metrics_repo=self.metrics_repo())
         return self._metrics
 
+    def authz(self) -> Authz:
+        """The authorization service."""
+        if not self._authz:
+            self._authz = Authz(authz_config=self.config.authz)
+        return self._authz
+
     def rp_repo(self) -> ResourcePoolRepository:
         """The resource pool repository."""
         if not self._rp_repo:
             self._rp_repo = ResourcePoolRepository(
-                session_maker=self.config.db.async_session_maker, quotas_repo=self.quota_repo()
+                session_maker=self.config.db.async_session_maker, quotas_repo=self.quota_repo(), authz=self.authz()
             )
         return self._rp_repo
 

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -1392,11 +1392,9 @@ class Authz:
 
         if resource_pool.public:
             # For undo, only remove wildcards if they didn't exist before
-            # existing_ids = {rel.subject.object.object_id for rel in existing_rels}
             existing_subjects = {
                 (rel.subject.object.object_type, rel.subject.object.object_id) for rel in existing_rels
             }
-            # if "all-users" in existing_ids or "*" in existing_ids:
             if ("user", "*") not in existing_subjects:
                 apply_updates.append(
                     RelationshipUpdate(
@@ -1410,7 +1408,6 @@ class Authz:
                         relationship=all_users_are_public,
                     )
                 )
-            # if "anonymous-user:*" in existing_ids or "*" in existing_ids:
             if ("anonymous_user", "*") not in existing_subjects:
                 apply_updates.append(
                     RelationshipUpdate(

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -633,8 +633,8 @@ class Authz:
                     if len(found_users) > 1:
                         raise errors.ProgrammingError(
                             message="The decorator for authorization database changes found two APIUser parameters in"
-                            " the 'user', 'requested_by' and 'api_user' keyword arguments but expected only one of them to be "
-                            "present."
+                            " the 'user', 'requested_by' and 'api_user' keyword arguments but expected only one of "
+                            "them to be present."
                         )
                     potential_user = found_users[0] if found_users else None
                 else:
@@ -740,29 +740,23 @@ class Authz:
                     case AuthzOperation.delete, ResourceType.resource_pool if isinstance(result, DeletedResourcePool):
                         user = _extract_user_from_args(*func_args, **func_kwargs)
                         authz_change = await db_repo.authz._remove_resource_pool(user, result)
-                    case AuthzOperation.create, ResourceType.resource_pool_member if isinstance(
-                        result, ResourcePoolMembershipChange
-                    ):
-                        authz_change = await db_repo.authz._add_resource_pool_members(
-                            result.resource_pool_id, result.user_ids
-                        )
-                    case AuthzOperation.delete, ResourceType.resource_pool_member if isinstance(
-                        result, ResourcePoolMembershipChange
-                    ):
-                        authz_change = await db_repo.authz._remove_resource_pool_members(
-                            result.resource_pool_id, result.user_ids
-                        )
-                    case AuthzOperation.create, ResourceType.resource_pool_prohibited if isinstance(
-                        result, ResourcePoolMembershipChange
-                    ):
-                        authz_change = await db_repo.authz._add_resource_pool_prohibited(
-                            result.resource_pool_id, result.user_ids
-                        )
-                    case AuthzOperation.delete, ResourceType.resource_pool_prohibited if isinstance(
-                        result, ResourcePoolMembershipChange
-                    ):
-                        authz_change = await db_repo.authz._remove_resource_pool_prohibited(
-                            result.resource_pool_id, result.user_ids
+                    case (
+                        (AuthzOperation.create | AuthzOperation.delete),
+                        (ResourceType.resource_pool_member | ResourceType.resource_pool_prohibited),
+                    ) if isinstance(result, ResourcePoolMembershipChange):
+                        authz_operation = {
+                            AuthzOperation.create: RelationshipUpdate.OPERATION_TOUCH,
+                            AuthzOperation.delete: RelationshipUpdate.OPERATION_DELETE,
+                        }[operation]
+                        relation = {
+                            ResourceType.resource_pool_member: _Relation.viewer.value,
+                            ResourceType.resource_pool_prohibited: _Relation.prohibited.value,
+                        }[resource]
+                        authz_change = await db_repo.authz._update_resource_pool_user_relationships(
+                            resource_pool_id=result.resource_pool_id,
+                            user_ids=result.user_ids,
+                            relation=relation,
+                            operation=authz_operation,
                         )
                     case (
                         (AuthzOperation.create | AuthzOperation.delete),
@@ -1456,77 +1450,44 @@ class Authz:
         undo = WriteRelationshipsRequest(updates=undo_updates)
         return _AuthzChange(apply=apply, undo=undo)
 
-    async def _add_resource_pool_members(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
-        """Grant member access to users on a resource pool."""
-        rels = [
-            Relationship(
-                resource=_AuthzConverter.resource_pool(resource_pool_id),
-                relation=_Relation.viewer.value,
-                subject=_AuthzConverter.user_subject(uid),
-            )
-            for uid in user_ids
-        ]
-        apply = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
-        )
-        undo = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
-        )
-        return _AuthzChange(apply=apply, undo=undo)
+    async def _update_resource_pool_user_relationships(
+        self,
+        resource_pool_id: int,
+        user_ids: Collection[str],
+        relation: str,
+        operation: RelationshipUpdate.Operation.ValueType,
+    ) -> _AuthzChange:
+        """Create an AuthzChange for resource pool user relationships.
 
-    async def _remove_resource_pool_members(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
-        """Revoke member access from users on a resource pool."""
-        rels = [
-            Relationship(
-                resource=_AuthzConverter.resource_pool(resource_pool_id),
-                relation=_Relation.viewer.value,
-                subject=_AuthzConverter.user_subject(uid),
-            )
-            for uid in user_ids
-        ]
-        apply = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
-        )
-        undo = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
-        )
-        return _AuthzChange(apply=apply, undo=undo)
+        Args:
+            resource_pool_id: The ID of the resource pool.
+            user_ids: Keycloak IDs of the users to update.
+            relation: The SpiceDB relation name (e.g. "member", "prohibited").
+            operation: OPERATION_TOUCH to add, OPERATION_DELETE to remove.
 
-    async def _add_resource_pool_prohibited(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
-        """Mark users as prohibited from accessing a resource pool (overrides public_viewer wildcard)."""
-        rels = [
-            Relationship(
-                resource=_AuthzConverter.resource_pool(resource_pool_id),
-                relation=_Relation.prohibited.value,
-                subject=_AuthzConverter.user_subject(uid),
-            )
-            for uid in user_ids
-        ]
-        apply = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
-        )
-        undo = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
-        )
-        return _AuthzChange(apply=apply, undo=undo)
+        Returns:
+            An _AuthzChange with apply and undo WriteRelationshipsRequests.
+        """
+        inverse_operation = {
+            RelationshipUpdate.OPERATION_TOUCH: RelationshipUpdate.OPERATION_DELETE,
+            RelationshipUpdate.OPERATION_DELETE: RelationshipUpdate.OPERATION_TOUCH,
+        }[operation]
+        apply_updates: list[RelationshipUpdate] = []
+        undo_updates: list[RelationshipUpdate] = []
 
-    async def _remove_resource_pool_prohibited(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
-        """Un-prohibit users from a resource pool."""
-        rels = [
-            Relationship(
+        for uid in user_ids:
+            rel = Relationship(
                 resource=_AuthzConverter.resource_pool(resource_pool_id),
-                relation=_Relation.prohibited.value,
+                relation=relation,
                 subject=_AuthzConverter.user_subject(uid),
             )
-            for uid in user_ids
-        ]
-        apply = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
+            apply_updates.append(RelationshipUpdate(operation=operation, relationship=rel))
+            undo_updates.append(RelationshipUpdate(operation=inverse_operation, relationship=rel))
+
+        return _AuthzChange(
+            apply=WriteRelationshipsRequest(updates=apply_updates),
+            undo=WriteRelationshipsRequest(updates=undo_updates),
         )
-        undo = WriteRelationshipsRequest(
-            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
-        )
-        return _AuthzChange(apply=apply, undo=undo)
 
     async def _remove_admin(self, user_id: str) -> _AuthzChange:
         """Add a deployment-wide administrator in the authorization database."""

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -737,6 +737,33 @@ class Authz:
                     case AuthzOperation.delete, ResourceType.resource_pool if isinstance(result, DeletedResourcePool):
                         user = _extract_user_from_args(*func_args, **func_kwargs)
                         authz_change = await db_repo.authz._remove_resource_pool(user, result)
+                    case AuthzOperation.create, ResourceType.resource_pool_member if isinstance(
+                        result, ResourcePoolMembershipChange
+                    ):
+                        authz_change = await db_repo.authz._add_resource_pool_members(
+                            result.resource_pool_id, result.user_ids
+                        )
+                    case AuthzOperation.delete, ResourceType.resource_pool_member if isinstance(
+                        result, ResourcePoolMembershipChange
+                    ):
+                        authz_change = await db_repo.authz._remove_resource_pool_members(
+                            result.resource_pool_id, result.user_ids
+                        )
+                    case AuthzOperation.create, ResourceType.resource_pool_prohibited if isinstance(
+                        result, ResourcePoolMembershipChange
+                    ):
+                        authz_change = await db_repo.authz._add_resource_pool_prohibited(
+                            result.resource_pool_id, result.user_ids
+                        )
+                    case AuthzOperation.delete, ResourceType.resource_pool_prohibited if isinstance(
+                        result, ResourcePoolMembershipChange
+                    ):
+                        authz_change = await db_repo.authz._remove_resource_pool_prohibited(
+                            result.resource_pool_id, result.user_ids
+                        )
+                    case (
+                        (AuthzOperation.create | AuthzOperation.delete),
+                        (ResourceType.resource_pool_member | ResourceType.resource_pool_prohibited),
                     ) if result is None:
                         # Handle None returns (nothing to sync)
                         pass
@@ -1426,6 +1453,78 @@ class Authz:
 
         apply = WriteRelationshipsRequest(updates=apply_updates)
         undo = WriteRelationshipsRequest(updates=undo_updates)
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _add_resource_pool_members(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
+        """Grant member access to users on a resource pool."""
+        rels = [
+            Relationship(
+                resource=_AuthzConverter.resource_pool(resource_pool_id),
+                relation=_Relation.member.value,
+                subject=_AuthzConverter.user_subject(uid),
+            )
+            for uid in user_ids
+        ]
+        apply = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
+        )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _remove_resource_pool_members(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
+        """Revoke member access from users on a resource pool."""
+        rels = [
+            Relationship(
+                resource=_AuthzConverter.resource_pool(resource_pool_id),
+                relation=_Relation.member.value,
+                subject=_AuthzConverter.user_subject(uid),
+            )
+            for uid in user_ids
+        ]
+        apply = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
+        )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _add_resource_pool_prohibited(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
+        """Mark users as prohibited from accessing a resource pool (overrides public_user wildcard)."""
+        rels = [
+            Relationship(
+                resource=_AuthzConverter.resource_pool(resource_pool_id),
+                relation=_Relation.prohibited.value,
+                subject=_AuthzConverter.user_subject(uid),
+            )
+            for uid in user_ids
+        ]
+        apply = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
+        )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _remove_resource_pool_prohibited(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
+        """Un-prohibit users from a resource pool."""
+        rels = [
+            Relationship(
+                resource=_AuthzConverter.resource_pool(resource_pool_id),
+                relation=_Relation.prohibited.value,
+                subject=_AuthzConverter.user_subject(uid),
+            )
+            for uid in user_ids
+        ]
+        apply = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=r) for r in rels]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=r) for r in rels]
+        )
         return _AuthzChange(apply=apply, undo=undo)
 
     async def _remove_admin(self, user_id: str) -> _AuthzChange:

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -624,17 +624,22 @@ class Authz:
                 if len(args) == 0:
                     user_kwarg = kwargs.get("user")
                     requested_by_kwarg = kwargs.get("requested_by")
-                    if isinstance(user_kwarg, base_models.APIUser) and isinstance(
-                        requested_by_kwarg, base_models.APIUser
-                    ):
+                    api_user_kwarg = kwargs.get("api_user")
+                    found_users = [
+                        u
+                        for u in (user_kwarg, requested_by_kwarg, api_user_kwarg)
+                        if isinstance(u, base_models.APIUser)
+                    ]
+
+                    if len(found_users) > 1:
                         raise errors.ProgrammingError(
                             message="The decorator for authorization database changes found two APIUser parameters in"
                             " the 'user' and 'requested_by' keyword arguments but expected only one of them to be "
                             "present."
                         )
-                    potential_user = user_kwarg if isinstance(user_kwarg, base_models.APIUser) else requested_by_kwarg
+                    potential_user = found_users[0] if found_users else None
                 else:
-                    potential_user = args[0]
+                    potential_user = args[0] if isinstance(args[0], base_models.APIUser) else None
                 if not isinstance(potential_user, base_models.APIUser):
                     raise errors.ProgrammingError(
                         message="The decorator for authorization database changes could not find APIUser in the "

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -1397,19 +1397,6 @@ class Authz:
         undo_updates: list[RelationshipUpdate] = []
 
         if resource_pool.public:
-            # Ensure public_viewer wildcards exist (operation is idempotent)
-            apply_updates.extend(
-                [
-                    RelationshipUpdate(
-                        operation=RelationshipUpdate.OPERATION_TOUCH,
-                        relationship=all_users_are_public,
-                    ),
-                    RelationshipUpdate(
-                        operation=RelationshipUpdate.OPERATION_TOUCH,
-                        relationship=anon_users_are_public,
-                    ),
-                ]
-            )
             # For undo, only remove wildcards if they didn't exist before
             # existing_ids = {rel.subject.object.object_id for rel in existing_rels}
             existing_subjects = {
@@ -1417,6 +1404,12 @@ class Authz:
             }
             # if "all-users" in existing_ids or "*" in existing_ids:
             if ("user", "*") not in existing_subjects:
+                apply_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=all_users_are_public,
+                    )
+                )
                 undo_updates.append(
                     RelationshipUpdate(
                         operation=RelationshipUpdate.OPERATION_DELETE,
@@ -1425,6 +1418,12 @@ class Authz:
                 )
             # if "anonymous-user:*" in existing_ids or "*" in existing_ids:
             if ("anonymous_user", "*") not in existing_subjects:
+                apply_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=anon_users_are_public,
+                    )
+                )
                 undo_updates.append(
                     RelationshipUpdate(
                         operation=RelationshipUpdate.OPERATION_DELETE,
@@ -1440,19 +1439,19 @@ class Authz:
                         relationship=existing_rel,
                     )
                 )
-            undo_updates.append(
-                RelationshipUpdate(
-                    operation=RelationshipUpdate.OPERATION_TOUCH,
-                    relationship=all_users_are_public,
+            if existing_rels:
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=all_users_are_public,
+                    )
                 )
-            )
-            undo_updates.append(
-                RelationshipUpdate(
-                    operation=RelationshipUpdate.OPERATION_TOUCH,
-                    relationship=anon_users_are_public,
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=anon_users_are_public,
+                    )
                 )
-            )
-
         apply = WriteRelationshipsRequest(updates=apply_updates)
         undo = WriteRelationshipsRequest(updates=undo_updates)
         return _AuthzChange(apply=apply, undo=undo)

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -815,7 +815,6 @@ class Authz:
                     result = await f(db_repo, *args, **kwargs)
                     authz_change = await _get_authz_change(db_repo, op, resource, result, *args, **kwargs)
                     await db_repo.authz.client.WriteRelationships(authz_change.apply)
-                    await session.commit()
                     return result
                 except Exception as err:
                     db_rollback_err = None

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -1,7 +1,7 @@
 """Projects authorization adapter."""
 
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable, Collection
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps
@@ -46,7 +46,7 @@ from renku_data_services.authz.models import (
     Visibility,
 )
 from renku_data_services.base_models.core import InternalServiceAdmin, ResourceType
-from renku_data_services.crc.models import ResourcePool
+from renku_data_services.crc.models import DeletedResourcePool, ResourcePool, ResourcePoolMembershipChange
 from renku_data_services.data_connectors.models import (
     DataConnector,
     DataConnectorToProjectLink,
@@ -98,6 +98,9 @@ _AuthzChangeFuncResult = TypeVar(
     | DataConnectorUpdate
     | DeletedDataConnector
     | DataConnectorToProjectLink
+    | ResourcePool
+    | DeletedResourcePool
+    | ResourcePoolMembershipChange
     | None,
 )
 _T = TypeVar("_T")
@@ -130,6 +133,7 @@ class _Relation(StrEnum):
     viewer = "viewer"
     public_viewer = "public_viewer"
     admin = "admin"
+    public_user = "public_user"
     project_platform = "project_platform"
     group_platform = "group_platform"
     user_namespace_platform = "user_namespace_platform"
@@ -138,6 +142,7 @@ class _Relation(StrEnum):
     data_connector_namespace = "data_connector_namespace"
     linked_to = "linked_to"
     prohibited = "prohibited"
+    resource_pool_platform = "resource_pool_platform"
 
     @classmethod
     def from_role(cls, role: Role) -> "_Relation":
@@ -719,9 +724,25 @@ class Authz:
                     ):
                         user = _extract_user_from_args(*func_args, **func_kwargs)
                         authz_change = await db_repo.authz._remove_data_connector_to_project_link(user, result)
+                    case AuthzOperation.create, ResourceType.resource_pool if isinstance(result, ResourcePool):
+                        print("yup RP")
+                        authz_change = db_repo.authz._add_resource_pool(result)
+                    case AuthzOperation.update, ResourceType.resource_pool if isinstance(result, ResourcePool):
+                        user = _extract_user_from_args(*func_args, **func_kwargs)
+                        authz_change = await db_repo.authz._update_resource_pool_visibility(user, result)
+                    case AuthzOperation.delete, ResourceType.resource_pool if result is None:
+                        # NOTE: This means that the resource pool does not exist
+                        # in the first place so nothing was deleted
+                        pass
+                    case AuthzOperation.delete, ResourceType.resource_pool if isinstance(result, DeletedResourcePool):
+                        user = _extract_user_from_args(*func_args, **func_kwargs)
+                        authz_change = await db_repo.authz._remove_resource_pool(user, result)
+                    ) if result is None:
+                        # Handle None returns (nothing to sync)
+                        pass
                     case _:
-                        resource_id: str | ULID | None = "unknown"
-                        if isinstance(result, (Project, Namespace, Group, DataConnector)):
+                        resource_id: str | ULID | int | None = "unknown"
+                        if isinstance(result, (Project, Namespace, Group, DataConnector, ResourcePool)):
                             resource_id = result.id
                         elif isinstance(result, (ProjectUpdate, GroupUpdate, DataConnectorUpdate)):
                             resource_id = result.new.id
@@ -1247,6 +1268,164 @@ class Authz:
         undo = WriteRelationshipsRequest(
             updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=rel)]
         )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    def _add_resource_pool(self, resource_pool: ResourcePool) -> _AuthzChange:
+        """Create the new resource pool and associated resources and relations in the DB."""
+        resource_pool_res = _AuthzConverter.resource_pool(resource_pool.id)
+        all_users = SubjectReference(object=_AuthzConverter.all_users())
+        all_anon_users = SubjectReference(object=_AuthzConverter.anonymous_users())
+        resource_pool_in_platform = Relationship(
+            resource=resource_pool_res,
+            relation=_Relation.resource_pool_platform.value,
+            subject=SubjectReference(object=self._platform),
+        )
+        relationships = [resource_pool_in_platform]
+        if resource_pool.public:
+            all_users_are_public_users = Relationship(
+                resource=resource_pool_res,
+                relation=_Relation.public_user.value,
+                subject=all_users,
+            )
+            all_anon_users_are_public_users = Relationship(
+                resource=resource_pool_res,
+                relation=_Relation.public_user.value,
+                subject=all_anon_users,
+            )
+            relationships.extend([all_users_are_public_users, all_anon_users_are_public_users])
+        apply = WriteRelationshipsRequest(
+            updates=[
+                RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=i) for i in relationships
+            ]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[
+                RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=i) for i in relationships
+            ]
+        )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _remove_resource_pool(
+        self,
+        user: base_models.APIUser,
+        deleted_resource_pool: DeletedResourcePool,
+        *,
+        zed_token: ZedToken | None = None,
+    ) -> _AuthzChange:
+        """Remove the relationships associated with the resource pool."""
+        consistency = Consistency(at_least_as_fresh=zed_token) if zed_token else Consistency(fully_consistent=True)
+        rel_filter = RelationshipFilter(
+            resource_type=ResourceType.resource_pool.value, optional_resource_id=str(deleted_resource_pool.id)
+        )
+        responses: AsyncIterable[ReadRelationshipsResponse] = self.client.ReadRelationships(
+            ReadRelationshipsRequest(consistency=consistency, relationship_filter=rel_filter)
+        )
+        rels: list[Relationship] = []
+        async for response in responses:
+            rels.append(response.relationship)
+        apply = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=i) for i in rels]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=i) for i in rels]
+        )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _update_resource_pool_visibility(
+        self, user: base_models.APIUser, resource_pool: ResourcePool, *, zed_token: ZedToken | None = None
+    ) -> _AuthzChange:
+        """Update public_user wildcard relationships when public flag changes."""
+        consistency = Consistency(at_least_as_fresh=zed_token) if zed_token else Consistency(fully_consistent=True)
+        pool_res = _AuthzConverter.resource_pool(resource_pool.id)
+
+        # Read existing public_user relationships
+        rel_filter = RelationshipFilter(
+            resource_type=ResourceType.resource_pool.value,
+            optional_resource_id=str(resource_pool.id),
+            optional_relation=_Relation.public_user.value,
+        )
+        responses = self.client.ReadRelationships(
+            ReadRelationshipsRequest(consistency=consistency, relationship_filter=rel_filter)
+        )
+        existing_rels: list[Relationship] = []
+        async for response in responses:
+            existing_rels.append(response.relationship)
+
+        all_users_sub = SubjectReference(object=_AuthzConverter.all_users())
+        anon_users_sub = SubjectReference(object=_AuthzConverter.anonymous_users())
+        all_users_are_public = Relationship(
+            resource=pool_res,
+            relation=_Relation.public_user.value,
+            subject=all_users_sub,
+        )
+        anon_users_are_public = Relationship(
+            resource=pool_res,
+            relation=_Relation.public_user.value,
+            subject=anon_users_sub,
+        )
+
+        apply_updates: list[RelationshipUpdate] = []
+        undo_updates: list[RelationshipUpdate] = []
+
+        if resource_pool.public:
+            # Ensure public_user wildcards exist (operation is idempotent)
+            apply_updates.extend(
+                [
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=all_users_are_public,
+                    ),
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=anon_users_are_public,
+                    ),
+                ]
+            )
+            # For undo, only remove wildcards if they didn't exist before
+            # existing_ids = {rel.subject.object.object_id for rel in existing_rels}
+            existing_subjects = {
+                (rel.subject.object.object_type, rel.subject.object.object_id) for rel in existing_rels
+            }
+            # if "all-users" in existing_ids or "*" in existing_ids:
+            if ("user", "*") not in existing_subjects:
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_DELETE,
+                        relationship=all_users_are_public,
+                    )
+                )
+            # if "anonymous-user:*" in existing_ids or "*" in existing_ids:
+            if ("anonymous_user", "*") not in existing_subjects:
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_DELETE,
+                        relationship=anon_users_are_public,
+                    )
+                )
+        else:
+            # Remove public_user wildcards
+            for existing_rel in existing_rels:
+                apply_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_DELETE,
+                        relationship=existing_rel,
+                    )
+                )
+            undo_updates.append(
+                RelationshipUpdate(
+                    operation=RelationshipUpdate.OPERATION_TOUCH,
+                    relationship=all_users_are_public,
+                )
+            )
+            undo_updates.append(
+                RelationshipUpdate(
+                    operation=RelationshipUpdate.OPERATION_TOUCH,
+                    relationship=anon_users_are_public,
+                )
+            )
+
+        apply = WriteRelationshipsRequest(updates=apply_updates)
+        undo = WriteRelationshipsRequest(updates=undo_updates)
         return _AuthzChange(apply=apply, undo=undo)
 
     async def _remove_admin(self, user_id: str) -> _AuthzChange:

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -633,7 +633,7 @@ class Authz:
                     if len(found_users) > 1:
                         raise errors.ProgrammingError(
                             message="The decorator for authorization database changes found two APIUser parameters in"
-                            " the 'user' and 'requested_by' keyword arguments but expected only one of them to be "
+                            " the 'user', 'requested_by' and 'api_user' keyword arguments but expected only one of them to be "
                             "present."
                         )
                     potential_user = found_users[0] if found_users else None

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -133,7 +133,6 @@ class _Relation(StrEnum):
     viewer = "viewer"
     public_viewer = "public_viewer"
     admin = "admin"
-    public_user = "public_user"
     project_platform = "project_platform"
     group_platform = "group_platform"
     user_namespace_platform = "user_namespace_platform"
@@ -1313,17 +1312,17 @@ class Authz:
         )
         relationships = [resource_pool_in_platform]
         if resource_pool.public:
-            all_users_are_public_users = Relationship(
+            all_users_are_public_viewers = Relationship(
                 resource=resource_pool_res,
-                relation=_Relation.public_user.value,
+                relation=_Relation.public_viewer.value,
                 subject=all_users,
             )
-            all_anon_users_are_public_users = Relationship(
+            all_anon_users_are_public_viewers = Relationship(
                 resource=resource_pool_res,
-                relation=_Relation.public_user.value,
+                relation=_Relation.public_viewer.value,
                 subject=all_anon_users,
             )
-            relationships.extend([all_users_are_public_users, all_anon_users_are_public_users])
+            relationships.extend([all_users_are_public_viewers, all_anon_users_are_public_viewers])
         apply = WriteRelationshipsRequest(
             updates=[
                 RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=i) for i in relationships
@@ -1365,15 +1364,15 @@ class Authz:
     async def _update_resource_pool_visibility(
         self, user: base_models.APIUser, resource_pool: ResourcePool, *, zed_token: ZedToken | None = None
     ) -> _AuthzChange:
-        """Update public_user wildcard relationships when public flag changes."""
+        """Update public_viewer wildcard relationships when public flag changes."""
         consistency = Consistency(at_least_as_fresh=zed_token) if zed_token else Consistency(fully_consistent=True)
         pool_res = _AuthzConverter.resource_pool(resource_pool.id)
 
-        # Read existing public_user relationships
+        # Read existing public_viewer relationships
         rel_filter = RelationshipFilter(
             resource_type=ResourceType.resource_pool.value,
             optional_resource_id=str(resource_pool.id),
-            optional_relation=_Relation.public_user.value,
+            optional_relation=_Relation.public_viewer.value,
         )
         responses = self.client.ReadRelationships(
             ReadRelationshipsRequest(consistency=consistency, relationship_filter=rel_filter)
@@ -1386,12 +1385,12 @@ class Authz:
         anon_users_sub = SubjectReference(object=_AuthzConverter.anonymous_users())
         all_users_are_public = Relationship(
             resource=pool_res,
-            relation=_Relation.public_user.value,
+            relation=_Relation.public_viewer.value,
             subject=all_users_sub,
         )
         anon_users_are_public = Relationship(
             resource=pool_res,
-            relation=_Relation.public_user.value,
+            relation=_Relation.public_viewer.value,
             subject=anon_users_sub,
         )
 
@@ -1399,7 +1398,7 @@ class Authz:
         undo_updates: list[RelationshipUpdate] = []
 
         if resource_pool.public:
-            # Ensure public_user wildcards exist (operation is idempotent)
+            # Ensure public_viewer wildcards exist (operation is idempotent)
             apply_updates.extend(
                 [
                     RelationshipUpdate(
@@ -1434,7 +1433,7 @@ class Authz:
                     )
                 )
         else:
-            # Remove public_user wildcards
+            # Remove public_viewer wildcards
             for existing_rel in existing_rels:
                 apply_updates.append(
                     RelationshipUpdate(
@@ -1464,7 +1463,7 @@ class Authz:
         rels = [
             Relationship(
                 resource=_AuthzConverter.resource_pool(resource_pool_id),
-                relation=_Relation.member.value,
+                relation=_Relation.viewer.value,
                 subject=_AuthzConverter.user_subject(uid),
             )
             for uid in user_ids
@@ -1482,7 +1481,7 @@ class Authz:
         rels = [
             Relationship(
                 resource=_AuthzConverter.resource_pool(resource_pool_id),
-                relation=_Relation.member.value,
+                relation=_Relation.viewer.value,
                 subject=_AuthzConverter.user_subject(uid),
             )
             for uid in user_ids
@@ -1496,7 +1495,7 @@ class Authz:
         return _AuthzChange(apply=apply, undo=undo)
 
     async def _add_resource_pool_prohibited(self, resource_pool_id: int, user_ids: Collection[str]) -> _AuthzChange:
-        """Mark users as prohibited from accessing a resource pool (overrides public_user wildcard)."""
+        """Mark users as prohibited from accessing a resource pool (overrides public_viewer wildcard)."""
         rels = [
             Relationship(
                 resource=_AuthzConverter.resource_pool(resource_pool_id),

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -729,7 +729,6 @@ class Authz:
                         user = _extract_user_from_args(*func_args, **func_kwargs)
                         authz_change = await db_repo.authz._remove_data_connector_to_project_link(user, result)
                     case AuthzOperation.create, ResourceType.resource_pool if isinstance(result, ResourcePool):
-                        print("yup RP")
                         authz_change = db_repo.authz._add_resource_pool(result)
                     case AuthzOperation.update, ResourceType.resource_pool if isinstance(result, ResourcePool):
                         user = _extract_user_from_args(*func_args, **func_kwargs)

--- a/components/renku_data_services/base_models/core.py
+++ b/components/renku_data_services/base_models/core.py
@@ -453,3 +453,5 @@ class ResourceType(StrEnum):
     user_namespace = "user_namespace"
     data_connector = "data_connector"
     resource_pool = "resource_pool"
+    resource_pool_member = "resource_pool_member"
+    resource_pool_prohibited = "resource_pool_prohibited"

--- a/components/renku_data_services/crc/blueprints.py
+++ b/components/renku_data_services/crc/blueprints.py
@@ -13,7 +13,7 @@ from renku_data_services.base_api.auth import authenticate, only_admins
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
 from renku_data_services.base_api.misc import validate_db_ids, validate_query
 from renku_data_services.base_models.validation import validated_json
-from renku_data_services.crc import apispec, models
+from renku_data_services.crc import apispec
 from renku_data_services.crc.core import (
     validate_cluster,
     validate_cluster_patch,
@@ -72,13 +72,7 @@ class ResourcePoolsBP(CustomBlueprint):
         async def _get_one(
             request: Request, user: base_models.APIUser, resource_pool_id: int, query: apispec.UserResourceParams
         ) -> HTTPResponse:
-            rps: list[models.ResourcePool]
-            rps = await self.rp_repo.get_resource_pools(api_user=user, id=resource_pool_id, name=query.name)
-            if len(rps) < 1:
-                raise errors.MissingResourceError(
-                    message=f"The resource pool with id {resource_pool_id} cannot be found."
-                )
-            rp = rps[0]
+            rp = await self.rp_repo.get_resource_pool(api_user=user, resource_pool_id=resource_pool_id, name=query.name)
             return validated_json(apispec.ResourcePoolWithId, rp)
 
         return "/resource_pools/<resource_pool_id>", ["GET"], _get_one

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -404,124 +404,128 @@ class ResourcePoolRepository(_Base):
     ) -> models.ResourcePool:
         """Update an existing resource pool in the database."""
         async with self.session_maker() as session, session.begin():
-            return await self._update_resource_pool(
-                api_user=api_user,
-                resource_pool_id=resource_pool_id,
-                update=update,
-                session=session,
+            stmt = (
+                select(schemas.ResourcePoolORM)
+                .where(schemas.ResourcePoolORM.id == resource_pool_id)
+                .options(selectinload(schemas.ResourcePoolORM.classes))
             )
+            res = await session.scalars(stmt)
+            rp = res.one_or_none()
+            if rp is None:
+                raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} cannot be found")
+            quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
+
+            validate_resource_pool_update(existing=rp.dump(quota=quota), update=update)
+
+            update_authz = False
+
+            if update.name is not None:
+                rp.name = update.name
+            if update.public is not None:
+                rp.public = update.public
+                update_authz = True
+            if update.default is not None:
+                rp.default = update.default
+                update_authz = True
+            if update.idle_threshold == 0 or update.idle_threshold is RESET:
+                # Using "0" removes the value
+                rp.idle_threshold = None
+            elif isinstance(update.idle_threshold, int):
+                rp.idle_threshold = update.idle_threshold
+            if update.hibernation_threshold == 0 or update.hibernation_threshold is RESET:
+                # Using "0" removes the value
+                rp.hibernation_threshold = None
+            elif isinstance(update.hibernation_threshold, int):
+                rp.hibernation_threshold = update.hibernation_threshold
+            if update.hibernation_warning_period == 0 or update.hibernation_warning_period is RESET:
+                rp.hibernation_warning_period = None
+            elif isinstance(update.hibernation_warning_period, int):
+                rp.hibernation_warning_period = update.hibernation_warning_period
+            if update.platform is not None:
+                rp.platform = update.platform
+
+            match (update.cluster_id, rp.cluster_id):
+                case ResetType.Reset, x if x is not None:
+                    raise errors.ValidationError(
+                        message="Resetting the cluster of an existing resource pool is not supported."
+                    )
+                case ULID(), ULID():
+                    if update.cluster_id != rp.cluster_id:
+                        raise errors.ValidationError(
+                            message="Changing the cluster of an existing resource pool is not supported."
+                        )
+
+            cluster_id = rp.get_cluster_id()
+            if update.quota is RESET and rp.quota:
+                # Remove the existing quota
+                await self.quotas_repo.delete_quota(name=rp.quota, cluster_id=cluster_id)
+            elif isinstance(update.quota, models.QuotaPatch) and rp.quota is None:
+                # Create a new quota, the `update.quota` object has already been validated
+                assert update.quota.cpu is not None
+                assert update.quota.memory is not None
+                assert update.quota.gpu is not None
+                new_quota = models.UnsavedQuota(
+                    cpu=update.quota.cpu,
+                    memory=update.quota.memory,
+                    gpu=update.quota.gpu,
+                )
+                quota = await self.quotas_repo.create_quota(new_quota=new_quota, cluster_id=cluster_id)
+                rp.quota = quota.id
+            elif isinstance(update.quota, models.QuotaPatch):
+                assert rp.quota is not None
+                assert quota is not None
+                # Update the existing quota
+                updated_quota = models.Quota(
+                    cpu=update.quota.cpu if update.quota.cpu is not None else quota.cpu,
+                    memory=update.quota.memory if update.quota.memory is not None else quota.memory,
+                    gpu=update.quota.gpu if update.quota.gpu is not None else quota.gpu,
+                    gpu_kind=update.quota.gpu_kind if update.quota.gpu_kind is not None else quota.gpu_kind,
+                    id=quota.id,
+                )
+                quota = await self.quotas_repo.update_quota(quota=updated_quota, cluster_id=cluster_id)
+                rp.quota = quota.id
+
+            new_classes_coroutines = []
+            if update.classes is not None:
+                for rc in update.classes:
+                    new_classes_coroutines.append(
+                        self.update_resource_class(
+                            api_user=api_user, resource_pool_id=resource_pool_id, resource_class_id=rc.id, update=rc
+                        )
+                    )
+
+            if update.remote is RESET:
+                rp.remote_provider_id = None
+                rp.remote_json = None
+            elif update.remote is not None:
+                rp.remote_provider_id = (
+                    update.remote.provider_id if update.remote.provider_id is not None else rp.remote_provider_id
+                )
+                remote_json = rp.remote_json if rp.remote_json is not None else dict()
+                remote_json.update(update.remote.to_dict())
+                del remote_json["provider_id"]
+                rp.remote_json = remote_json
+
+            await gather(*new_classes_coroutines)
+            await session.flush()
+            await session.refresh(rp)
+            result = rp.dump(quota=quota)
+            if update_authz:
+                return await self._update_resource_pool(
+                    api_user=api_user,
+                    rp=result,
+                    session=session,
+                )
+            return result
 
     @Authz.authz_change(op=AuthzOperation.update, resource=ResourceType.resource_pool)
     async def _update_resource_pool(
         self,
         api_user: base_models.APIUser,
-        resource_pool_id: int,
-        update: models.ResourcePoolPatch,
+        rp: models.ResourcePool,
         session: AsyncSession,
     ) -> models.ResourcePool:
-        stmt = (
-            select(schemas.ResourcePoolORM)
-            .where(schemas.ResourcePoolORM.id == resource_pool_id)
-            .options(selectinload(schemas.ResourcePoolORM.classes))
-        )
-        res = await session.scalars(stmt)
-        rp = res.one_or_none()
-        if rp is None:
-            raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} cannot be found")
-        quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
-
-        validate_resource_pool_update(existing=rp.dump(quota=quota), update=update)
-
-        if update.name is not None:
-            rp.name = update.name
-        if update.public is not None:
-            rp.public = update.public
-        if update.default is not None:
-            rp.default = update.default
-        if update.idle_threshold == 0 or update.idle_threshold is RESET:
-            # Using "0" removes the value
-            rp.idle_threshold = None
-        elif isinstance(update.idle_threshold, int):
-            rp.idle_threshold = update.idle_threshold
-        if update.hibernation_threshold == 0 or update.hibernation_threshold is RESET:
-            # Using "0" removes the value
-            rp.hibernation_threshold = None
-        elif isinstance(update.hibernation_threshold, int):
-            rp.hibernation_threshold = update.hibernation_threshold
-        if update.hibernation_warning_period == 0 or update.hibernation_warning_period is RESET:
-            rp.hibernation_warning_period = None
-        elif isinstance(update.hibernation_warning_period, int):
-            rp.hibernation_warning_period = update.hibernation_warning_period
-        if update.platform is not None:
-            rp.platform = update.platform
-
-        match (update.cluster_id, rp.cluster_id):
-            case ResetType.Reset, x if x is not None:
-                raise errors.ValidationError(
-                    message="Resetting the cluster of an existing resource pool is not supported."
-                )
-            case ULID(), ULID():
-                if update.cluster_id != rp.cluster_id:
-                    raise errors.ValidationError(
-                        message="Changing the cluster of an existing resource pool is not supported."
-                    )
-
-        cluster_id = rp.get_cluster_id()
-        if update.quota is RESET and rp.quota:
-            # Remove the existing quota
-            await self.quotas_repo.delete_quota(name=rp.quota, cluster_id=cluster_id)
-        elif isinstance(update.quota, models.QuotaPatch) and rp.quota is None:
-            # Create a new quota, the `update.quota` object has already been validated
-            assert update.quota.cpu is not None
-            assert update.quota.memory is not None
-            assert update.quota.gpu is not None
-            new_quota = models.UnsavedQuota(
-                cpu=update.quota.cpu,
-                memory=update.quota.memory,
-                gpu=update.quota.gpu,
-            )
-            quota = await self.quotas_repo.create_quota(new_quota=new_quota, cluster_id=cluster_id)
-            rp.quota = quota.id
-        elif isinstance(update.quota, models.QuotaPatch):
-            assert rp.quota is not None
-            assert quota is not None
-            # Update the existing quota
-            updated_quota = models.Quota(
-                cpu=update.quota.cpu if update.quota.cpu is not None else quota.cpu,
-                memory=update.quota.memory if update.quota.memory is not None else quota.memory,
-                gpu=update.quota.gpu if update.quota.gpu is not None else quota.gpu,
-                gpu_kind=update.quota.gpu_kind if update.quota.gpu_kind is not None else quota.gpu_kind,
-                id=quota.id,
-            )
-            quota = await self.quotas_repo.update_quota(quota=updated_quota, cluster_id=cluster_id)
-            rp.quota = quota.id
-
-        new_classes_coroutines = []
-        if update.classes is not None:
-            for rc in update.classes:
-                new_classes_coroutines.append(
-                    self.update_resource_class(
-                        api_user=api_user, resource_pool_id=resource_pool_id, resource_class_id=rc.id, update=rc
-                    )
-                )
-
-        if update.remote is RESET:
-            rp.remote_provider_id = None
-            rp.remote_json = None
-        elif update.remote is not None:
-            rp.remote_provider_id = (
-                update.remote.provider_id if update.remote.provider_id is not None else rp.remote_provider_id
-            )
-            remote_json = rp.remote_json if rp.remote_json is not None else dict()
-            remote_json.update(update.remote.to_dict())
-            del remote_json["provider_id"]
-            rp.remote_json = remote_json
-
-        await gather(*new_classes_coroutines)
-        await session.flush()
-        await session.refresh(rp)
-        result = rp.dump(quota=quota)
-        return result
+        return rp
 
     @_only_admins
     async def delete_resource_pool(self, api_user: base_models.APIUser, id: int) -> None:

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -118,7 +118,7 @@ class ResourcePoolRepository(_Base):
             res = await session.execute(stmt)
             default_rp = res.scalars().first()
             if default_rp is None:
-                self._create_rp(rp, session=session)
+                await self._create_rp(rp, session=session)
 
     @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
     async def _create_rp(self, rp: models.UnsavedResourcePool, session: AsyncSession) -> models.ResourcePool:

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -55,7 +55,7 @@ async def _resource_pool_access_control(
     if api_user.is_admin:
         return output
     allowed_resource_pools = await authz.resources_with_permission(
-        api_user, api_user.id, ResourceType.resource_pool, Scope.USE
+        api_user, api_user.id, ResourceType.resource_pool, Scope.READ
     )
     allowed_ids = [int(id) for id in allowed_resource_pools]
     output = output.where(schemas.ResourcePoolORM.id.in_(allowed_ids))
@@ -72,7 +72,7 @@ async def _classes_user_access_control(
     if api_user.is_admin:
         return output
     allowed_resource_pools = await authz.resources_with_permission(
-        api_user, api_user.id, ResourceType.resource_pool, Scope.USE
+        api_user, api_user.id, ResourceType.resource_pool, Scope.READ
     )
     allowed_ids = [int(id) for id in allowed_resource_pools]
     output = output.where(schemas.ResourcePoolORM.id.in_(allowed_ids))
@@ -194,7 +194,9 @@ class ResourcePoolRepository(_Base):
     ) -> models.ResourcePool:
         """Get a specific resource pool by ID with Authzed permission check."""
         if not api_user.is_admin:
-            allowed = await self.authz.has_permission(api_user, ResourceType.resource_pool, resource_pool_id, Scope.USE)
+            allowed = await self.authz.has_permission(
+                api_user, ResourceType.resource_pool, resource_pool_id, Scope.READ
+            )
             if not allowed:
                 raise errors.MissingResourceError(
                     message=f"The resource pool with id {resource_pool_id} cannot be found."

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -45,29 +45,15 @@ class _Base:
         self.authz: Authz = authz
 
 
-async def _resource_pool_access_control(
+_ORM = TypeVar("_ORM", schemas.ResourcePoolORM, schemas.ResourceClassORM)
+
+
+async def _filter_by_authz(
     api_user: base_models.APIUser,
-    stmt: Select[tuple[schemas.ResourcePoolORM]],
+    stmt: Select[tuple[_ORM]],
     authz: Authz,
-) -> Select[tuple[schemas.ResourcePoolORM]]:
+) -> Select[tuple[_ORM]]:
     """Modifies a select query to list resource pools based on whether the user is logged in or not."""
-    output = stmt
-    if api_user.is_admin:
-        return output
-    allowed_resource_pools = await authz.resources_with_permission(
-        api_user, api_user.id, ResourceType.resource_pool, Scope.READ
-    )
-    allowed_ids = [int(id) for id in allowed_resource_pools]
-    output = output.where(schemas.ResourcePoolORM.id.in_(allowed_ids))
-    return output
-
-
-async def _classes_user_access_control(
-    api_user: base_models.APIUser,
-    stmt: Select[tuple[schemas.ResourceClassORM]],
-    authz: Authz,
-) -> Select[tuple[schemas.ResourceClassORM]]:
-    """Adjust the select statement for classes based on whether the user is logged in or not."""
     output = stmt
     if api_user.is_admin:
         return output
@@ -158,7 +144,7 @@ class ResourcePoolRepository(_Base):
             if id is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.id == id)
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             orms = res.scalars().all()
             output: list[models.ResourcePool] = []
@@ -179,7 +165,7 @@ class ResourcePoolRepository(_Base):
                 .options(selectinload(schemas.ResourcePoolORM.cluster))
             )
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             orm = res.scalar()
             if orm is None:
@@ -200,7 +186,7 @@ class ResourcePoolRepository(_Base):
                 .options(selectinload(schemas.ResourcePoolORM.classes))
                 .options(selectinload(schemas.ResourcePoolORM.cluster))
             )
-            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             if name is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.name == name)
             res = await session.execute(stmt)
@@ -273,7 +259,7 @@ class ResourcePoolRepository(_Base):
                 )
             )
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             output: list[models.ResourcePool] = []
             for rp in res.scalars().all():
@@ -346,7 +332,7 @@ class ResourcePoolRepository(_Base):
             # Apply user access control if api_user is provided
             if api_user is not None:
                 # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-                stmt = await _classes_user_access_control(api_user, stmt, self.authz)
+                stmt = await _filter_by_authz(api_user, stmt, self.authz)
 
             res = await session.execute(stmt)
             orms = res.scalars().all()
@@ -878,7 +864,7 @@ class UserRepository(_Base):
             if resource_pool_id is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.id == resource_pool_id)
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             rps: Sequence[schemas.ResourcePoolORM] = res.scalars().all()
             output: list[models.ResourcePool] = []
@@ -943,9 +929,9 @@ class UserRepository(_Base):
                 if rp.default or rp.public:
                     await self._unprohibit_resource_pool_users(api_user, rp.id, [keycloak_id], session=session)
             for rp in removed_rps:
-                await self._revoke_resource_pool_member(api_user, rp.id, keycloak_id, session=session)
+                await self._revoke_resource_pool_member(api_user, rp.id, [keycloak_id], session=session)
                 if rp.default or rp.public:
-                    await self._prohibit_resource_pool_user(api_user, rp.id, keycloak_id, session=session)
+                    await self._prohibit_resource_pool_user(api_user, rp.id, [keycloak_id], session=session)
             output: list[models.ResourcePool] = []
             for rp in rps_to_add:
                 quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
@@ -973,21 +959,9 @@ class UserRepository(_Base):
             )
             stmt = delete(schemas.resource_pools_users).where(schemas.resource_pools_users.c.user_id.in_(sub))
             await session.execute(stmt)
-            await self._revoke_resource_pool_member(api_user, resource_pool_id, keycloak_id, session=session)
+            await self._revoke_resource_pool_member(api_user, resource_pool_id, [keycloak_id], session=session)
             if rp.default or rp.public:
-                await self._prohibit_resource_pool_user(api_user, resource_pool_id, keycloak_id, session=session)
-
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_prohibited)
-    async def _prohibit_resource_pool_user(
-        self, api_user: base_models.APIUser, resource_pool_id: int, keycloak_id: str, session: AsyncSession
-    ) -> models.ResourcePoolMembershipChange:
-        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=[keycloak_id])
-
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_member)
-    async def _revoke_resource_pool_member(
-        self, api_user: base_models.APIUser, resource_pool_id: int, keycloak_id: str, session: AsyncSession
-    ) -> models.ResourcePoolMembershipChange:
-        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=[keycloak_id])
+                await self._prohibit_resource_pool_user(api_user, resource_pool_id, [keycloak_id], session=session)
 
     @_only_admins
     async def update_resource_pool_users(
@@ -1042,21 +1016,36 @@ class UserRepository(_Base):
                 rp.users = list(users_to_add_exist) + users_to_add_missing
             return [usr.dump() for usr in rp.users]
 
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_member)
-    async def _grant_resource_pool_members(
+    async def _write_resource_pool_user_relationship(
         self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
     ) -> models.ResourcePoolMembershipChange | None:
         if not user_ids:
             return None
         return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=user_ids)
 
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_member)
+    async def _grant_resource_pool_members(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+
     @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_prohibited)
     async def _unprohibit_resource_pool_users(
         self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
     ) -> models.ResourcePoolMembershipChange | None:
-        if not user_ids:
-            return None
-        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=user_ids)
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_prohibited)
+    async def _prohibit_resource_pool_user(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_member)
+    async def _revoke_resource_pool_member(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
 
     @_only_admins
     async def update_user(self, api_user: base_models.APIUser, keycloak_id: str, **kwargs: Any) -> base_models.User:
@@ -1081,7 +1070,7 @@ class UserRepository(_Base):
 
                 for rp_id in default_rp_ids:
                     if no_default_access:
-                        await self._prohibit_resource_pool_user(api_user, rp_id, keycloak_id, session=session)
+                        await self._prohibit_resource_pool_user(api_user, rp_id, [keycloak_id], session=session)
                     else:
                         await self._unprohibit_resource_pool_users(api_user, rp_id, [keycloak_id], session=session)
             return user.dump()

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -290,7 +290,7 @@ class ResourcePoolRepository(_Base):
     async def insert_resource_pool(
         self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool
     ) -> models.ResourcePool:
-        """Insert a new resource pool."""
+        """Insert resource pool into database."""
         async with self.session_maker() as session, session.begin():
             return await self._insert_resource_pool(
                 api_user=api_user,
@@ -302,7 +302,6 @@ class ResourcePoolRepository(_Base):
     async def _insert_resource_pool(
         self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool, session: AsyncSession
     ) -> models.ResourcePool:
-        """Insert resource pool into database."""
         cluster = None
         if new_resource_pool.cluster_id:
             cluster = await self.__cluster_repo.select(cluster_id=new_resource_pool.cluster_id)
@@ -408,7 +407,7 @@ class ResourcePoolRepository(_Base):
     async def update_resource_pool(
         self, api_user: base_models.APIUser, resource_pool_id: int, update: models.ResourcePoolPatch
     ) -> models.ResourcePool:
-        """Insert a new resource pool."""
+        """Update an existing resource pool in the database."""
         async with self.session_maker() as session, session.begin():
             return await self._update_resource_pool(
                 api_user=api_user,
@@ -425,7 +424,6 @@ class ResourcePoolRepository(_Base):
         update: models.ResourcePoolPatch,
         session: AsyncSession,
     ) -> models.ResourcePool:
-        """Update an existing resource pool in the database."""
         stmt = (
             select(schemas.ResourcePoolORM)
             .where(schemas.ResourcePoolORM.id == resource_pool_id)
@@ -532,7 +530,7 @@ class ResourcePoolRepository(_Base):
 
     @_only_admins
     async def delete_resource_pool(self, api_user: base_models.APIUser, id: int) -> None:
-        """Insert a new resource pool."""
+        """Delete a resource pool from the database."""
         async with self.session_maker() as session, session.begin():
             await self._delete_resource_pool(
                 api_user=api_user,
@@ -544,7 +542,6 @@ class ResourcePoolRepository(_Base):
     async def _delete_resource_pool(
         self, api_user: base_models.APIUser, id: int, session: AsyncSession
     ) -> models.DeletedResourcePool | None:
-        """Delete a resource pool from the database."""
         stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == id)
         res = await session.execute(stmt)
         rp = res.scalars().first()

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -132,8 +132,16 @@ class ResourcePoolRepository(_Base):
             res = await session.execute(stmt)
             default_rp = res.scalars().first()
             if default_rp is None:
-                orm = schemas.ResourcePoolORM.from_unsaved_model(new_resource_pool=rp, quota=None, cluster=None)
-                session.add(orm)
+                self._create_rp(rp, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    async def _create_rp(self, rp: models.UnsavedResourcePool, session: AsyncSession) -> models.ResourcePool:
+        default_rp = schemas.ResourcePoolORM.from_unsaved_model(new_resource_pool=rp, quota=None, cluster=None)
+        session.add(default_rp)
+        await session.flush()
+        await session.refresh(default_rp)
+        result = default_rp.dump(quota=None)
+        return result
 
     async def get_resource_pools(
         self, api_user: base_models.APIUser, id: int | None = None, name: Optional[str] = None
@@ -150,7 +158,7 @@ class ResourcePoolRepository(_Base):
             if id is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.id == id)
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             orms = res.scalars().all()
             output: list[models.ResourcePool] = []
@@ -171,12 +179,40 @@ class ResourcePoolRepository(_Base):
                 .options(selectinload(schemas.ResourcePoolORM.cluster))
             )
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             orm = res.scalar()
             if orm is None:
                 raise errors.MissingResourceError(
                     message=f"Could not find the resource pool where a class with ID {resource_class_id} exists."
+                )
+            quota = await self.quotas_repo.get_quota(orm.quota, orm.get_cluster_id()) if orm.quota else None
+            return orm.dump(quota)
+
+    async def get_resource_pool(
+        self, api_user: base_models.APIUser, resource_pool_id: int, name: str | None = None
+    ) -> models.ResourcePool:
+        """Get a specific resource pool by ID with Authzed permission check."""
+        if not api_user.is_admin:
+            allowed = await self.authz.has_permission(api_user, ResourceType.resource_pool, resource_pool_id, Scope.USE)
+            if not allowed:
+                raise errors.MissingResourceError(
+                    message=f"The resource pool with id {resource_pool_id} cannot be found."
+                )
+        async with self.session_maker() as session:
+            stmt = (
+                select(schemas.ResourcePoolORM)
+                .where(schemas.ResourcePoolORM.id == resource_pool_id)
+                .options(selectinload(schemas.ResourcePoolORM.classes))
+                .options(selectinload(schemas.ResourcePoolORM.cluster))
+            )
+            if name is not None:
+                stmt = stmt.where(schemas.ResourcePoolORM.name == name)
+            res = await session.execute(stmt)
+            orm = res.scalar()
+            if orm is None:
+                raise errors.MissingResourceError(
+                    message=f"The resource pool with id {resource_pool_id} cannot be found."
                 )
             quota = await self.quotas_repo.get_quota(orm.quota, orm.get_cluster_id()) if orm.quota else None
             return orm.dump(quota)
@@ -242,7 +278,7 @@ class ResourcePoolRepository(_Base):
                 )
             )
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             output: list[models.ResourcePool] = []
             for rp in res.scalars().all():
@@ -254,6 +290,18 @@ class ResourcePoolRepository(_Base):
     async def insert_resource_pool(
         self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool
     ) -> models.ResourcePool:
+        """Insert a new resource pool."""
+        async with self.session_maker() as session, session.begin():
+            return await self._insert_resource_pool(
+                api_user=api_user,
+                new_resource_pool=new_resource_pool,
+                session=session,
+            )
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    async def _insert_resource_pool(
+        self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool, session: AsyncSession
+    ) -> models.ResourcePool:
         """Insert resource pool into database."""
         cluster = None
         if new_resource_pool.cluster_id:
@@ -264,23 +312,23 @@ class ResourcePoolRepository(_Base):
         if new_resource_pool.quota is not None:
             quota = await self.quotas_repo.create_quota(new_quota=new_resource_pool.quota, cluster_id=cluster_id)
 
-        async with self.session_maker() as session, session.begin():
-            resource_pool = schemas.ResourcePoolORM.from_unsaved_model(
-                new_resource_pool=new_resource_pool, quota=quota, cluster=cluster
-            )
-            if resource_pool.default:
-                stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.default == true())
-                res = await session.execute(stmt)
-                default_rps = res.unique().scalars().all()
-                if len(default_rps) >= 1:
-                    raise errors.ValidationError(
-                        message="There can only be one default resource pool and one already exists."
-                    )
+        resource_pool = schemas.ResourcePoolORM.from_unsaved_model(
+            new_resource_pool=new_resource_pool, quota=quota, cluster=cluster
+        )
+        if resource_pool.default:
+            stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.default == true())
+            res = await session.execute(stmt)
+            default_rps = res.unique().scalars().all()
+            if len(default_rps) >= 1:
+                raise errors.ValidationError(
+                    message="There can only be one default resource pool and one already exists."
+                )
 
-            session.add(resource_pool)
-            await session.flush()
-            await session.refresh(resource_pool)
-            return resource_pool.dump(quota=quota)
+        session.add(resource_pool)
+        await session.flush()
+        await session.refresh(resource_pool)
+        result = resource_pool.dump(quota=quota)
+        return result
 
     async def get_classes(
         self,
@@ -304,7 +352,7 @@ class ResourcePoolRepository(_Base):
             # Apply user access control if api_user is provided
             if api_user is not None:
                 # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-                stmt = _classes_user_access_control(api_user, stmt)
+                stmt = await _classes_user_access_control(api_user, stmt, self.authz)
 
             res = await session.execute(stmt)
             orms = res.scalars().all()
@@ -360,125 +408,154 @@ class ResourcePoolRepository(_Base):
     async def update_resource_pool(
         self, api_user: base_models.APIUser, resource_pool_id: int, update: models.ResourcePoolPatch
     ) -> models.ResourcePool:
-        """Update an existing resource pool in the database."""
+        """Insert a new resource pool."""
         async with self.session_maker() as session, session.begin():
-            stmt = (
-                select(schemas.ResourcePoolORM)
-                .where(schemas.ResourcePoolORM.id == resource_pool_id)
-                .options(selectinload(schemas.ResourcePoolORM.classes))
+            return await self._update_resource_pool(
+                api_user=api_user,
+                resource_pool_id=resource_pool_id,
+                update=update,
+                session=session,
             )
-            res = await session.scalars(stmt)
-            rp = res.one_or_none()
-            if rp is None:
-                raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} cannot be found")
-            quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
 
-            validate_resource_pool_update(existing=rp.dump(quota=quota), update=update)
+    @Authz.authz_change(op=AuthzOperation.update, resource=ResourceType.resource_pool)
+    async def _update_resource_pool(
+        self,
+        api_user: base_models.APIUser,
+        resource_pool_id: int,
+        update: models.ResourcePoolPatch,
+        session: AsyncSession,
+    ) -> models.ResourcePool:
+        """Update an existing resource pool in the database."""
+        stmt = (
+            select(schemas.ResourcePoolORM)
+            .where(schemas.ResourcePoolORM.id == resource_pool_id)
+            .options(selectinload(schemas.ResourcePoolORM.classes))
+        )
+        res = await session.scalars(stmt)
+        rp = res.one_or_none()
+        if rp is None:
+            raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} cannot be found")
+        quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
 
-            if update.name is not None:
-                rp.name = update.name
-            if update.public is not None:
-                rp.public = update.public
-            if update.default is not None:
-                rp.default = update.default
-            if update.idle_threshold == 0 or update.idle_threshold is RESET:
-                # Using "0" removes the value
-                rp.idle_threshold = None
-            elif isinstance(update.idle_threshold, int):
-                rp.idle_threshold = update.idle_threshold
-            if update.hibernation_threshold == 0 or update.hibernation_threshold is RESET:
-                # Using "0" removes the value
-                rp.hibernation_threshold = None
-            elif isinstance(update.hibernation_threshold, int):
-                rp.hibernation_threshold = update.hibernation_threshold
-            if update.hibernation_warning_period == 0 or update.hibernation_warning_period is RESET:
-                rp.hibernation_warning_period = None
-            elif isinstance(update.hibernation_warning_period, int):
-                rp.hibernation_warning_period = update.hibernation_warning_period
-            if update.platform is not None:
-                rp.platform = update.platform
+        validate_resource_pool_update(existing=rp.dump(quota=quota), update=update)
 
-            match (update.cluster_id, rp.cluster_id):
-                case ResetType.Reset, x if x is not None:
+        if update.name is not None:
+            rp.name = update.name
+        if update.public is not None:
+            rp.public = update.public
+        if update.default is not None:
+            rp.default = update.default
+        if update.idle_threshold == 0 or update.idle_threshold is RESET:
+            # Using "0" removes the value
+            rp.idle_threshold = None
+        elif isinstance(update.idle_threshold, int):
+            rp.idle_threshold = update.idle_threshold
+        if update.hibernation_threshold == 0 or update.hibernation_threshold is RESET:
+            # Using "0" removes the value
+            rp.hibernation_threshold = None
+        elif isinstance(update.hibernation_threshold, int):
+            rp.hibernation_threshold = update.hibernation_threshold
+        if update.hibernation_warning_period == 0 or update.hibernation_warning_period is RESET:
+            rp.hibernation_warning_period = None
+        elif isinstance(update.hibernation_warning_period, int):
+            rp.hibernation_warning_period = update.hibernation_warning_period
+        if update.platform is not None:
+            rp.platform = update.platform
+
+        match (update.cluster_id, rp.cluster_id):
+            case ResetType.Reset, x if x is not None:
+                raise errors.ValidationError(
+                    message="Resetting the cluster of an existing resource pool is not supported."
+                )
+            case ULID(), ULID():
+                if update.cluster_id != rp.cluster_id:
                     raise errors.ValidationError(
-                        message="Resetting the cluster of an existing resource pool is not supported."
-                    )
-                case ULID(), ULID():
-                    if update.cluster_id != rp.cluster_id:
-                        raise errors.ValidationError(
-                            message="Changing the cluster of an existing resource pool is not supported."
-                        )
-
-            cluster_id = rp.get_cluster_id()
-            if update.quota is RESET and rp.quota:
-                # Remove the existing quota
-                await self.quotas_repo.delete_quota(name=rp.quota, cluster_id=cluster_id)
-            elif isinstance(update.quota, models.QuotaPatch) and rp.quota is None:
-                # Create a new quota, the `update.quota` object has already been validated
-                assert update.quota.cpu is not None
-                assert update.quota.memory is not None
-                assert update.quota.gpu is not None
-                new_quota = models.UnsavedQuota(
-                    cpu=update.quota.cpu,
-                    memory=update.quota.memory,
-                    gpu=update.quota.gpu,
-                )
-                quota = await self.quotas_repo.create_quota(new_quota=new_quota, cluster_id=cluster_id)
-                rp.quota = quota.id
-            elif isinstance(update.quota, models.QuotaPatch):
-                assert rp.quota is not None
-                assert quota is not None
-                # Update the existing quota
-                updated_quota = models.Quota(
-                    cpu=update.quota.cpu if update.quota.cpu is not None else quota.cpu,
-                    memory=update.quota.memory if update.quota.memory is not None else quota.memory,
-                    gpu=update.quota.gpu if update.quota.gpu is not None else quota.gpu,
-                    gpu_kind=update.quota.gpu_kind if update.quota.gpu_kind is not None else quota.gpu_kind,
-                    id=quota.id,
-                )
-                quota = await self.quotas_repo.update_quota(quota=updated_quota, cluster_id=cluster_id)
-                rp.quota = quota.id
-
-            new_classes_coroutines = []
-            if update.classes is not None:
-                for rc in update.classes:
-                    new_classes_coroutines.append(
-                        self.update_resource_class(
-                            api_user=api_user, resource_pool_id=resource_pool_id, resource_class_id=rc.id, update=rc
-                        )
+                        message="Changing the cluster of an existing resource pool is not supported."
                     )
 
-            if update.remote is RESET:
-                rp.remote_provider_id = None
-                rp.remote_json = None
-            elif update.remote is not None:
-                rp.remote_provider_id = (
-                    update.remote.provider_id if update.remote.provider_id is not None else rp.remote_provider_id
-                )
-                remote_json = rp.remote_json if rp.remote_json is not None else dict()
-                remote_json.update(update.remote.to_dict())
-                del remote_json["provider_id"]
-                rp.remote_json = remote_json
+        cluster_id = rp.get_cluster_id()
+        if update.quota is RESET and rp.quota:
+            # Remove the existing quota
+            await self.quotas_repo.delete_quota(name=rp.quota, cluster_id=cluster_id)
+        elif isinstance(update.quota, models.QuotaPatch) and rp.quota is None:
+            # Create a new quota, the `update.quota` object has already been validated
+            assert update.quota.cpu is not None
+            assert update.quota.memory is not None
+            assert update.quota.gpu is not None
+            new_quota = models.UnsavedQuota(
+                cpu=update.quota.cpu,
+                memory=update.quota.memory,
+                gpu=update.quota.gpu,
+            )
+            quota = await self.quotas_repo.create_quota(new_quota=new_quota, cluster_id=cluster_id)
+            rp.quota = quota.id
+        elif isinstance(update.quota, models.QuotaPatch):
+            assert rp.quota is not None
+            assert quota is not None
+            # Update the existing quota
+            updated_quota = models.Quota(
+                cpu=update.quota.cpu if update.quota.cpu is not None else quota.cpu,
+                memory=update.quota.memory if update.quota.memory is not None else quota.memory,
+                gpu=update.quota.gpu if update.quota.gpu is not None else quota.gpu,
+                gpu_kind=update.quota.gpu_kind if update.quota.gpu_kind is not None else quota.gpu_kind,
+                id=quota.id,
+            )
+            quota = await self.quotas_repo.update_quota(quota=updated_quota, cluster_id=cluster_id)
+            rp.quota = quota.id
 
-            await gather(*new_classes_coroutines)
-            await session.flush()
-            await session.refresh(rp)
-            return rp.dump(quota=quota)
+        new_classes_coroutines = []
+        if update.classes is not None:
+            for rc in update.classes:
+                new_classes_coroutines.append(
+                    self.update_resource_class(
+                        api_user=api_user, resource_pool_id=resource_pool_id, resource_class_id=rc.id, update=rc
+                    )
+                )
+
+        if update.remote is RESET:
+            rp.remote_provider_id = None
+            rp.remote_json = None
+        elif update.remote is not None:
+            rp.remote_provider_id = (
+                update.remote.provider_id if update.remote.provider_id is not None else rp.remote_provider_id
+            )
+            remote_json = rp.remote_json if rp.remote_json is not None else dict()
+            remote_json.update(update.remote.to_dict())
+            del remote_json["provider_id"]
+            rp.remote_json = remote_json
+
+        await gather(*new_classes_coroutines)
+        await session.flush()
+        await session.refresh(rp)
+        result = rp.dump(quota=quota)
+        return result
 
     @_only_admins
     async def delete_resource_pool(self, api_user: base_models.APIUser, id: int) -> None:
-        """Delete a resource pool from the database."""
+        """Insert a new resource pool."""
         async with self.session_maker() as session, session.begin():
-            stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == id)
-            res = await session.execute(stmt)
-            rp = res.scalars().first()
-            if rp is not None:
-                if rp.default:
-                    raise errors.ValidationError(message="The default resource pool cannot be deleted.")
-                await session.delete(rp)
-                if rp.quota:
-                    await self.quotas_repo.delete_quota(rp.quota, rp.get_cluster_id())
-            return None
+            await self._delete_resource_pool(
+                api_user=api_user,
+                id=id,
+                session=session,
+            )
+
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
+    async def _delete_resource_pool(
+        self, api_user: base_models.APIUser, id: int, session: AsyncSession
+    ) -> models.DeletedResourcePool | None:
+        """Delete a resource pool from the database."""
+        stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == id)
+        res = await session.execute(stmt)
+        rp = res.scalars().first()
+        if rp is not None:
+            if rp.default:
+                raise errors.ValidationError(message="The default resource pool cannot be deleted.")
+            await session.delete(rp)
+            if rp.quota:
+                await self.quotas_repo.delete_quota(rp.quota, rp.get_cluster_id())
+            return models.DeletedResourcePool(id=id)
+        return None
 
     @_only_admins
     async def delete_resource_class(
@@ -720,9 +797,13 @@ class UserRepository(_Base):
     """The adapter used for accessing resource pool users with SQLAlchemy."""
 
     def __init__(
-        self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository, user_repo: UserRepo
+        self,
+        session_maker: Callable[..., AsyncSession],
+        quotas_repo: QuotaRepository,
+        user_repo: UserRepo,
+        authz: Authz,
     ) -> None:
-        super().__init__(session_maker, quotas_repo)
+        super().__init__(session_maker, quotas_repo, authz)
         self.kc_user_repo = user_repo
 
     @_only_admins
@@ -801,7 +882,7 @@ class UserRepository(_Base):
             if resource_pool_id is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.id == resource_pool_id)
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             rps: Sequence[schemas.ResourcePoolORM] = res.scalars().all()
             output: list[models.ResourcePool] = []
@@ -852,12 +933,23 @@ class UserRepository(_Base):
                     raise errors.ForbiddenError(
                         message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
                     )
+            existing_rp_ids = {rp.id for rp in user.resource_pools}
+            new_rp_ids = {rp.id for rp in rps_to_add}
             if append:
-                user_rp_ids = {rp.id for rp in user.resource_pools}
-                rps_to_add = [rp for rp in rps_to_add if rp.id not in user_rp_ids]
+                rps_to_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
                 user.resource_pools.extend(rps_to_add)
+                removed_rps: list[schemas.ResourcePoolORM] = []
             else:
+                removed_rps = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
                 user.resource_pools = list(rps_to_add)
+            for rp in rps_to_add:
+                await self._grant_resource_pool_members(api_user, rp.id, [keycloak_id], session=session)
+                if rp.default or rp.public:
+                    await self._unprohibit_resource_pool_users(api_user, rp.id, [keycloak_id], session=session)
+            for rp in removed_rps:
+                await self._revoke_resource_pool_member(api_user, rp.id, keycloak_id, session=session)
+                if rp.default or rp.public:
+                    await self._prohibit_resource_pool_user(api_user, rp.id, keycloak_id, session=session)
             output: list[models.ResourcePool] = []
             for rp in rps_to_add:
                 quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
@@ -870,6 +962,13 @@ class UserRepository(_Base):
     ) -> None:
         """Remove a user from a specific resource pool."""
         async with self.session_maker() as session, session.begin():
+            rp_stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == resource_pool_id)
+            rp_res = await session.execute(rp_stmt)
+            rp = rp_res.scalars().first()
+            if rp is None:
+                raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} does not exist")
+
+            # SQL removal (existing logic)
             sub = (
                 select(schemas.UserORM.id)
                 .join(schemas.ResourcePoolORM, schemas.UserORM.resource_pools)
@@ -878,6 +977,21 @@ class UserRepository(_Base):
             )
             stmt = delete(schemas.resource_pools_users).where(schemas.resource_pools_users.c.user_id.in_(sub))
             await session.execute(stmt)
+            await self._revoke_resource_pool_member(api_user, resource_pool_id, keycloak_id, session=session)
+            if rp.default or rp.public:
+                await self._prohibit_resource_pool_user(api_user, resource_pool_id, keycloak_id, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_prohibited)
+    async def _prohibit_resource_pool_user(
+        self, api_user: base_models.APIUser, resource_pool_id: int, keycloak_id: str, session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange:
+        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=[keycloak_id])
+
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_member)
+    async def _revoke_resource_pool_member(
+        self, api_user: base_models.APIUser, resource_pool_id: int, keycloak_id: str, session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange:
+        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=[keycloak_id])
 
     @_only_admins
     async def update_resource_pool_users(
@@ -906,6 +1020,8 @@ class UserRepository(_Base):
                     api_user=api_user, resource_pool_id=resource_pool_id
                 )
                 users_to_modify = [user for user in all_existing_users.disallowed if user.keycloak_id in user_ids]
+                re_allowed_ids = [u.keycloak_id for u in users_to_modify]
+                await self._unprohibit_resource_pool_users(api_user, resource_pool_id, re_allowed_ids, session=session)
                 return await gather(
                     *[
                         self.update_user(
@@ -925,9 +1041,26 @@ class UserRepository(_Base):
                 rp_user_ids = {rp.id for rp in rp.users}
                 users_to_add = [u for u in list(users_to_add_exist) + users_to_add_missing if u.id not in rp_user_ids]
                 rp.users.extend(users_to_add)
+                await self._grant_resource_pool_members(api_user, resource_pool_id, user_ids, session=session)
             else:
                 rp.users = list(users_to_add_exist) + users_to_add_missing
             return [usr.dump() for usr in rp.users]
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_member)
+    async def _grant_resource_pool_members(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        if not user_ids:
+            return None
+        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=user_ids)
+
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_prohibited)
+    async def _unprohibit_resource_pool_users(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        if not user_ids:
+            return None
+        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=user_ids)
 
     @_only_admins
     async def update_user(self, api_user: base_models.APIUser, keycloak_id: str, **kwargs: Any) -> base_models.User:
@@ -946,6 +1079,15 @@ class UserRepository(_Base):
                 )
             if (no_default_access := kwargs.get("no_default_access")) is not None:
                 user.no_default_access = no_default_access
+                default_rps_stmt = select(schemas.ResourcePoolORM.id).where(schemas.ResourcePoolORM.default == true())
+                default_rps_res = await session.execute(default_rps_stmt)
+                default_rp_ids = [row[0] for row in default_rps_res.all()]
+
+                for rp_id in default_rp_ids:
+                    if no_default_access:
+                        await self._prohibit_resource_pool_user(api_user, rp_id, keycloak_id, session=session)
+                    else:
+                        await self._unprohibit_resource_pool_users(api_user, rp_id, [keycloak_id], session=session)
             return user.dump()
 
 

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -193,14 +193,6 @@ class ResourcePoolRepository(_Base):
         self, api_user: base_models.APIUser, resource_pool_id: int, name: str | None = None
     ) -> models.ResourcePool:
         """Get a specific resource pool by ID with Authzed permission check."""
-        if not api_user.is_admin:
-            allowed = await self.authz.has_permission(
-                api_user, ResourceType.resource_pool, resource_pool_id, Scope.READ
-            )
-            if not allowed:
-                raise errors.MissingResourceError(
-                    message=f"The resource pool with id {resource_pool_id} cannot be found."
-                )
         async with self.session_maker() as session:
             stmt = (
                 select(schemas.ResourcePoolORM)
@@ -208,6 +200,7 @@ class ResourcePoolRepository(_Base):
                 .options(selectinload(schemas.ResourcePoolORM.classes))
                 .options(selectinload(schemas.ResourcePoolORM.cluster))
             )
+            stmt = await _resource_pool_access_control(api_user, stmt, self.authz)
             if name is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.name == name)
             res = await session.execute(stmt)

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -18,13 +18,15 @@ from uuid import uuid4
 from sqlalchemy import NullPool, delete, false, select, true
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import selectinload
-from sqlalchemy.sql import Select, and_, not_, or_
+from sqlalchemy.sql import Select, or_
 from ulid import ULID
 
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
+from renku_data_services.authz.authz import Authz, AuthzOperation
+from renku_data_services.authz.models import Scope
 from renku_data_services.base_models import RESET
-from renku_data_services.base_models.core import ResetType
+from renku_data_services.base_models.core import ResetType, ResourceType
 from renku_data_services.crc import models
 from renku_data_services.crc import orm as schemas
 from renku_data_services.crc.core import validate_resource_class_update, validate_resource_pool_update
@@ -37,84 +39,43 @@ from renku_data_services.users.db import UserRepo
 
 
 class _Base:
-    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository) -> None:
+    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository, authz: Authz) -> None:
         self.session_maker = session_maker
         self.quotas_repo = quotas_repo
+        self.authz: Authz = authz
 
 
-def _resource_pool_access_control(
+async def _resource_pool_access_control(
     api_user: base_models.APIUser,
     stmt: Select[tuple[schemas.ResourcePoolORM]],
+    authz: Authz,
 ) -> Select[tuple[schemas.ResourcePoolORM]]:
     """Modifies a select query to list resource pools based on whether the user is logged in or not."""
     output = stmt
-    match (api_user.is_authenticated, api_user.is_admin):
-        case True, False:
-            # The user is logged in but not an admin
-            api_user_has_default_pool_access = not_(
-                # NOTE: The only way to check that a user is allowed to access the default pool is that such a
-                # record does NOT EXIST in the database
-                select(schemas.UserORM.no_default_access)
-                .where(and_(schemas.UserORM.keycloak_id == api_user.id, schemas.UserORM.no_default_access == true()))
-                .exists()
-            )
-            output = output.join(schemas.UserORM, schemas.ResourcePoolORM.users, isouter=True).where(
-                or_(
-                    schemas.UserORM.keycloak_id == api_user.id,  # the user is part of the pool
-                    and_(  # the pool is not default but is public
-                        schemas.ResourcePoolORM.default != true(), schemas.ResourcePoolORM.public == true()
-                    ),
-                    and_(  # the pool is default and the user is not prohibited from accessing it
-                        schemas.ResourcePoolORM.default == true(),
-                        api_user_has_default_pool_access,
-                    ),
-                )
-            )
-        case True, True:
-            # The user is logged in and is an admin, they can see all resource pools
-            pass
-        case False, _:
-            # The user is not logged in, they can see only the public resource pools
-            output = output.where(schemas.ResourcePoolORM.public == true())
+    if api_user.is_admin:
+        return output
+    allowed_resource_pools = await authz.resources_with_permission(
+        api_user, api_user.id, ResourceType.resource_pool, Scope.USE
+    )
+    allowed_ids = [int(id) for id in allowed_resource_pools]
+    output = output.where(schemas.ResourcePoolORM.id.in_(allowed_ids))
     return output
 
 
-def _classes_user_access_control(
+async def _classes_user_access_control(
     api_user: base_models.APIUser,
     stmt: Select[tuple[schemas.ResourceClassORM]],
+    authz: Authz,
 ) -> Select[tuple[schemas.ResourceClassORM]]:
     """Adjust the select statement for classes based on whether the user is logged in or not."""
     output = stmt
-    match (api_user.is_authenticated, api_user.is_admin):
-        case True, False:
-            # The user is logged in but is not an admin
-            api_user_has_default_pool_access = not_(
-                # NOTE: The only way to check that a user is allowed to access the default pool is that such a
-                # record does NOT EXIST in the database
-                select(schemas.UserORM.no_default_access)
-                .where(and_(schemas.UserORM.keycloak_id == api_user.id, schemas.UserORM.no_default_access == true()))
-                .exists()
-            )
-            output = output.join(schemas.UserORM, schemas.ResourcePoolORM.users, isouter=True).where(
-                or_(
-                    schemas.UserORM.keycloak_id == api_user.id,  # the user is part of the pool
-                    and_(  # the pool is not default but is public
-                        schemas.ResourcePoolORM.default != true(), schemas.ResourcePoolORM.public == true()
-                    ),
-                    and_(  # the pool is default and the user is not prohibited from accessing it
-                        schemas.ResourcePoolORM.default == true(),
-                        api_user_has_default_pool_access,
-                    ),
-                )
-            )
-        case True, True:
-            # The user is logged in and is an admin, they can see all resource classes
-            pass
-        case False, _:
-            # The user is not logged in, they can see only the classes from public resource pools
-            output = output.join(schemas.UserORM, schemas.ResourcePoolORM.users, isouter=True).where(
-                schemas.ResourcePoolORM.public == true(),
-            )
+    if api_user.is_admin:
+        return output
+    allowed_resource_pools = await authz.resources_with_permission(
+        api_user, api_user.id, ResourceType.resource_pool, Scope.USE
+    )
+    allowed_ids = [int(id) for id in allowed_resource_pools]
+    output = output.where(schemas.ResourcePoolORM.id.in_(allowed_ids))
     return output
 
 
@@ -155,8 +116,8 @@ def _only_admins(
 class ResourcePoolRepository(_Base):
     """The adapter used for accessing resource pools with SQLAlchemy."""
 
-    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository):
-        super().__init__(session_maker, quotas_repo)
+    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository, authz: Authz):
+        super().__init__(session_maker, quotas_repo, authz)
         self.__cluster_repo = ClusterRepository(session_maker=self.session_maker)
 
     async def initialize(self, async_connection_url: str, rp: models.UnsavedResourcePool) -> None:

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from math import ceil
@@ -472,3 +472,18 @@ class RemoteConfigurationRunaiPatch:
 
 
 RemoteConfigurationPatch = ResetType | RemoteConfigurationFirecrestPatch | RemoteConfigurationRunaiPatch
+
+
+@dataclass(frozen=True, eq=True, kw_only=True)
+class DeletedResourcePool:
+    """A resource pool that has been deleted."""
+
+    id: int
+
+
+@dataclass(frozen=True, eq=True, kw_only=True)
+class ResourcePoolMembershipChange:
+    """Returned by user-management methods so the authz_change decorator knows what to sync to SpiceDB."""
+
+    resource_pool_id: int
+    user_ids: Collection[str]

--- a/components/renku_data_services/notebooks/config/__init__.py
+++ b/components/renku_data_services/notebooks/config/__init__.py
@@ -7,6 +7,8 @@ from typing import Any, Protocol, Self
 
 import kr8s
 
+from renku_data_services.authz.authz import Authz
+from renku_data_services.authz.config import AuthzConfig
 from renku_data_services.base_models import APIUser
 from renku_data_services.crc.db import ClusterRepository, QuotaRepository, ResourcePoolRepository
 from renku_data_services.crc.models import ClusterSettings, ResourceClass, SessionProtocol
@@ -147,7 +149,7 @@ class NotebooksConfig:
     local_cluster_session_service_account: str | None = None
 
     @classmethod
-    def from_env(cls, db_config: DBConfig, enable_internal_gitlab: bool) -> Self:
+    def from_env(cls, db_config: DBConfig, authz_config: AuthzConfig, enable_internal_gitlab: bool) -> Self:
         """Create a configuration object from environment variables."""
         enable_internal_gitlab = os.getenv("ENABLE_INTERNAL_GITLAB", "false").lower() == "true"
         dummy_stores = _parse_str_as_bool(os.environ.get("DUMMY_STORES", False))
@@ -182,8 +184,9 @@ class NotebooksConfig:
         )
         secrets_client = K8sSecretClient(client)
 
+        authz = Authz(authz_config)
         quota_repo = QuotaRepository(K8sResourceQuotaClient(client), K8sPriorityClassClient(client))
-        rp_repo = ResourcePoolRepository(db_config.async_session_maker, quota_repo)
+        rp_repo = ResourcePoolRepository(db_config.async_session_maker, quota_repo, authz=authz)
         crc_validator = CRCValidator(rp_repo)
         k8s_v2_client = NotebookK8sClient(
             client=client,

--- a/test/bases/renku_data_services/data_api/test_resource_pools.py
+++ b/test/bases/renku_data_services/data_api/test_resource_pools.py
@@ -1645,3 +1645,51 @@ async def test_resource_class_empty_patch_noop(
     assert res.json is not None
     rc = res.json
     assert rc == default_rc
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_visibility_toggle(
+    sanic_client: SanicASGITestClient,
+    admin_headers: dict[str, str],
+    valid_resource_pool_payload: dict[str, Any],
+    cluster: KindCluster,
+) -> None:
+    """E2E: toggling the public flag via PATCH updates Authzed access for non-admin users."""
+    valid_resource_pool_payload["default"] = False
+    valid_resource_pool_payload["public"] = True
+
+    _, res = await create_rp(valid_resource_pool_payload, sanic_client)
+    assert res.status_code == 201
+    rp_id = res.json["id"]
+
+    # Pick a regular user (not user[0] who is admin)
+    _, res = await sanic_client.get("/api/data/users", headers=admin_headers)
+    assert res.status_code == 200
+    assert len(res.json) >= 1
+    user_id = res.json[1]["id"]
+    user_headers = {"Authorization": f"Bearer {json.dumps({'id': user_id})}"}
+
+    # Visible while public
+    _, res = await sanic_client.get(f"/api/data/resource_pools/{rp_id}", headers=user_headers)
+    assert res.status_code == 200
+
+    # PATCH → private
+    _, res = await sanic_client.patch(
+        f"/api/data/resource_pools/{rp_id}", headers=admin_headers, json={"public": False}
+    )
+    assert res.status_code == 200
+    assert res.json["public"] is False
+
+    # Hidden after going private
+    _, res = await sanic_client.get(f"/api/data/resource_pools/{rp_id}", headers=user_headers)
+    assert res.status_code == 404
+
+    # PATCH → public again
+    _, res = await sanic_client.patch(f"/api/data/resource_pools/{rp_id}", headers=admin_headers, json={"public": True})
+    assert res.status_code == 200
+    assert res.json["public"] is True
+
+    # Visible again
+    _, res = await sanic_client.get(f"/api/data/resource_pools/{rp_id}", headers=user_headers)
+    assert res.status_code == 200

--- a/test/bases/renku_data_services/data_api/test_resource_pools.py
+++ b/test/bases/renku_data_services/data_api/test_resource_pools.py
@@ -548,8 +548,8 @@ async def test_restricted_default_resource_pool_access(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 2
-    # Restrict one user to not have access to the default pool
-    no_default_user = existing_users[0]
+    # Restrict one user to not have access to the default pool (not user[0] who is admin)
+    no_default_user = existing_users[1]
     no_default_user_id = no_default_user["id"]
     no_default_access_token = json.dumps({"id": no_default_user_id})
     _, res = await sanic_client.delete(
@@ -558,7 +558,7 @@ async def test_restricted_default_resource_pool_access(
     )
     assert res.status_code == 204
     # The other user in the db should be able to access the default pool
-    default_access_user = existing_users[1]
+    default_access_user = existing_users[2]
     user_id = default_access_user["id"]
     access_token = json.dumps({"id": user_id})
     # Ensure non-authenticated users have access to the default pool
@@ -618,8 +618,8 @@ async def test_restricted_default_resource_pool_access_changes(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 2
-    # Restrict one user to not have access to the default pool
-    no_default_user = existing_users[0]
+    # Restrict one user to not have access to the default pool (not user[0] who is admin)
+    no_default_user = existing_users[1]
     no_default_user_id = no_default_user["id"]
     no_default_access_token = json.dumps({"id": no_default_user_id})
     _, res = await sanic_client.delete(
@@ -665,8 +665,8 @@ async def test_private_resource_pool_access(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 2
-    # Select one user that has no access
-    restricted_user = existing_users[0]
+    # Select one user that has no access (not user[0] who is admin)
+    restricted_user = existing_users[3]
     restricted_user_id = restricted_user["id"]
     restricted_access_token = json.dumps({"id": restricted_user_id})
     # Give another user access to the private pool
@@ -801,7 +801,8 @@ async def test_user_resource_pools(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 1
-    user = existing_users[0]
+    # not user[0] who is admin
+    user = existing_users[1]
     user_id = user["id"]
     user_access_token = json.dumps({"id": user_id})
     user_headers = {"Authorization": f"Bearer {user_access_token}"}

--- a/test/components/renku_data_services/authz/test_authorization.py
+++ b/test/components/renku_data_services/authz/test_authorization.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 import pytest_asyncio
 from authzed.api.v1 import (
@@ -13,6 +15,7 @@ from renku_data_services.authz.authz import _AuthzConverter, _Relation
 from renku_data_services.authz.models import Member, Role, Scope, Visibility
 from renku_data_services.base_models import APIUser
 from renku_data_services.base_models.core import NamespacePath, ResourceType
+from renku_data_services.crc.models import DeletedResourcePool
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.errors import errors
 from renku_data_services.migrations.core import run_migrations_for_app
@@ -546,3 +549,174 @@ async def test_resource_pool_isolation(app_manager_instance: DependencyManager, 
 
     assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_a, Scope.READ)
     assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_b, Scope.READ)
+
+
+# Unique ID ranges per test — avoids cross-test interference in shared SpiceDB
+_ADD_DELETE_BASE = 9100
+_UNDO_BASE = 9110
+_VISIBILITY_BASE = 9120
+_LOOKUP_BASE = 9130
+_CLEANUP_BASE = 9140
+
+
+async def _assert_pool_access(
+    authz,
+    pool_id: int,
+    *,
+    admin_use: bool = True,
+    admin_write: bool = True,
+    user_use: bool,
+    anon_use: bool,
+) -> None:
+    """Assert USE / WRITE for admin, regular_user1 and anon_user on *pool_id*.
+
+    regular_user1 and anon_user are never expected to have WRITE — those two
+    assertions are always ``False`` and included automatically.
+    """
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, pool_id, Scope.READ) is admin_use
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, pool_id, Scope.WRITE) is admin_write
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_id, Scope.READ) is user_use
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_id, Scope.WRITE) is False
+    assert await authz.has_permission(anon_user, ResourceType.resource_pool, pool_id, Scope.READ) is anon_use
+    assert await authz.has_permission(anon_user, ResourceType.resource_pool, pool_id, Scope.WRITE) is False
+
+
+async def _create_pool_in_authz(authz, pool_id: int, *, public: bool) -> None:
+    """Shorthand: call ``_add_resource_pool`` and write the result to SpiceDB."""
+    change = authz._add_resource_pool(SimpleNamespace(id=pool_id, public=public))
+    await authz.client.WriteRelationships(change.apply)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_pool", [True, False], ids=["public", "private"])
+async def test_resource_pool_add_delete_authz(
+    app_manager_instance: DependencyManager, bootstrap_admins, public_pool: bool
+) -> None:
+    """_add_resource_pool creates correct rels; _remove_resource_pool cleans them all."""
+    authz = app_manager_instance.authz
+    pool_id = _ADD_DELETE_BASE + int(public_pool)
+
+    await _create_pool_in_authz(authz, pool_id, public=public_pool)
+    await _assert_pool_access(authz, pool_id, user_use=public_pool, anon_use=public_pool)
+
+    remove_change = await authz._remove_resource_pool(admin_user, DeletedResourcePool(id=pool_id))
+    await authz.client.WriteRelationships(remove_change.apply)
+
+    await _assert_pool_access(authz, pool_id, admin_use=False, admin_write=False, user_use=False, anon_use=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_pool", [True, False], ids=["public", "private"])
+async def test_resource_pool_add_undo(
+    app_manager_instance: DependencyManager, bootstrap_admins, public_pool: bool
+) -> None:
+    """Applying the undo payload from _add_resource_pool fully reverses creation."""
+    authz = app_manager_instance.authz
+    pool_id = _UNDO_BASE + int(public_pool)
+
+    change = authz._add_resource_pool(SimpleNamespace(id=pool_id, public=public_pool))
+    await authz.client.WriteRelationships(change.apply)
+    await _assert_pool_access(authz, pool_id, user_use=public_pool, anon_use=public_pool)
+
+    # Undo — simulates DB-rollback recovery path
+    await authz.client.WriteRelationships(change.undo)
+    await _assert_pool_access(authz, pool_id, admin_use=False, admin_write=False, user_use=False, anon_use=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_public,new_public",
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+        (False, False),
+    ],
+    ids=["public_to_private", "private_to_public", "public_to_public(noop)", "private_to_private(noop)"],
+)
+async def test_resource_pool_visibility_update(
+    app_manager_instance: DependencyManager,
+    bootstrap_admins,
+    initial_public: bool,
+    new_public: bool,
+) -> None:
+    """_update_resource_pool_visibility adds/removes public_viewer wildcards correctly."""
+    authz = app_manager_instance.authz
+    pool_id = _VISIBILITY_BASE + int(initial_public) * 2 + int(new_public)
+
+    await _create_pool_in_authz(authz, pool_id, public=initial_public)
+    await _assert_pool_access(authz, pool_id, user_use=initial_public, anon_use=initial_public)
+
+    vis_change = await authz._update_resource_pool_visibility(
+        admin_user, SimpleNamespace(id=pool_id, public=new_public)
+    )
+    await authz.client.WriteRelationships(vis_change.apply)
+
+    await _assert_pool_access(authz, pool_id, user_use=new_public, anon_use=new_public)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_lookup_resources(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """resources_with_permission returns correct pool IDs per user role."""
+    authz = app_manager_instance.authz
+    public_id, private_id = _LOOKUP_BASE, _LOOKUP_BASE + 1
+
+    for pid, public in [(public_id, True), (private_id, False)]:
+        await _create_pool_in_authz(authz, pid, public=public)
+
+    # Admin sees both
+    admin_pools = set(
+        await authz.resources_with_permission(admin_user, admin_user.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert {str(public_id), str(private_id)}.issubset(admin_pools)
+
+    # Regular user sees only public
+    user_pools = set(
+        await authz.resources_with_permission(regular_user1, regular_user1.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert str(public_id) in user_pools
+    assert str(private_id) not in user_pools
+
+    # Add regular_user1 as member → now sees both
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(updates=[_rel(private_id, _Relation.viewer, regular_user1.id)])
+    )
+    user_pools = set(
+        await authz.resources_with_permission(regular_user1, regular_user1.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert str(private_id) in user_pools
+
+    # Anon still only sees public
+    anon_pools = set(
+        await authz.resources_with_permission(anon_user, anon_user.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert str(public_id) in anon_pools
+    assert str(private_id) not in anon_pools
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_delete_cleans_all_relations(
+    app_manager_instance: DependencyManager, bootstrap_admins
+) -> None:
+    """_remove_resource_pool removes ALL rels including member and prohibited."""
+    authz = app_manager_instance.authz
+    pool_id = _CLEANUP_BASE
+
+    await _create_pool_in_authz(authz, pool_id, public=True)
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(
+            updates=[
+                _rel(pool_id, _Relation.viewer, regular_user1.id),
+                _rel(pool_id, _Relation.prohibited, regular_user2.id),
+            ]
+        )
+    )
+
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_id, Scope.READ)
+    assert not await authz.has_permission(regular_user2, ResourceType.resource_pool, pool_id, Scope.READ)
+
+    remove_change = await authz._remove_resource_pool(admin_user, DeletedResourcePool(id=pool_id))
+    await authz.client.WriteRelationships(remove_change.apply)
+
+    await _assert_pool_access(authz, pool_id, admin_use=False, admin_write=False, user_use=False, anon_use=False)
+    assert not await authz.has_permission(regular_user2, ResourceType.resource_pool, pool_id, Scope.READ)

--- a/test/components/renku_data_services/authz/test_authorization.py
+++ b/test/components/renku_data_services/authz/test_authorization.py
@@ -654,6 +654,13 @@ async def test_resource_pool_visibility_update(
 
     await _assert_pool_access(authz, pool_id, user_use=new_public, anon_use=new_public)
 
+    if initial_public == new_public:
+        assert len(vis_change.apply.updates) == 0, "No-op transition should produce no apply ops"
+        assert len(vis_change.undo.updates) == 0, (
+            f"No-op transition ({initial_public}->{new_public}) produced "
+            f"{len(vis_change.undo.updates)} undo op(s) that would corrupt state on rollback"
+        )
+
 
 @pytest.mark.asyncio
 async def test_resource_pool_lookup_resources(app_manager_instance: DependencyManager, bootstrap_admins) -> None:

--- a/test/utils.py
+++ b/test/utils.py
@@ -262,6 +262,8 @@ class TestDependencyManager(DependencyManager):
         gitlab_authenticator: base_models.Authenticator
         gitlab_client: base_models.GitlabAPIProtocol
         config.authz_config = AuthzConfigStack.from_env()
+        nb_authz = NonCachingAuthz(config.authz_config)
+        config.nb_config.k8s_v2_client._NotebookK8sClient__rp_repo.authz = nb_authz
         kc_api: IKeycloakAPI
 
         default_kubeconfig = KubeConfigEnv()

--- a/test/utils.py
+++ b/test/utils.py
@@ -333,8 +333,11 @@ class TestDependencyManager(DependencyManager):
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
+            authz=authz,
         )
-        rp_repo = ResourcePoolRepository(session_maker=config.db.async_session_maker, quotas_repo=quota_repo)
+        rp_repo = ResourcePoolRepository(
+            session_maker=config.db.async_session_maker, quotas_repo=quota_repo, authz=authz
+        )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,
             gitlab_client=gitlab_client,


### PR DESCRIPTION
## Summary

Migrate resource pool access control from SQL-based checks to the Authzed/SpiceDB authorization service, achieving feature parity with the previous implementation.

## Key Changes

- **Authzed-based Access Control**: Replaced `_resource_pool_access_control` and `_classes_user_access_control` with `_filter_by_authz`, shifting permission resolution to `Authzed`.
- **Automated Synchronization**: Integrated `@Authz.authz_change` decorators in `ResourcePoolRepository` and `UserRepository` to automatically synchronize DB changes with `SpiceDB`.
- **Authz Logic Extension**: Implemented `_add_resource_pool`, `_remove_resource_pool`, `_update_resource_pool_visibility`, and `_update_resource_pool_user_relationships` in the `Authz` class.
- **Membership Management**: Updated `UserRepository` to map user memberships and `no_default_access` flags to `member` and `prohibited` relations in `Authzed`.
- **Dependency Injection**: Updated `Config` and `DependencyManager` to provide `Authz` service instances to repositories.

## Gotchas & Implementation Details

- **Idempotency**: All `Authzed` updates use `OPERATION_TOUCH`, ensuring operations are idempotent.
- **Public Access**: Implemented using `SpiceDB` wildcards (user:* and anonymous_user:*) for the `public_user` relation.
- **Default Pool Restrictions**: The `no_default_access` logic is now enforced via the `prohibited` relation on the default resource pool.
---

## PR stack

- (base) #1248
  - (this) #1256
---

/deploy renku=salimkayal-add-AUTHZ-config-to-k8s-watcher
