### PR TITLE
fix: users API response

### DIFF
--- a/components/renku_data_services/users/blueprints.py
+++ b/components/renku_data_services/users/blueprints.py
@@ -44,9 +44,9 @@ class KCUsersBP(CustomBlueprint):
                     dict(
                         id=user.id,
                         username=user.namespace.path.first.value,
-                        email=user.email,
-                        first_name=user.first_name,
-                        last_name=user.last_name,
+                        email=user.email if user.email else None,
+                        first_name=user.first_name if user.first_name else None,
+                        last_name=user.last_name if user.last_name else None,
                     )
                     for user in users
                 ],
@@ -70,10 +70,9 @@ class KCUsersBP(CustomBlueprint):
                 dict(
                     id=user_info.id,
                     username=user_info.namespace.path.first.value,
-                    email=user_info.email,
-                    first_name=user_info.first_name,
-                    last_name=user_info.last_name,
-                    is_admin=user.is_admin,
+                    email=user_info.email if user_info.email else None,
+                    first_name=user_info.first_name if user_info.first_name else None,
+                    last_name=user_info.last_name if user_info.last_name else None,
                 ),
             )
 
@@ -106,9 +105,9 @@ class KCUsersBP(CustomBlueprint):
                 dict(
                     id=user_info.id,
                     username=user_info.namespace.path.first.value,
-                    email=user_info.email,
-                    first_name=user_info.first_name,
-                    last_name=user_info.last_name,
+                    email=user_info.email if user_info.email else None,
+                    first_name=user_info.first_name if user_info.first_name else None,
+                    last_name=user_info.last_name if user_info.last_name else None,
                 ),
             )
 

--- a/components/renku_data_services/users/blueprints.py
+++ b/components/renku_data_services/users/blueprints.py
@@ -9,6 +9,7 @@ from sanic_ext import validate
 from ulid import ULID
 
 import renku_data_services.base_models as base_models
+from renku_data_services.app_config import logging
 from renku_data_services.base_api.auth import authenticate, only_admins, only_authenticated, validate_path_user_id
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
 from renku_data_services.base_api.misc import validate_query
@@ -19,6 +20,8 @@ from renku_data_services.secrets.models import Secret, SecretKind
 from renku_data_services.users import apispec, models
 from renku_data_services.users.core import validate_secret_patch, validate_unsaved_secret
 from renku_data_services.users.db import UserPreferencesRepository, UserRepo
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(kw_only=True)
@@ -97,6 +100,7 @@ class KCUsersBP(CustomBlueprint):
             user_info = await self.repo.get_or_create_user(requested_by=user, id=user_id)
             if not user_info:
                 raise errors.MissingResourceError(message=f"The user with ID {user_id} cannot be found.")
+            logger.info(f"user last_name: {user_info.last_name}")
             return validated_json(
                 apispec.UserWithId,
                 dict(

--- a/components/renku_data_services/users/blueprints.py
+++ b/components/renku_data_services/users/blueprints.py
@@ -9,7 +9,6 @@ from sanic_ext import validate
 from ulid import ULID
 
 import renku_data_services.base_models as base_models
-from renku_data_services.app_config import logging
 from renku_data_services.base_api.auth import authenticate, only_admins, only_authenticated, validate_path_user_id
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
 from renku_data_services.base_api.misc import validate_query
@@ -99,7 +98,6 @@ class KCUsersBP(CustomBlueprint):
             user_info = await self.repo.get_or_create_user(requested_by=user, id=user_id)
             if not user_info:
                 raise errors.MissingResourceError(message=f"The user with ID {user_id} cannot be found.")
-            logger.info(f"user last_name: {user_info.last_name}")
             return validated_json(
                 apispec.UserWithId,
                 dict(

--- a/components/renku_data_services/users/blueprints.py
+++ b/components/renku_data_services/users/blueprints.py
@@ -70,6 +70,7 @@ class KCUsersBP(CustomBlueprint):
                     email=user_info.email if user_info.email else None,
                     first_name=user_info.first_name if user_info.first_name else None,
                     last_name=user_info.last_name if user_info.last_name else None,
+                    is_admin=user.is_admin,
                 ),
             )
 

--- a/components/renku_data_services/users/blueprints.py
+++ b/components/renku_data_services/users/blueprints.py
@@ -20,8 +20,6 @@ from renku_data_services.users import apispec, models
 from renku_data_services.users.core import validate_secret_patch, validate_unsaved_secret
 from renku_data_services.users.db import UserPreferencesRepository, UserRepo
 
-logger = logging.getLogger(__name__)
-
 
 @dataclass(kw_only=True)
 class KCUsersBP(CustomBlueprint):


### PR DESCRIPTION
See: https://renku.sentry.io/issues/112402815/?referrer=slack&notification_uuid=4a875e70-0f1b-4ce2-be31-e0db72c689b0&environment=renkulab&alert_rule_id=260870&alert_type=issue

Note: not sure how to test this: every time I create a user without a last name in Keycloak, the DB gets populated with `NULL` by data-tasks and not with `""` (empty string).

/deploy