### PR TITLE
feat(notebook): add secret handling for private registry image pull

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -222,6 +222,7 @@ def register_all_handlers(app: Sanic, dm: DependencyManager) -> Sanic:
         storage_repo=dm.storage_repo,
         user_repo=dm.kc_user_repo,
         git_repositories_repo=dm.git_repositories_repo,
+        builds_config=dm.config.builds,
     )
     platform_config = PlatformConfigBP(
         name="platform_config",

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -167,6 +167,7 @@ class NotebooksNewBP(CustomBlueprint):
                 metrics=self.metrics,
                 image_check_repo=self.image_check_repo,
                 data_source_repo=self.data_source_repo,
+                builds_config=self.builds_config,
             )
             return json(new_session.as_apispec().model_dump(exclude_none=True, mode="json"))
 

--- a/components/renku_data_services/notebooks/blueprints.py
+++ b/components/renku_data_services/notebooks/blueprints.py
@@ -32,6 +32,7 @@ from renku_data_services.notebooks.data_sources import DataSourceRepository
 from renku_data_services.notebooks.image_check import ImageCheckRepository
 from renku_data_services.project.db import ProjectRepository, ProjectSessionSecretRepository
 from renku_data_services.repositories.db import GitRepositoriesRepository
+from renku_data_services.session.config import BuildsConfig
 from renku_data_services.session.db import SessionRepository
 from renku_data_services.storage.db import StorageRepository
 from renku_data_services.users.db import UserRepo
@@ -61,6 +62,7 @@ class NotebooksNewBP(CustomBlueprint):
     user_repo: UserRepo
     metrics: MetricsService
     git_repositories_repo: GitRepositoriesRepository
+    builds_config: BuildsConfig
 
     def start(self) -> BlueprintFactoryResponse:
         """Start a session with the new operator."""
@@ -92,6 +94,7 @@ class NotebooksNewBP(CustomBlueprint):
                 image_check_repo=self.image_check_repo,
                 data_source_repo=self.data_source_repo,
                 git_repositories_repo=self.git_repositories_repo,
+                builds_config=self.builds_config,
             )
             status = 201 if created else 200
             return json(session.as_apispec().model_dump(exclude_none=True, mode="json"), status)

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -664,15 +664,12 @@ async def get_image_pull_secret(
         and builds_config.build_output_private_image_prefix is not None
         and image.startswith(builds_config.build_output_private_image_prefix)
     ):
