### PR TITLE
feat(builds): add the possibility to configure insecure registries

### DIFF
--- a/components/renku_data_services/session/config.py
+++ b/components/renku_data_services/session/config.py
@@ -54,6 +54,10 @@ class BuildsConfig:
         build_run_image = os.environ.get("BUILD_RUN_IMAGE")
         build_strategy_name = os.environ.get("BUILD_STRATEGY_NAME")
         build_insecure_registries = os.environ.get("BUILD_INSECURE_REGISTRIES", "")
+        if build_insecure_registries:
+            logger.warn(
+                f"Trusting insecure registries, this is not recommended in production: {build_insecure_registries}"
+            )
         push_secret_name = os.environ.get("BUILD_PUSH_SECRET_NAME")
         push_private_secret_name = os.environ.get("BUILD_PUSH_PRIVATE_SECRET_NAME")
         buildrun_retention_after_failed_seconds = int(os.environ.get("BUILD_RUN_RETENTION_AFTER_FAILED_SECONDS") or "0")

--- a/components/renku_data_services/session/config.py
+++ b/components/renku_data_services/session/config.py
@@ -34,6 +34,7 @@ class BuildsConfig:
     build_builder_image: str | None = None
     build_run_image: str | None = None
     build_strategy_name: str | None = None
+    build_insecure_registries: str = ""
     build_platform_overrides: dict[str, BuildPlatformOverrides] | None = None
     push_secret_name: str | None = None
     push_private_secret_name: str | None = None
@@ -52,6 +53,7 @@ class BuildsConfig:
         build_builder_image = os.environ.get("BUILD_BUILDER_IMAGE")
         build_run_image = os.environ.get("BUILD_RUN_IMAGE")
         build_strategy_name = os.environ.get("BUILD_STRATEGY_NAME")
+        build_insecure_registries = os.environ.get("BUILD_INSECURE_REGISTRIES", "")
         push_secret_name = os.environ.get("BUILD_PUSH_SECRET_NAME")
         push_private_secret_name = os.environ.get("BUILD_PUSH_PRIVATE_SECRET_NAME")
         buildrun_retention_after_failed_seconds = int(os.environ.get("BUILD_RUN_RETENTION_AFTER_FAILED_SECONDS") or "0")
@@ -124,6 +126,7 @@ class BuildsConfig:
             build_builder_image=build_builder_image,
             build_run_image=build_run_image,
             build_strategy_name=build_strategy_name or None,
+            build_insecure_registries=build_insecure_registries,
             build_platform_overrides=build_platform_overrides,
             push_secret_name=push_secret_name or None,
             push_private_secret_name=push_private_secret_name or None,

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -1187,6 +1187,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             frontend=build_parameters.frontend_variant,
             git_repository_revision=git_repository_revision,
             context_dir=context_dir,
+            insecure_registries=self.builds_config.build_insecure_registries,
         )
 
         platform = models.Platform.linux_amd64

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -221,6 +221,7 @@ class ShipwrightClient:
                             crs.ParamValue(name="frontend", value=params.frontend),
                             crs.ParamValue(name="run-image", value=params.run_image),
                             crs.ParamValue(name="builder-image", value=params.builder_image),
+                            crs.ParamValue(name="insecure-registries", value=params.insecure_registries),
                         ],
                         output=crs.BuildOutput(
                             image=params.output_image,

--- a/components/renku_data_services/session/models.py
+++ b/components/renku_data_services/session/models.py
@@ -352,6 +352,7 @@ class ShipwrightBuildRunParams:
     builder_image: str | None = None
     git_repository_revision: str | None = None
     context_dir: str | None = None
+    insecure_registries: str = ""
 
     def with_overrides(self, overrides: "config.BuildPlatformOverrides | None") -> "ShipwrightBuildRunParams":
         """Returns a copy of the BuildRun parameters with overrides applied."""
@@ -376,6 +377,7 @@ class ShipwrightBuildRunParams:
             builder_image=overrides.builder_image or self.builder_image,
             git_repository_revision=self.git_repository_revision,
             context_dir=self.context_dir,
+            insecure_registries=self.insecure_registries,
         )
 
 

--- a/components/renku_pack_builder/manifests/buildstrategy.yaml
+++ b/components/renku_pack_builder/manifests/buildstrategy.yaml
@@ -8,6 +8,9 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
+      default: ""
     - name: run-image
       description: The image to use as the base for all session images built with this strategy
       default: "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.1.0"
@@ -24,6 +27,8 @@ spec:
       env:
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: BP_RENKU_FRONTENDS
           value: $(params.frontend)
         - name: PARAM_SOURCE_CONTEXT


### PR DESCRIPTION
## Describe your changes

This PR implements the logic that allows to use insecure registries with the buildpacks based BuildStrategy.

This allows, for example, to use a local deployment of registries such as Harbor using a self-signed certificate or no certificate at all.

The buildpacks lifecycle supports this use case through the CNB_INSECURE_REGISTRIES environment variable with a comma separated list of insecure registries.

