### PR TITLE
Feat: Enable CNB image extensions support in BuildStrategy

### DIFF
--- a/components/renku_pack_builder/manifests/buildstrategy.yaml
+++ b/components/renku_pack_builder/manifests/buildstrategy.yaml
@@ -7,7 +7,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.15"
     - name: run-image
       description: The image to use as the base for all session images built with this strategy
       default: "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.1.0"
@@ -22,6 +22,8 @@ spec:
       image: $(params.builder-image)
       imagePullPolicy: IfNotPresent
       env:
+        - name: CNB_EXPERIMENTAL_MODE
+          value: "warn"
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: BP_RENKU_FRONTENDS
@@ -67,10 +69,57 @@ spec:
             fi
           done
 
-          /cnb/lifecycle/creator \
+          LAYERS_DIR=/layers
+          GENERATED_DIR="${LAYERS_DIR}/generated"
+
+          echo "> Running analyzer..."
+          /cnb/lifecycle/analyzer \
+            -run-image=${PARAM_RUN_IMAGE} \
+            ${PARAM_OUTPUT_IMAGE}
+
+          echo "> Running detector..."
+          /cnb/lifecycle/detector \
+            -app=${PARAM_SOURCE_CONTEXT}
+
+          echo "> Running restorer..."
+          /cnb/lifecycle/restorer
+
+          # Check if any extensions generated Dockerfiles
+          HAS_BUILD_EXT=false
+          HAS_RUN_EXT=false
+
+          if [ -d "${GENERATED_DIR}/build" ] && \
+             find "${GENERATED_DIR}/build" -name "Dockerfile" -print -quit | grep -q .; then
+            HAS_BUILD_EXT=true
+          fi
+
+          if [ -d "${GENERATED_DIR}/run" ] && \
+             find "${GENERATED_DIR}/run" -name "Dockerfile" -print -quit | grep -q .; then
+            HAS_RUN_EXT=true
+          fi
+
+          if [ "${HAS_BUILD_EXT}" == "true" ]; then
+            echo "> Extensions detected for build image. Running extender (build)..."
+            /cnb/lifecycle/extender \
+              -app=${PARAM_SOURCE_CONTEXT} \
+              -kind=build
+          else
+            echo "> No build extensions detected. Running builder..."
+            /cnb/lifecycle/builder \
+              -app=${PARAM_SOURCE_CONTEXT}
+          fi
+
+          if [ "${HAS_RUN_EXT}" == "true" ]; then
+            echo "> Extensions detected for run image. Running extender (run)..."
+            /cnb/lifecycle/extender \
+              -app=${PARAM_SOURCE_CONTEXT} \
+              -kind=run
+          fi
+
+          echo "> Running exporter..."
+          /cnb/lifecycle/exporter \
             -app=${PARAM_SOURCE_CONTEXT} \
             -report=/tmp/report.toml \
-            -run-image=${PARAM_RUN_IMAGE} \
             ${PARAM_OUTPUT_IMAGE}
       volumeMounts:
         - mountPath: /platform/env


### PR DESCRIPTION
### Summary

This PR updates the `renku-buildpacks-v3` BuildStrategy to support **Cloud Native Buildpacks image extensions**, an experimental feature that allows extensions to generate Dockerfiles to customize build and run base images.

### What changed

The previous strategy used a single `/cnb/lifecycle/creator` call to handle the entire build lifecycle. The `creator` binary **does not invoke the `extender` phase**, which is required for image extensions to work. This PR replaces the `creator` with explicit individual lifecycle phase calls.

### Key details

- **`CNB_EXPERIMENTAL_MODE=warn`** is set to unlock experimental features (image extensions).
- **Platform API version** bumped from `0.12` to `0.15`.
- **Conditional logic** determines whether to use `extender` or `builder`:
    - If the detector phase produces extension-generated Dockerfiles in `<layers>/generated/build/`, the `extender -kind=build` is used (which also runs the build phase internally, per spec).
    - Otherwise, the standard `builder` is called.
    - Similarly, `extender -kind=run` is only invoked if run Dockerfiles are found in `<layers>/generated/run/`.
- **`-run-image` flag removed from the exporter**: it is only passed to the `analyzer`, which writes the resolved reference to `analyzed.toml`. The exporter reads from `analyzed.toml` and picks up extended run image layers from `<layers>/extended/run/` when applicable. Passing `-run-image` explicitly to the exporter would override the extended run image.

### Why this approach

- The CNB spec requires the `extender` to be called explicitly: it is not part of the `creator` all-in-one binary.
- The conditional check ensures **backward compatibility**: builds that don't use image extensions still work correctly via the standard `builder` phase.
- This keeps the strategy as a single step, preserving compatibility with the existing Shipwright `Build` resources.

### References

- [CNB Platform Spec: Extender](https://github.com/buildpacks/spec/blob/main/platform.md)
- [CNB Experimental Features](https://buildpacks.io/docs/for-app-developers/concepts/experimental-features/)
- [CNB Extend Phase](https://buildpacks.io/docs/for-platform-operators/concepts/lifecycle/extend/)