-        v2_secret = ExtraSecret(
+        return ExtraSecret(
             V1Secret(
                 metadata=V1ObjectMeta(name=builds_config.pull_private_image_secret_name),
             ),
             adopt=False,
         )
-
-    if v2_secret:
-        return v2_secret
 
     if (
         nb_config.enable_internal_gitlab

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -659,7 +659,11 @@ async def get_image_pull_secret(
     if v2_secret:
         return v2_secret
 
-    if builds_config.enabled and image.startswith(builds_config.build_output_private_image_prefix):
+    if (
+        builds_config.enabled
+        and builds_config.build_output_private_image_prefix is not None
+        and image.startswith(builds_config.build_output_private_image_prefix)
+    ):
         v2_secret = ExtraSecret(
             V1Secret(
                 metadata=V1ObjectMeta(name=builds_config.pull_private_image_secret_name),

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -105,6 +105,7 @@ from renku_data_services.project.db import ProjectRepository, ProjectSessionSecr
 from renku_data_services.project.models import Project, SessionSecret
 from renku_data_services.repositories.db import GitRepositoriesRepository
 from renku_data_services.repositories.models import Metadata as RepoMetadata
+from renku_data_services.session.config import BuildsConfig
 from renku_data_services.session.db import SessionRepository
 from renku_data_services.session.models import SessionLauncher
 from renku_data_services.users.db import UserRepo
@@ -648,12 +649,24 @@ async def get_image_pull_secret(
     user: APIUser,
     internal_gitlab_user: APIUser,
     image_check_repo: ImageCheckRepository,
+    builds_config: BuildsConfig,
 ) -> ExtraSecret | None:
     """Get an image pull secret."""
 
     v2_secret = await __get_connected_services_image_pull_secret(
         f"{server_name}-image-secret", image_check_repo, image, user
     )
+    if v2_secret:
+        return v2_secret
+
+    if builds_config.enabled and image.startswith(builds_config.build_output_private_image_prefix):
+        v2_secret = ExtraSecret(
+            V1Secret(
+                metadata=V1ObjectMeta(name=builds_config.pull_private_image_secret_name),
+            ),
+            adopt=False,
+        )
+
     if v2_secret:
         return v2_secret
 
@@ -740,6 +753,7 @@ async def start_session(
     image_check_repo: ImageCheckRepository,
     data_source_repo: DataSourceRepository,
     git_repositories_repo: GitRepositoriesRepository,
+    builds_config: BuildsConfig,
 ) -> tuple[AmaltheaSessionV1Alpha1, bool]:
     """Start an Amalthea session.
 
@@ -910,6 +924,7 @@ async def start_session(
         user=user,
         internal_gitlab_user=internal_gitlab_user,
         image_check_repo=image_check_repo,
+        builds_config=builds_config,
     )
     if image_secret:
         session_extras = session_extras.concat(SessionExtraResources(secrets=[image_secret]))
@@ -969,7 +984,9 @@ async def start_session(
         metadata=Metadata(name=server_name, annotations=annotations),
         spec=AmaltheaSessionSpec(
             location=session_location,
-            imagePullSecrets=[ImagePullSecret(name=image_secret.name, adopt=True)] if image_secret else [],
+            imagePullSecrets=[ImagePullSecret(name=image_secret.name, adopt=image_secret.adopt)]
+            if image_secret
+            else [],
             codeRepositories=[],
             hibernated=False,
             reconcileStrategy=ReconcileStrategy.whenFailedOrHibernated,

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -618,7 +618,8 @@ def __format_image_pull_secret(secret_name: str, access_token: str, registry_dom
             data={".dockerconfigjson": registry_secret},
             metadata=V1ObjectMeta(name=secret_name),
             type="kubernetes.io/dockerconfigjson",
-        )
+        ),
+        adopt=True,
     )
 
 

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1086,6 +1086,7 @@ async def patch_session(
     image_check_repo: ImageCheckRepository,
     data_source_repo: DataSourceRepository,
     metrics: MetricsService,
+    builds_config: BuildsConfig,
 ) -> AmaltheaSessionV1Alpha1:
     """Patch an Amalthea session."""
     session = await nb_config.k8s_v2_client.get_session(session_id, user.id)
@@ -1237,6 +1238,7 @@ async def patch_session(
         image_check_repo=image_check_repo,
         user=user,
         internal_gitlab_user=internal_gitlab_user,
+        builds_config=builds_config,
     )
     if image_pull_secret:
         session_extras = session_extras.concat(SessionExtraResources(secrets=[image_pull_secret]))

--- a/components/renku_data_services/session/config.py
+++ b/components/renku_data_services/session/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from pydantic import ValidationError as PydanticValidationError
+from sanic_ext.exceptions import ValidationError
 
 from renku_data_services.app_config import logging
 from renku_data_services.session import crs as session_crs
@@ -51,6 +52,14 @@ class BuildsConfig:
         enabled = os.environ.get("IMAGE_BUILDERS_ENABLED", "false").lower() == "true"
         build_output_image_prefix = os.environ.get("BUILD_OUTPUT_IMAGE_PREFIX")
         build_output_private_image_prefix = os.environ.get("BUILD_OUTPUT_PRIVATE_IMAGE_PREFIX")
+
+        if (
+            build_output_image_prefix is not None
+            and build_output_private_image_prefix is not None
+            and build_output_image_prefix == build_output_private_image_prefix
+        ):
+            raise ValidationError("Public and private builds cannot use the same image prefix")
+
         build_builder_image = os.environ.get("BUILD_BUILDER_IMAGE")
         build_run_image = os.environ.get("BUILD_RUN_IMAGE")
         build_strategy_name = os.environ.get("BUILD_STRATEGY_NAME")

--- a/components/renku_data_services/session/config.py
+++ b/components/renku_data_services/session/config.py
@@ -37,6 +37,7 @@ class BuildsConfig:
     build_platform_overrides: dict[str, BuildPlatformOverrides] | None = None
     push_secret_name: str | None = None
     push_private_secret_name: str | None = None
+    pull_private_image_secret_name: str | None = None
     buildrun_retention_after_failed: timedelta | None = None
     buildrun_retention_after_succeeded: timedelta | None = None
     buildrun_build_timeout: timedelta | None = None
@@ -54,6 +55,7 @@ class BuildsConfig:
         build_strategy_name = os.environ.get("BUILD_STRATEGY_NAME")
         push_secret_name = os.environ.get("BUILD_PUSH_SECRET_NAME")
         push_private_secret_name = os.environ.get("BUILD_PUSH_PRIVATE_SECRET_NAME")
+        pull_private_image_secret_name = os.environ.get("BUILD_PULL_PRIVATE_SECRET_NAME")
         buildrun_retention_after_failed_seconds = int(os.environ.get("BUILD_RUN_RETENTION_AFTER_FAILED_SECONDS") or "0")
         buildrun_retention_after_failed = (
             timedelta(seconds=buildrun_retention_after_failed_seconds)
@@ -127,6 +129,7 @@ class BuildsConfig:
             build_platform_overrides=build_platform_overrides,
             push_secret_name=push_secret_name or None,
             push_private_secret_name=push_private_secret_name or None,
+            pull_private_image_secret_name=pull_private_image_secret_name or None,
             buildrun_retention_after_failed=buildrun_retention_after_failed,
             buildrun_retention_after_succeeded=buildrun_retention_after_succeeded,
             buildrun_build_timeout=buildrun_build_timeout,

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -57,13 +57,15 @@ def launch_session(
     return launch_session_helper
 
 
-@pytest.mark.parametrize("prefix,private_prefix,must_raise",
+@pytest.mark.parametrize(
+    "prefix,private_prefix,must_raise",
     [
         ("dummy/image-prefix", "dummy/private-image-prefix", False),
         (None, "dummy/private-image-prefix", False),
         ("dummy/image-prefix", None, False),
         ("dummy/private-image-prefix", "dummy/private-image-prefix", True),
-    ])
+    ],
+)
 def test_same_build_image_prefix(monkeypatch, prefix, private_prefix, must_raise) -> None:
     if prefix is not None:
         monkeypatch.setenv("BUILD_OUTPUT_IMAGE_PREFIX", prefix)

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -7,11 +7,13 @@ import kr8s
 import pytest
 from kr8s.objects import new_class
 from pytest import FixtureRequest
+from sanic_ext.exceptions import ValidationError
 from sanic_testing.testing import SanicASGITestClient, TestingResponse
 from syrupy.filters import props
 
 from renku_data_services import errors
 from renku_data_services.data_api.dependencies import DependencyManager
+from renku_data_services.session.config import BuildsConfig
 from renku_data_services.session.constants import BUILD_RUN_GVK
 from renku_data_services.session.models import EnvVar
 from renku_data_services.users.models import UserInfo
@@ -53,6 +55,26 @@ def launch_session(
         return res
 
     return launch_session_helper
+
+
+@pytest.mark.parametrize("prefix,private_prefix,must_raise",
+    [
+        ("dummy/image-prefix", "dummy/private-image-prefix", False),
+        (None, "dummy/private-image-prefix", False),
+        ("dummy/image-prefix", None, False),
+        ("dummy/private-image-prefix", "dummy/private-image-prefix", True),
+    ])
+def test_same_build_image_prefix(monkeypatch, prefix, private_prefix, must_raise) -> None:
+    if prefix is not None:
+        monkeypatch.setenv("BUILD_OUTPUT_IMAGE_PREFIX", prefix)
+    if private_prefix is not None:
+        monkeypatch.setenv("BUILD_OUTPUT_PRIVATE_IMAGE_PREFIX", private_prefix)
+
+    if must_raise:
+        with pytest.raises(ValidationError):
+            _ = BuildsConfig.from_env()
+    else:
+        _ = BuildsConfig.from_env()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

This is a followup of #1250 that implements the complementary part to support adding the private's registry corresponding image pull secret to a user's session.

This secret is created by the admin deploying the platform and is not user accessible.