### PR TITLE
Feat: ResourcePool Authorization via Authzed/SpiceDB

### DIFF
--- a/bases/renku_data_services/data_api/config.py
+++ b/bases/renku_data_services/data_api/config.py
@@ -51,6 +51,8 @@ class Config:
         if db is None:
             db = DBConfig.from_env()
 
+        authz_config = AuthzConfig.from_env()
+
         if dummy_stores:
             keycloak = None
             gitlab_url = None
@@ -63,7 +65,7 @@ class Config:
             else:
                 gitlab_url = None
 
-        nb_config = NotebooksConfig.from_env(db, enable_internal_gitlab=enable_internal_gitlab)
+        nb_config = NotebooksConfig.from_env(db, authz_config, enable_internal_gitlab=enable_internal_gitlab)
         return cls(
             enable_internal_gitlab=enable_internal_gitlab,
             version=os.environ.get("VERSION", "0.0.1"),
@@ -76,7 +78,7 @@ class Config:
             secrets=PublicSecretsConfig.from_env(),
             sentry=SentryConfig.from_env(),
             posthog=PosthogConfig.from_env(),
-            authz_config=AuthzConfig.from_env(),
+            authz_config=authz_config,
             solr=SolrClientConfig.from_env(),
             trusted_proxies=TrustedProxiesConfig.from_env(),
             keycloak=keycloak,

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -326,8 +326,11 @@ class DependencyManager:
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
+            authz=authz,
         )
-        rp_repo = ResourcePoolRepository(session_maker=config.db.async_session_maker, quotas_repo=quota_repo)
+        rp_repo = ResourcePoolRepository(
+            session_maker=config.db.async_session_maker, quotas_repo=quota_repo, authz=authz
+        )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,
             gitlab_client=gitlab_client,

--- a/bases/renku_data_services/k8s_cache/config.py
+++ b/bases/renku_data_services/k8s_cache/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from renku_data_services.app_config.config import SentryConfig
+from renku_data_services.authz.config import AuthzConfig
 from renku_data_services.db_config.config import DBConfig
 
 
@@ -74,6 +75,7 @@ class Config:
     metrics: _MetricsConfig
     image_builders: _ImageBuilderConfig
     v1_services: _V1ServicesConfig
+    authz: AuthzConfig
     sentry: SentryConfig
 
     @classmethod
@@ -84,6 +86,7 @@ class Config:
         metrics = _MetricsConfig.from_env()
         image_builders = _ImageBuilderConfig.from_env()
         v1_services = _V1ServicesConfig.from_env()
+        authz = AuthzConfig.from_env()
         sentry = SentryConfig.from_env()
         return cls(
             db=db,
@@ -91,5 +94,6 @@ class Config:
             metrics=metrics,
             image_builders=image_builders,
             v1_services=v1_services,
+            authz=authz,
             sentry=sentry,
         )

--- a/bases/renku_data_services/k8s_cache/dependencies.py
+++ b/bases/renku_data_services/k8s_cache/dependencies.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 
+from renku_data_services.authz.authz import Authz
 from renku_data_services.crc.db import ClusterRepository, QuotaRepository, ResourcePoolRepository
 from renku_data_services.k8s.clients import DummyPriorityClassClient, DummyResourceQuotaClient
 from renku_data_services.k8s.db import K8sDbCache
@@ -20,6 +21,7 @@ class DependencyManager:
     _k8s_cache: K8sDbCache | None = field(default=None, repr=False, init=False)
     _metrics_repo: MetricsRepository | None = field(default=None, repr=False, init=False)
     _metrics: StagingMetricsService | None = field(default=None, repr=False, init=False)
+    _authz: Authz | None = field(default=None, repr=False, init=False)
     _rp_repo: ResourcePoolRepository | None = field(default=None, repr=False, init=False)
     _cluster_repo: ClusterRepository | None = field(default=None, repr=False, init=False)
 
@@ -35,11 +37,17 @@ class DependencyManager:
             self._metrics = StagingMetricsService(enabled=self.config.metrics.enabled, metrics_repo=self.metrics_repo())
         return self._metrics
 
+    def authz(self) -> Authz:
+        """The authorization service."""
+        if not self._authz:
+            self._authz = Authz(authz_config=self.config.authz)
+        return self._authz
+
     def rp_repo(self) -> ResourcePoolRepository:
         """The resource pool repository."""
         if not self._rp_repo:
             self._rp_repo = ResourcePoolRepository(
-                session_maker=self.config.db.async_session_maker, quotas_repo=self.quota_repo()
+                session_maker=self.config.db.async_session_maker, quotas_repo=self.quota_repo(), authz=self.authz()
             )
         return self._rp_repo
 

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -152,6 +152,8 @@ class _Relation(StrEnum):
                 return cls.editor
             case Role.VIEWER:
                 return cls.viewer
+            case Role.PROHIBITED:
+                return cls.prohibited
         raise errors.ProgrammingError(message=f"Cannot map role {role} to any authorization database relation")
 
     def to_role(self) -> Role:
@@ -163,7 +165,7 @@ class _Relation(StrEnum):
             case _Relation.viewer:
                 return Role.VIEWER
             case _Relation.prohibited:
-                raise errors.ProgrammingError(message="Cannot map prohibited relation to a role")
+                return Role.PROHIBITED
         raise errors.ProgrammingError(message=f"Cannot map relation {self} to any role")
 
 

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -1,7 +1,7 @@
 """Projects authorization adapter."""
 
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable, Collection
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps
@@ -46,6 +46,7 @@ from renku_data_services.authz.models import (
     Visibility,
 )
 from renku_data_services.base_models.core import InternalServiceAdmin, ResourceType
+from renku_data_services.crc.models import DeletedResourcePool, ResourcePool, ResourcePoolMembershipChange
 from renku_data_services.data_connectors.models import (
     DataConnector,
     DataConnectorToProjectLink,
@@ -97,6 +98,9 @@ _AuthzChangeFuncResult = TypeVar(
     | DataConnectorUpdate
     | DeletedDataConnector
     | DataConnectorToProjectLink
+    | ResourcePool
+    | DeletedResourcePool
+    | ResourcePoolMembershipChange
     | None,
 )
 _T = TypeVar("_T")
@@ -136,6 +140,8 @@ class _Relation(StrEnum):
     data_connector_platform = "data_connector_platform"
     data_connector_namespace = "data_connector_namespace"
     linked_to = "linked_to"
+    prohibited = "prohibited"
+    resource_pool_platform = "resource_pool_platform"
 
     @classmethod
     def from_role(cls, role: Role) -> "_Relation":
@@ -156,6 +162,8 @@ class _Relation(StrEnum):
                 return Role.EDITOR
             case _Relation.viewer:
                 return Role.VIEWER
+            case _Relation.prohibited:
+                raise errors.ProgrammingError(message="Cannot map prohibited relation to a role")
         raise errors.ProgrammingError(message=f"Cannot map relation {self} to any role")
 
 
@@ -217,7 +225,13 @@ class _AuthzConverter:
         return ObjectReference(object_type=ResourceType.data_connector.value, object_id=str(id))
 
     @staticmethod
+    def resource_pool(id: int) -> ObjectReference:
+        """The id should be the id of the ResourcePoolORM object in the DB."""
+        return ObjectReference(object_type=ResourceType.resource_pool.value, object_id=str(id))
+
+    @staticmethod
     def to_object(resource_type: ResourceType, resource_id: str | ULID | int) -> ObjectReference:
+        """Convert a resource type and ID to an Authzed ObjectReference."""
         match (resource_type, resource_id):
             case (ResourceType.project, sid) if isinstance(sid, ULID):
                 return _AuthzConverter.project(sid)
@@ -231,6 +245,8 @@ class _AuthzConverter:
                 return _AuthzConverter.group(rid)
             case (ResourceType.data_connector, dcid) if isinstance(dcid, ULID):
                 return _AuthzConverter.data_connector(dcid)
+            case (ResourceType.resource_pool, rid) if isinstance(rid, int):
+                return _AuthzConverter.resource_pool(rid)
             case (ResourceType.platform, _):
                 return _AuthzConverter.platform()
         raise errors.ProgrammingError(
@@ -274,6 +290,7 @@ def _is_allowed_on_resource(
                 | DataConnector
                 | GlobalDataConnector
                 | DeletedDataConnector
+                | ResourcePool
                 | None
             ) = None
             match resource_type:
@@ -286,6 +303,8 @@ def _is_allowed_on_resource(
                 case ResourceType.data_connector if isinstance(
                     potential_resource, (DataConnector, GlobalDataConnector, DeletedDataConnector)
                 ):
+                    resource = potential_resource
+                case ResourceType.resource_pool if isinstance(potential_resource, ResourcePool):
                     resource = potential_resource
                 case _:
                     raise errors.ProgrammingError(
@@ -307,7 +326,7 @@ def _is_allowed_on_resource(
     return decorator
 
 
-_ID = TypeVar("_ID", str, ULID)
+_ID = TypeVar("_ID", str, ULID, int)
 
 
 def _is_allowed(
@@ -362,7 +381,7 @@ class Authz:
         return self._client
 
     async def _has_permission(
-        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: str | ULID | None, scope: Scope
+        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: str | ULID | int | None, scope: Scope
     ) -> tuple[bool, ZedToken | None]:
         """Checks whether the provided user has a specific permission on the specific resource."""
         if not resource_id:
@@ -385,7 +404,7 @@ class Authz:
         return response.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION, response.checked_at
 
     async def has_permission(
-        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: str | ULID, scope: Scope
+        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: str | ULID | int, scope: Scope
     ) -> bool:
         """Checks whether the provided user has a specific permission on the specific resource."""
         res, _ = await self._has_permission(user, resource_type, resource_id, scope)
@@ -604,17 +623,22 @@ class Authz:
                 if len(args) == 0:
                     user_kwarg = kwargs.get("user")
                     requested_by_kwarg = kwargs.get("requested_by")
-                    if isinstance(user_kwarg, base_models.APIUser) and isinstance(
-                        requested_by_kwarg, base_models.APIUser
-                    ):
+                    api_user_kwarg = kwargs.get("api_user")
+                    found_users = [
+                        u
+                        for u in (user_kwarg, requested_by_kwarg, api_user_kwarg)
+                        if isinstance(u, base_models.APIUser)
+                    ]
+
+                    if len(found_users) > 1:
                         raise errors.ProgrammingError(
                             message="The decorator for authorization database changes found two APIUser parameters in"
-                            " the 'user' and 'requested_by' keyword arguments but expected only one of them to be "
-                            "present."
+                            " the 'user', 'requested_by' and 'api_user' keyword arguments but expected only one of "
+                            "them to be present."
                         )
-                    potential_user = user_kwarg if isinstance(user_kwarg, base_models.APIUser) else requested_by_kwarg
+                    potential_user = found_users[0] if found_users else None
                 else:
-                    potential_user = args[0]
+                    potential_user = args[0] if isinstance(args[0], base_models.APIUser) else None
                 if not isinstance(potential_user, base_models.APIUser):
                     raise errors.ProgrammingError(
                         message="The decorator for authorization database changes could not find APIUser in the "
@@ -704,9 +728,45 @@ class Authz:
                     ):
                         user = _extract_user_from_args(*func_args, **func_kwargs)
                         authz_change = await db_repo.authz._remove_data_connector_to_project_link(user, result)
+                    case AuthzOperation.create, ResourceType.resource_pool if isinstance(result, ResourcePool):
+                        authz_change = db_repo.authz._add_resource_pool(result)
+                    case AuthzOperation.update, ResourceType.resource_pool if isinstance(result, ResourcePool):
+                        user = _extract_user_from_args(*func_args, **func_kwargs)
+                        authz_change = await db_repo.authz._update_resource_pool_visibility(user, result)
+                    case AuthzOperation.delete, ResourceType.resource_pool if result is None:
+                        # NOTE: This means that the resource pool does not exist
+                        # in the first place so nothing was deleted
+                        pass
+                    case AuthzOperation.delete, ResourceType.resource_pool if isinstance(result, DeletedResourcePool):
+                        user = _extract_user_from_args(*func_args, **func_kwargs)
+                        authz_change = await db_repo.authz._remove_resource_pool(user, result)
+                    case (
+                        (AuthzOperation.create | AuthzOperation.delete),
+                        (ResourceType.resource_pool_member | ResourceType.resource_pool_prohibited),
+                    ) if isinstance(result, ResourcePoolMembershipChange):
+                        authz_operation = {
+                            AuthzOperation.create: RelationshipUpdate.OPERATION_TOUCH,
+                            AuthzOperation.delete: RelationshipUpdate.OPERATION_DELETE,
+                        }[operation]
+                        relation = {
+                            ResourceType.resource_pool_member: _Relation.viewer.value,
+                            ResourceType.resource_pool_prohibited: _Relation.prohibited.value,
+                        }[resource]
+                        authz_change = await db_repo.authz._update_resource_pool_user_relationships(
+                            resource_pool_id=result.resource_pool_id,
+                            user_ids=result.user_ids,
+                            relation=relation,
+                            operation=authz_operation,
+                        )
+                    case (
+                        (AuthzOperation.create | AuthzOperation.delete),
+                        (ResourceType.resource_pool_member | ResourceType.resource_pool_prohibited),
+                    ) if result is None:
+                        # Handle None returns (nothing to sync)
+                        pass
                     case _:
-                        resource_id: str | ULID | None = "unknown"
-                        if isinstance(result, (Project, Namespace, Group, DataConnector)):
+                        resource_id: str | ULID | int | None = "unknown"
+                        if isinstance(result, (Project, Namespace, Group, DataConnector, ResourcePool)):
                             resource_id = result.id
                         elif isinstance(result, (ProjectUpdate, GroupUpdate, DataConnectorUpdate)):
                             resource_id = result.new.id
@@ -747,7 +807,6 @@ class Authz:
                     result = await f(db_repo, *args, **kwargs)
                     authz_change = await _get_authz_change(db_repo, op, resource, result, *args, **kwargs)
                     await db_repo.authz.client.WriteRelationships(authz_change.apply)
-                    await session.commit()
                     return result
                 except Exception as err:
                     db_rollback_err = None
@@ -1233,6 +1292,199 @@ class Authz:
             updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=rel)]
         )
         return _AuthzChange(apply=apply, undo=undo)
+
+    def _add_resource_pool(self, resource_pool: ResourcePool) -> _AuthzChange:
+        """Create the new resource pool and associated resources and relations in the DB."""
+        resource_pool_res = _AuthzConverter.resource_pool(resource_pool.id)
+        all_users = SubjectReference(object=_AuthzConverter.all_users())
+        all_anon_users = SubjectReference(object=_AuthzConverter.anonymous_users())
+        resource_pool_in_platform = Relationship(
+            resource=resource_pool_res,
+            relation=_Relation.resource_pool_platform.value,
+            subject=SubjectReference(object=self._platform),
+        )
+        relationships = [resource_pool_in_platform]
+        if resource_pool.public:
+            all_users_are_public_viewers = Relationship(
+                resource=resource_pool_res,
+                relation=_Relation.public_viewer.value,
+                subject=all_users,
+            )
+            all_anon_users_are_public_viewers = Relationship(
+                resource=resource_pool_res,
+                relation=_Relation.public_viewer.value,
+                subject=all_anon_users,
+            )
+            relationships.extend([all_users_are_public_viewers, all_anon_users_are_public_viewers])
+        apply = WriteRelationshipsRequest(
+            updates=[
+                RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=i) for i in relationships
+            ]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[
+                RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=i) for i in relationships
+            ]
+        )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _remove_resource_pool(
+        self,
+        user: base_models.APIUser,
+        deleted_resource_pool: DeletedResourcePool,
+        *,
+        zed_token: ZedToken | None = None,
+    ) -> _AuthzChange:
+        """Remove the relationships associated with the resource pool."""
+        consistency = Consistency(at_least_as_fresh=zed_token) if zed_token else Consistency(fully_consistent=True)
+        rel_filter = RelationshipFilter(
+            resource_type=ResourceType.resource_pool.value, optional_resource_id=str(deleted_resource_pool.id)
+        )
+        responses: AsyncIterable[ReadRelationshipsResponse] = self.client.ReadRelationships(
+            ReadRelationshipsRequest(consistency=consistency, relationship_filter=rel_filter)
+        )
+        rels: list[Relationship] = []
+        async for response in responses:
+            rels.append(response.relationship)
+        apply = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=i) for i in rels]
+        )
+        undo = WriteRelationshipsRequest(
+            updates=[RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=i) for i in rels]
+        )
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _update_resource_pool_visibility(
+        self, user: base_models.APIUser, resource_pool: ResourcePool, *, zed_token: ZedToken | None = None
+    ) -> _AuthzChange:
+        """Update public_viewer wildcard relationships when public flag changes."""
+        consistency = Consistency(at_least_as_fresh=zed_token) if zed_token else Consistency(fully_consistent=True)
+        pool_res = _AuthzConverter.resource_pool(resource_pool.id)
+
+        # Read existing public_viewer relationships
+        rel_filter = RelationshipFilter(
+            resource_type=ResourceType.resource_pool.value,
+            optional_resource_id=str(resource_pool.id),
+            optional_relation=_Relation.public_viewer.value,
+        )
+        responses = self.client.ReadRelationships(
+            ReadRelationshipsRequest(consistency=consistency, relationship_filter=rel_filter)
+        )
+        existing_rels: list[Relationship] = []
+        async for response in responses:
+            existing_rels.append(response.relationship)
+
+        all_users_sub = SubjectReference(object=_AuthzConverter.all_users())
+        anon_users_sub = SubjectReference(object=_AuthzConverter.anonymous_users())
+        all_users_are_public = Relationship(
+            resource=pool_res,
+            relation=_Relation.public_viewer.value,
+            subject=all_users_sub,
+        )
+        anon_users_are_public = Relationship(
+            resource=pool_res,
+            relation=_Relation.public_viewer.value,
+            subject=anon_users_sub,
+        )
+
+        apply_updates: list[RelationshipUpdate] = []
+        undo_updates: list[RelationshipUpdate] = []
+
+        if resource_pool.public:
+            # For undo, only remove wildcards if they didn't exist before
+            existing_subjects = {
+                (rel.subject.object.object_type, rel.subject.object.object_id) for rel in existing_rels
+            }
+            if ("user", "*") not in existing_subjects:
+                apply_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=all_users_are_public,
+                    )
+                )
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_DELETE,
+                        relationship=all_users_are_public,
+                    )
+                )
+            if ("anonymous_user", "*") not in existing_subjects:
+                apply_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=anon_users_are_public,
+                    )
+                )
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_DELETE,
+                        relationship=anon_users_are_public,
+                    )
+                )
+        else:
+            # Remove public_viewer wildcards
+            for existing_rel in existing_rels:
+                apply_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_DELETE,
+                        relationship=existing_rel,
+                    )
+                )
+            if existing_rels:
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=all_users_are_public,
+                    )
+                )
+                undo_updates.append(
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=anon_users_are_public,
+                    )
+                )
+        apply = WriteRelationshipsRequest(updates=apply_updates)
+        undo = WriteRelationshipsRequest(updates=undo_updates)
+        return _AuthzChange(apply=apply, undo=undo)
+
+    async def _update_resource_pool_user_relationships(
+        self,
+        resource_pool_id: int,
+        user_ids: Collection[str],
+        relation: str,
+        operation: RelationshipUpdate.Operation.ValueType,
+    ) -> _AuthzChange:
+        """Create an AuthzChange for resource pool user relationships.
+
+        Args:
+            resource_pool_id: The ID of the resource pool.
+            user_ids: Keycloak IDs of the users to update.
+            relation: The SpiceDB relation name (e.g. "member", "prohibited").
+            operation: OPERATION_TOUCH to add, OPERATION_DELETE to remove.
+
+        Returns:
+            An _AuthzChange with apply and undo WriteRelationshipsRequests.
+        """
+        inverse_operation = {
+            RelationshipUpdate.OPERATION_TOUCH: RelationshipUpdate.OPERATION_DELETE,
+            RelationshipUpdate.OPERATION_DELETE: RelationshipUpdate.OPERATION_TOUCH,
+        }[operation]
+        apply_updates: list[RelationshipUpdate] = []
+        undo_updates: list[RelationshipUpdate] = []
+
+        for uid in user_ids:
+            rel = Relationship(
+                resource=_AuthzConverter.resource_pool(resource_pool_id),
+                relation=relation,
+                subject=_AuthzConverter.user_subject(uid),
+            )
+            apply_updates.append(RelationshipUpdate(operation=operation, relationship=rel))
+            undo_updates.append(RelationshipUpdate(operation=inverse_operation, relationship=rel))
+
+        return _AuthzChange(
+            apply=WriteRelationshipsRequest(updates=apply_updates),
+            undo=WriteRelationshipsRequest(updates=undo_updates),
+        )
 
     async def _remove_admin(self, user_id: str) -> _AuthzChange:
         """Add a deployment-wide administrator in the authorization database."""

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -1,7 +1,7 @@
 """Projects authorization adapter."""
 
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable, Collection
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps
@@ -744,27 +744,16 @@ class Authz:
                         authz_change = await db_repo.authz._remove_resource_pool(user, result)
                     case (
                         (AuthzOperation.create | AuthzOperation.delete),
-                        (ResourceType.resource_pool_member | ResourceType.resource_pool_prohibited),
+                        ResourceType.resource_pool,
                     ) if isinstance(result, ResourcePoolMembershipChange):
-                        authz_operation = {
-                            AuthzOperation.create: RelationshipUpdate.OPERATION_TOUCH,
-                            AuthzOperation.delete: RelationshipUpdate.OPERATION_DELETE,
-                        }[operation]
-                        relation = {
-                            ResourceType.resource_pool_member: _Relation.viewer.value,
-                            ResourceType.resource_pool_prohibited: _Relation.prohibited.value,
-                        }[resource]
-                        authz_change = await db_repo.authz._update_resource_pool_user_relationships(
-                            resource_pool_id=result.resource_pool_id,
-                            user_ids=result.user_ids,
-                            relation=relation,
-                            operation=authz_operation,
+                        authz_change = db_repo.authz._resource_pool_membership_changes_to_authz_change(
+                            result, operation
                         )
-                    case (
-                        (AuthzOperation.create | AuthzOperation.delete),
-                        (ResourceType.resource_pool_member | ResourceType.resource_pool_prohibited),
-                    ) if result is None:
-                        # Handle None returns (nothing to sync)
+                    case AuthzOperation.create, ResourceType.resource_pool if result is None:
+                        pass
+                    case AuthzOperation.delete, ResourceType.resource_pool if result is None:
+                        # NOTE: This means that the resource pool does not exist
+                        # in the first place so nothing was deleted
                         pass
                     case _:
                         resource_id: str | ULID | int | None = "unknown"
@@ -1449,39 +1438,38 @@ class Authz:
         undo = WriteRelationshipsRequest(updates=undo_updates)
         return _AuthzChange(apply=apply, undo=undo)
 
-    async def _update_resource_pool_user_relationships(
+    def _resource_pool_membership_changes_to_authz_change(
         self,
-        resource_pool_id: int,
-        user_ids: Collection[str],
-        relation: str,
-        operation: RelationshipUpdate.Operation.ValueType,
+        pool_change: ResourcePoolMembershipChange,
+        operation: AuthzOperation,
     ) -> _AuthzChange:
-        """Create an AuthzChange for resource pool user relationships.
+        """Convert resource pool membership changes into an AuthzChange.
 
         Args:
-            resource_pool_id: The ID of the resource pool.
-            user_ids: Keycloak IDs of the users to update.
-            relation: The SpiceDB relation name (e.g. "member", "prohibited").
-            operation: OPERATION_TOUCH to add, OPERATION_DELETE to remove.
+            pool_change: The resource pool membership changes to apply.
+            operation: The authorization operation (create or delete).
 
         Returns:
             An _AuthzChange with apply and undo WriteRelationshipsRequests.
         """
-        inverse_operation = {
-            RelationshipUpdate.OPERATION_TOUCH: RelationshipUpdate.OPERATION_DELETE,
-            RelationshipUpdate.OPERATION_DELETE: RelationshipUpdate.OPERATION_TOUCH,
-        }[operation]
         apply_updates: list[RelationshipUpdate] = []
         undo_updates: list[RelationshipUpdate] = []
 
-        for uid in user_ids:
-            rel = Relationship(
-                resource=_AuthzConverter.resource_pool(resource_pool_id),
-                relation=relation,
-                subject=_AuthzConverter.user_subject(uid),
-            )
-            apply_updates.append(RelationshipUpdate(operation=operation, relationship=rel))
-            undo_updates.append(RelationshipUpdate(operation=inverse_operation, relationship=rel))
+        for mc in pool_change.changes:
+            member = mc.member
+            relation = _Relation.from_role(member.role).value
+            resource = _AuthzConverter.resource_pool(cast(int, member.resource_id))
+            subject = _AuthzConverter.user_subject(member.user_id)
+            rel = Relationship(resource=resource, relation=relation, subject=subject)
+
+            if operation == AuthzOperation.create:
+                apply_updates.append(RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=rel))
+                undo_updates.append(RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=rel))
+            else:
+                apply_updates.append(
+                    RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=rel)
+                )
+                undo_updates.append(RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=rel))
 
         return _AuthzChange(
             apply=WriteRelationshipsRequest(updates=apply_updates),

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -70,6 +70,10 @@ from renku_data_services.users.models import DeletedUser, UserInfo, UserInfoUpda
 
 logger = logging.getLogger(__name__)
 
+
+_ID = TypeVar("_ID", bound="str | ULID | int")
+
+
 _P = ParamSpec("_P")
 
 
@@ -232,7 +236,7 @@ class _AuthzConverter:
         return ObjectReference(object_type=ResourceType.resource_pool.value, object_id=str(id))
 
     @staticmethod
-    def to_object(resource_type: ResourceType, resource_id: str | ULID | int) -> ObjectReference:
+    def to_object(resource_type: ResourceType, resource_id: _ID) -> ObjectReference:
         """Convert a resource type and ID to an Authzed ObjectReference."""
         match (resource_type, resource_id):
             case (ResourceType.project, sid) if isinstance(sid, ULID):
@@ -328,9 +332,6 @@ def _is_allowed_on_resource(
     return decorator
 
 
-_ID = TypeVar("_ID", str, ULID, int)
-
-
 def _is_allowed(
     operation: Scope,
 ) -> Callable[
@@ -383,7 +384,7 @@ class Authz:
         return self._client
 
     async def _has_permission(
-        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: str | ULID | int | None, scope: Scope
+        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: _ID | None, scope: Scope
     ) -> tuple[bool, ZedToken | None]:
         """Checks whether the provided user has a specific permission on the specific resource."""
         if not resource_id:
@@ -406,7 +407,7 @@ class Authz:
         return response.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION, response.checked_at
 
     async def has_permission(
-        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: str | ULID | int, scope: Scope
+        self, user: base_models.APIUser, resource_type: ResourceType, resource_id: _ID, scope: Scope
     ) -> bool:
         """Checks whether the provided user has a specific permission on the specific resource."""
         res, _ = await self._has_permission(user, resource_type, resource_id, scope)

--- a/components/renku_data_services/authz/models.py
+++ b/components/renku_data_services/authz/models.py
@@ -110,5 +110,5 @@ class CheckPermissionItem:
     """Represent a permission item to be checked by the authorization service."""
 
     resource_type: "ResourceType"
-    resource_id: str | ULID
+    resource_id: str | ULID | int
     scope: Scope

--- a/components/renku_data_services/authz/models.py
+++ b/components/renku_data_services/authz/models.py
@@ -2,15 +2,12 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from ulid import ULID
 
+from renku_data_services.base_models.core import ResourceType
 from renku_data_services.errors import errors
 from renku_data_services.namespace.apispec import GroupRole
-
-if TYPE_CHECKING:
-    from renku_data_services.base_models.core import ResourceType
 
 
 class Role(Enum):
@@ -19,6 +16,7 @@ class Role(Enum):
     OWNER = "owner"
     VIEWER = "viewer"
     EDITOR = "editor"
+    PROHIBITED = "prohibited"
 
     @classmethod
     def from_group_role(cls, role: GroupRole) -> "Role":

--- a/components/renku_data_services/authz/models.py
+++ b/components/renku_data_services/authz/models.py
@@ -70,14 +70,20 @@ class UnsavedMember:
 
     def with_group(self, group_id: ULID) -> "Member":
         """Turn to member with group."""
-        return Member(role=self.role, user_id=self.user_id, resource_id=group_id)
+        return Member(
+            role=self.role,
+            user_id=self.user_id,
+            resource_id=group_id,
+            resource_type=ResourceType.group,
+        )
 
 
 @dataclass
 class Member(UnsavedMember):
     """Member stored in the database."""
 
-    resource_id: ULID
+    resource_id: ULID | int
+    resource_type: ResourceType = ResourceType.group
 
 
 class Change(Enum):

--- a/components/renku_data_services/authz/schemas.py
+++ b/components/renku_data_services/authz/schemas.py
@@ -763,3 +763,103 @@ v8 = AuthzSchemaMigration(
     up=[WriteSchemaRequest(schema=_v8)],
     down=[WriteSchemaRequest(schema=_v7)],
 )
+
+_v9 = """\
+definition user {}
+
+definition group {
+    relation group_platform: platform
+    relation owner: user
+    relation editor: user
+    relation viewer: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + read_children
+    permission read_children = viewer + write
+    permission write = editor + delete
+    permission change_membership = delete
+    permission delete = owner + group_platform->is_admin
+    permission non_public_read = owner + editor + viewer - public_viewer
+    permission exclusive_owner = owner
+    permission exclusive_editor = editor
+    permission exclusive_member = viewer + editor + owner
+    permission direct_member = owner + editor + viewer
+}
+
+definition user_namespace {
+    relation user_namespace_platform: platform
+    relation owner: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + read_children
+    permission read_children = delete
+    permission write = delete
+    permission delete = owner + user_namespace_platform->is_admin
+    permission non_public_read = owner - public_viewer
+    permission exclusive_owner = owner
+    permission exclusive_member = owner
+    permission direct_member = owner
+}
+
+definition anonymous_user {}
+
+definition platform {
+    relation admin: user
+    permission is_admin = admin
+}
+
+definition project {
+    relation project_platform: platform
+    relation project_namespace: user_namespace | group
+    relation owner: user
+    relation editor: user
+    relation viewer: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + read_children
+    permission read_children = viewer + write + project_namespace->read_children
+    permission write = editor + delete
+    permission change_membership = delete
+    permission delete = owner + project_platform->is_admin + project_namespace->delete
+    permission non_public_read = owner + editor + viewer + project_namespace->read_children - public_viewer
+    permission exclusive_owner = owner + project_namespace->exclusive_owner
+    permission exclusive_editor = editor
+    permission exclusive_member = owner + editor + viewer + project_namespace->exclusive_member
+    permission direct_member = owner + editor + viewer
+}
+
+definition data_connector {
+    relation data_connector_platform: platform
+    relation data_connector_namespace: user_namespace | group | project
+    relation linked_to: project
+    relation owner: user
+    relation editor: user
+    relation viewer: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + viewer + write + data_connector_namespace->read_children
+    permission write = editor + delete
+    permission change_membership = delete
+    permission delete = owner + data_connector_platform->is_admin + data_connector_namespace->delete
+    permission non_public_read = owner + editor + viewer + data_connector_namespace->read_children - public_viewer
+    permission exclusive_owner = owner + data_connector_namespace->exclusive_owner
+    permission exclusive_editor = editor
+    permission exclusive_member = owner + editor + viewer + data_connector_namespace->exclusive_member
+    permission direct_member = owner + editor + viewer
+}
+
+definition resource_pool {
+    relation resource_pool_platform: platform
+    relation viewer: user
+    relation prohibited: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = (viewer + public_viewer - prohibited) + resource_pool_platform->is_admin
+    permission write = resource_pool_platform->is_admin
+}"""
+"""Adds the resource_pool definition for Authzed authorization."""
+
+v9 = AuthzSchemaMigration(
+    up=[WriteSchemaRequest(schema=_v9)],
+    down=[
+        DeleteRelationshipsRequest(
+            relationship_filter=RelationshipFilter(resource_type=ResourceType.resource_pool.value)
+        ),
+        WriteSchemaRequest(schema=_v8),
+    ],
+)

--- a/components/renku_data_services/base_models/core.py
+++ b/components/renku_data_services/base_models/core.py
@@ -452,3 +452,6 @@ class ResourceType(StrEnum):
     group = "group"
     user_namespace = "user_namespace"
     data_connector = "data_connector"
+    resource_pool = "resource_pool"
+    resource_pool_member = "resource_pool_member"
+    resource_pool_prohibited = "resource_pool_prohibited"

--- a/components/renku_data_services/base_models/core.py
+++ b/components/renku_data_services/base_models/core.py
@@ -453,5 +453,3 @@ class ResourceType(StrEnum):
     user_namespace = "user_namespace"
     data_connector = "data_connector"
     resource_pool = "resource_pool"
-    resource_pool_member = "resource_pool_member"
-    resource_pool_prohibited = "resource_pool_prohibited"

--- a/components/renku_data_services/crc/blueprints.py
+++ b/components/renku_data_services/crc/blueprints.py
@@ -13,7 +13,7 @@ from renku_data_services.base_api.auth import authenticate, only_admins
 from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, CustomBlueprint
 from renku_data_services.base_api.misc import validate_db_ids, validate_query
 from renku_data_services.base_models.validation import validated_json
-from renku_data_services.crc import apispec, models
+from renku_data_services.crc import apispec
 from renku_data_services.crc.core import (
     validate_cluster,
     validate_cluster_patch,
@@ -72,13 +72,7 @@ class ResourcePoolsBP(CustomBlueprint):
         async def _get_one(
             request: Request, user: base_models.APIUser, resource_pool_id: int, query: apispec.UserResourceParams
         ) -> HTTPResponse:
-            rps: list[models.ResourcePool]
-            rps = await self.rp_repo.get_resource_pools(api_user=user, id=resource_pool_id, name=query.name)
-            if len(rps) < 1:
-                raise errors.MissingResourceError(
-                    message=f"The resource pool with id {resource_pool_id} cannot be found."
-                )
-            rp = rps[0]
+            rp = await self.rp_repo.get_resource_pool(api_user=user, resource_pool_id=resource_pool_id, name=query.name)
             return validated_json(apispec.ResourcePoolWithId, rp)
 
         return "/resource_pools/<resource_pool_id>", ["GET"], _get_one

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -24,7 +24,7 @@ from ulid import ULID
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
 from renku_data_services.authz.authz import Authz, AuthzOperation
-from renku_data_services.authz.models import Scope
+from renku_data_services.authz.models import Change, Member, MembershipChange, Role, Scope
 from renku_data_services.base_models import RESET
 from renku_data_services.base_models.core import ResetType, ResourceType
 from renku_data_services.crc import models
@@ -1016,36 +1016,46 @@ class UserRepository(_Base):
                 rp.users = list(users_to_add_exist) + users_to_add_missing
             return [usr.dump() for usr in rp.users]
 
-    async def _write_resource_pool_user_relationship(
-        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    def _build_pool_membership_change(
+        self, user_ids: Collection[str], resource_pool_id: int, role: Role, change: Change
     ) -> models.ResourcePoolMembershipChange | None:
         if not user_ids:
             return None
-        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=user_ids)
+        return models.ResourcePoolMembershipChange(
+            changes=[
+                MembershipChange(
+                    Member(
+                        role=role, user_id=uid, resource_id=resource_pool_id, resource_type=ResourceType.resource_pool
+                    ),
+                    change,
+                )
+                for uid in user_ids
+            ]
+        )
 
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_member)
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
     async def _grant_resource_pool_members(
         self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
     ) -> models.ResourcePoolMembershipChange | None:
-        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.VIEWER, Change.ADD)
 
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_prohibited)
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
     async def _unprohibit_resource_pool_users(
         self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
     ) -> models.ResourcePoolMembershipChange | None:
-        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.PROHIBITED, Change.REMOVE)
 
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_prohibited)
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
     async def _prohibit_resource_pool_user(
         self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
     ) -> models.ResourcePoolMembershipChange | None:
-        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.PROHIBITED, Change.ADD)
 
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_member)
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
     async def _revoke_resource_pool_member(
         self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
     ) -> models.ResourcePoolMembershipChange | None:
-        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.VIEWER, Change.REMOVE)
 
     @_only_admins
     async def update_user(self, api_user: base_models.APIUser, keycloak_id: str, **kwargs: Any) -> base_models.User:

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -18,13 +18,15 @@ from uuid import uuid4
 from sqlalchemy import NullPool, delete, false, select, true
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import selectinload
-from sqlalchemy.sql import Select, and_, not_, or_
+from sqlalchemy.sql import Select, or_
 from ulid import ULID
 
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
+from renku_data_services.authz.authz import Authz, AuthzOperation
+from renku_data_services.authz.models import Scope
 from renku_data_services.base_models import RESET
-from renku_data_services.base_models.core import ResetType
+from renku_data_services.base_models.core import ResetType, ResourceType
 from renku_data_services.crc import models
 from renku_data_services.crc import orm as schemas
 from renku_data_services.crc.core import validate_resource_class_update, validate_resource_pool_update
@@ -37,84 +39,29 @@ from renku_data_services.users.db import UserRepo
 
 
 class _Base:
-    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository) -> None:
+    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository, authz: Authz) -> None:
         self.session_maker = session_maker
         self.quotas_repo = quotas_repo
+        self.authz: Authz = authz
 
 
-def _resource_pool_access_control(
+_ORM = TypeVar("_ORM", schemas.ResourcePoolORM, schemas.ResourceClassORM)
+
+
+async def _filter_by_authz(
     api_user: base_models.APIUser,
-    stmt: Select[tuple[schemas.ResourcePoolORM]],
-) -> Select[tuple[schemas.ResourcePoolORM]]:
+    stmt: Select[tuple[_ORM]],
+    authz: Authz,
+) -> Select[tuple[_ORM]]:
     """Modifies a select query to list resource pools based on whether the user is logged in or not."""
     output = stmt
-    match (api_user.is_authenticated, api_user.is_admin):
-        case True, False:
-            # The user is logged in but not an admin
-            api_user_has_default_pool_access = not_(
-                # NOTE: The only way to check that a user is allowed to access the default pool is that such a
-                # record does NOT EXIST in the database
-                select(schemas.UserORM.no_default_access)
-                .where(and_(schemas.UserORM.keycloak_id == api_user.id, schemas.UserORM.no_default_access == true()))
-                .exists()
-            )
-            output = output.join(schemas.UserORM, schemas.ResourcePoolORM.users, isouter=True).where(
-                or_(
-                    schemas.UserORM.keycloak_id == api_user.id,  # the user is part of the pool
-                    and_(  # the pool is not default but is public
-                        schemas.ResourcePoolORM.default != true(), schemas.ResourcePoolORM.public == true()
-                    ),
-                    and_(  # the pool is default and the user is not prohibited from accessing it
-                        schemas.ResourcePoolORM.default == true(),
-                        api_user_has_default_pool_access,
-                    ),
-                )
-            )
-        case True, True:
-            # The user is logged in and is an admin, they can see all resource pools
-            pass
-        case False, _:
-            # The user is not logged in, they can see only the public resource pools
-            output = output.where(schemas.ResourcePoolORM.public == true())
-    return output
-
-
-def _classes_user_access_control(
-    api_user: base_models.APIUser,
-    stmt: Select[tuple[schemas.ResourceClassORM]],
-) -> Select[tuple[schemas.ResourceClassORM]]:
-    """Adjust the select statement for classes based on whether the user is logged in or not."""
-    output = stmt
-    match (api_user.is_authenticated, api_user.is_admin):
-        case True, False:
-            # The user is logged in but is not an admin
-            api_user_has_default_pool_access = not_(
-                # NOTE: The only way to check that a user is allowed to access the default pool is that such a
-                # record does NOT EXIST in the database
-                select(schemas.UserORM.no_default_access)
-                .where(and_(schemas.UserORM.keycloak_id == api_user.id, schemas.UserORM.no_default_access == true()))
-                .exists()
-            )
-            output = output.join(schemas.UserORM, schemas.ResourcePoolORM.users, isouter=True).where(
-                or_(
-                    schemas.UserORM.keycloak_id == api_user.id,  # the user is part of the pool
-                    and_(  # the pool is not default but is public
-                        schemas.ResourcePoolORM.default != true(), schemas.ResourcePoolORM.public == true()
-                    ),
-                    and_(  # the pool is default and the user is not prohibited from accessing it
-                        schemas.ResourcePoolORM.default == true(),
-                        api_user_has_default_pool_access,
-                    ),
-                )
-            )
-        case True, True:
-            # The user is logged in and is an admin, they can see all resource classes
-            pass
-        case False, _:
-            # The user is not logged in, they can see only the classes from public resource pools
-            output = output.join(schemas.UserORM, schemas.ResourcePoolORM.users, isouter=True).where(
-                schemas.ResourcePoolORM.public == true(),
-            )
+    if api_user.is_admin:
+        return output
+    allowed_resource_pools = await authz.resources_with_permission(
+        api_user, api_user.id, ResourceType.resource_pool, Scope.READ
+    )
+    allowed_ids = [int(id) for id in allowed_resource_pools]
+    output = output.where(schemas.ResourcePoolORM.id.in_(allowed_ids))
     return output
 
 
@@ -155,8 +102,8 @@ def _only_admins(
 class ResourcePoolRepository(_Base):
     """The adapter used for accessing resource pools with SQLAlchemy."""
 
-    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository):
-        super().__init__(session_maker, quotas_repo)
+    def __init__(self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository, authz: Authz):
+        super().__init__(session_maker, quotas_repo, authz)
         self.__cluster_repo = ClusterRepository(session_maker=self.session_maker)
 
     async def initialize(self, async_connection_url: str, rp: models.UnsavedResourcePool) -> None:
@@ -171,8 +118,16 @@ class ResourcePoolRepository(_Base):
             res = await session.execute(stmt)
             default_rp = res.scalars().first()
             if default_rp is None:
-                orm = schemas.ResourcePoolORM.from_unsaved_model(new_resource_pool=rp, quota=None, cluster=None)
-                session.add(orm)
+                await self._create_rp(rp, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    async def _create_rp(self, rp: models.UnsavedResourcePool, session: AsyncSession) -> models.ResourcePool:
+        default_rp = schemas.ResourcePoolORM.from_unsaved_model(new_resource_pool=rp, quota=None, cluster=None)
+        session.add(default_rp)
+        await session.flush()
+        await session.refresh(default_rp)
+        result = default_rp.dump(quota=None)
+        return result
 
     async def get_resource_pools(
         self, api_user: base_models.APIUser, id: int | None = None, name: Optional[str] = None
@@ -189,7 +144,7 @@ class ResourcePoolRepository(_Base):
             if id is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.id == id)
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             orms = res.scalars().all()
             output: list[models.ResourcePool] = []
@@ -210,12 +165,35 @@ class ResourcePoolRepository(_Base):
                 .options(selectinload(schemas.ResourcePoolORM.cluster))
             )
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             orm = res.scalar()
             if orm is None:
                 raise errors.MissingResourceError(
                     message=f"Could not find the resource pool where a class with ID {resource_class_id} exists."
+                )
+            quota = await self.quotas_repo.get_quota(orm.quota, orm.get_cluster_id()) if orm.quota else None
+            return orm.dump(quota)
+
+    async def get_resource_pool(
+        self, api_user: base_models.APIUser, resource_pool_id: int, name: str | None = None
+    ) -> models.ResourcePool:
+        """Get a specific resource pool by ID with Authzed permission check."""
+        async with self.session_maker() as session:
+            stmt = (
+                select(schemas.ResourcePoolORM)
+                .where(schemas.ResourcePoolORM.id == resource_pool_id)
+                .options(selectinload(schemas.ResourcePoolORM.classes))
+                .options(selectinload(schemas.ResourcePoolORM.cluster))
+            )
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
+            if name is not None:
+                stmt = stmt.where(schemas.ResourcePoolORM.name == name)
+            res = await session.execute(stmt)
+            orm = res.scalar()
+            if orm is None:
+                raise errors.MissingResourceError(
+                    message=f"The resource pool with id {resource_pool_id} cannot be found."
                 )
             quota = await self.quotas_repo.get_quota(orm.quota, orm.get_cluster_id()) if orm.quota else None
             return orm.dump(quota)
@@ -281,7 +259,7 @@ class ResourcePoolRepository(_Base):
                 )
             )
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             output: list[models.ResourcePool] = []
             for rp in res.scalars().all():
@@ -294,6 +272,17 @@ class ResourcePoolRepository(_Base):
         self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool
     ) -> models.ResourcePool:
         """Insert resource pool into database."""
+        async with self.session_maker() as session, session.begin():
+            return await self._insert_resource_pool(
+                api_user=api_user,
+                new_resource_pool=new_resource_pool,
+                session=session,
+            )
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    async def _insert_resource_pool(
+        self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool, session: AsyncSession
+    ) -> models.ResourcePool:
         cluster = None
         if new_resource_pool.cluster_id:
             cluster = await self.__cluster_repo.select(cluster_id=new_resource_pool.cluster_id)
@@ -303,23 +292,23 @@ class ResourcePoolRepository(_Base):
         if new_resource_pool.quota is not None:
             quota = await self.quotas_repo.create_quota(new_quota=new_resource_pool.quota, cluster_id=cluster_id)
 
-        async with self.session_maker() as session, session.begin():
-            resource_pool = schemas.ResourcePoolORM.from_unsaved_model(
-                new_resource_pool=new_resource_pool, quota=quota, cluster=cluster
-            )
-            if resource_pool.default:
-                stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.default == true())
-                res = await session.execute(stmt)
-                default_rps = res.unique().scalars().all()
-                if len(default_rps) >= 1:
-                    raise errors.ValidationError(
-                        message="There can only be one default resource pool and one already exists."
-                    )
+        resource_pool = schemas.ResourcePoolORM.from_unsaved_model(
+            new_resource_pool=new_resource_pool, quota=quota, cluster=cluster
+        )
+        if resource_pool.default:
+            stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.default == true())
+            res = await session.execute(stmt)
+            default_rps = res.unique().scalars().all()
+            if len(default_rps) >= 1:
+                raise errors.ValidationError(
+                    message="There can only be one default resource pool and one already exists."
+                )
 
-            session.add(resource_pool)
-            await session.flush()
-            await session.refresh(resource_pool)
-            return resource_pool.dump(quota=quota)
+        session.add(resource_pool)
+        await session.flush()
+        await session.refresh(resource_pool)
+        result = resource_pool.dump(quota=quota)
+        return result
 
     async def get_classes(
         self,
@@ -343,7 +332,7 @@ class ResourcePoolRepository(_Base):
             # Apply user access control if api_user is provided
             if api_user is not None:
                 # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-                stmt = _classes_user_access_control(api_user, stmt)
+                stmt = await _filter_by_authz(api_user, stmt, self.authz)
 
             res = await session.execute(stmt)
             orms = res.scalars().all()
@@ -414,12 +403,16 @@ class ResourcePoolRepository(_Base):
 
             validate_resource_pool_update(existing=rp.dump(quota=quota), update=update)
 
+            update_authz = False
+
             if update.name is not None:
                 rp.name = update.name
             if update.public is not None:
                 rp.public = update.public
+                update_authz = True
             if update.default is not None:
                 rp.default = update.default
+                update_authz = True
             if update.idle_threshold == 0 or update.idle_threshold is RESET:
                 # Using "0" removes the value
                 rp.idle_threshold = None
@@ -502,22 +495,49 @@ class ResourcePoolRepository(_Base):
             await gather(*new_classes_coroutines)
             await session.flush()
             await session.refresh(rp)
-            return rp.dump(quota=quota)
+            result = rp.dump(quota=quota)
+            if update_authz:
+                return await self._update_resource_pool(
+                    api_user=api_user,
+                    rp=result,
+                    session=session,
+                )
+            return result
+
+    @Authz.authz_change(op=AuthzOperation.update, resource=ResourceType.resource_pool)
+    async def _update_resource_pool(
+        self,
+        api_user: base_models.APIUser,
+        rp: models.ResourcePool,
+        session: AsyncSession,
+    ) -> models.ResourcePool:
+        return rp
 
     @_only_admins
     async def delete_resource_pool(self, api_user: base_models.APIUser, id: int) -> None:
         """Delete a resource pool from the database."""
         async with self.session_maker() as session, session.begin():
-            stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == id)
-            res = await session.execute(stmt)
-            rp = res.scalars().first()
-            if rp is not None:
-                if rp.default:
-                    raise errors.ValidationError(message="The default resource pool cannot be deleted.")
-                await session.delete(rp)
-                if rp.quota:
-                    await self.quotas_repo.delete_quota(rp.quota, rp.get_cluster_id())
-            return None
+            await self._delete_resource_pool(
+                api_user=api_user,
+                id=id,
+                session=session,
+            )
+
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
+    async def _delete_resource_pool(
+        self, api_user: base_models.APIUser, id: int, session: AsyncSession
+    ) -> models.DeletedResourcePool | None:
+        stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == id)
+        res = await session.execute(stmt)
+        rp = res.scalars().first()
+        if rp is not None:
+            if rp.default:
+                raise errors.ValidationError(message="The default resource pool cannot be deleted.")
+            await session.delete(rp)
+            if rp.quota:
+                await self.quotas_repo.delete_quota(rp.quota, rp.get_cluster_id())
+            return models.DeletedResourcePool(id=id)
+        return None
 
     @_only_admins
     async def delete_resource_class(
@@ -759,9 +779,13 @@ class UserRepository(_Base):
     """The adapter used for accessing resource pool users with SQLAlchemy."""
 
     def __init__(
-        self, session_maker: Callable[..., AsyncSession], quotas_repo: QuotaRepository, user_repo: UserRepo
+        self,
+        session_maker: Callable[..., AsyncSession],
+        quotas_repo: QuotaRepository,
+        user_repo: UserRepo,
+        authz: Authz,
     ) -> None:
-        super().__init__(session_maker, quotas_repo)
+        super().__init__(session_maker, quotas_repo, authz)
         self.kc_user_repo = user_repo
 
     @_only_admins
@@ -840,7 +864,7 @@ class UserRepository(_Base):
             if resource_pool_id is not None:
                 stmt = stmt.where(schemas.ResourcePoolORM.id == resource_pool_id)
             # NOTE: The line below ensures that the right users can access the right resources, do not remove.
-            stmt = _resource_pool_access_control(api_user, stmt)
+            stmt = await _filter_by_authz(api_user, stmt, self.authz)
             res = await session.execute(stmt)
             rps: Sequence[schemas.ResourcePoolORM] = res.scalars().all()
             output: list[models.ResourcePool] = []
@@ -891,12 +915,23 @@ class UserRepository(_Base):
                     raise errors.ForbiddenError(
                         message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
                     )
+            existing_rp_ids = {rp.id for rp in user.resource_pools}
+            new_rp_ids = {rp.id for rp in rps_to_add}
             if append:
-                user_rp_ids = {rp.id for rp in user.resource_pools}
-                rps_to_add = [rp for rp in rps_to_add if rp.id not in user_rp_ids]
+                rps_to_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
                 user.resource_pools.extend(rps_to_add)
+                removed_rps: list[schemas.ResourcePoolORM] = []
             else:
+                removed_rps = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
                 user.resource_pools = list(rps_to_add)
+            for rp in rps_to_add:
+                await self._grant_resource_pool_members(api_user, rp.id, [keycloak_id], session=session)
+                if rp.default or rp.public:
+                    await self._unprohibit_resource_pool_users(api_user, rp.id, [keycloak_id], session=session)
+            for rp in removed_rps:
+                await self._revoke_resource_pool_member(api_user, rp.id, [keycloak_id], session=session)
+                if rp.default or rp.public:
+                    await self._prohibit_resource_pool_user(api_user, rp.id, [keycloak_id], session=session)
             output: list[models.ResourcePool] = []
             for rp in rps_to_add:
                 quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
@@ -909,6 +944,13 @@ class UserRepository(_Base):
     ) -> None:
         """Remove a user from a specific resource pool."""
         async with self.session_maker() as session, session.begin():
+            rp_stmt = select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == resource_pool_id)
+            rp_res = await session.execute(rp_stmt)
+            rp = rp_res.scalars().first()
+            if rp is None:
+                raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} does not exist")
+
+            # SQL removal (existing logic)
             sub = (
                 select(schemas.UserORM.id)
                 .join(schemas.ResourcePoolORM, schemas.UserORM.resource_pools)
@@ -917,6 +959,9 @@ class UserRepository(_Base):
             )
             stmt = delete(schemas.resource_pools_users).where(schemas.resource_pools_users.c.user_id.in_(sub))
             await session.execute(stmt)
+            await self._revoke_resource_pool_member(api_user, resource_pool_id, [keycloak_id], session=session)
+            if rp.default or rp.public:
+                await self._prohibit_resource_pool_user(api_user, resource_pool_id, [keycloak_id], session=session)
 
     @_only_admins
     async def update_resource_pool_users(
@@ -945,6 +990,8 @@ class UserRepository(_Base):
                     api_user=api_user, resource_pool_id=resource_pool_id
                 )
                 users_to_modify = [user for user in all_existing_users.disallowed if user.keycloak_id in user_ids]
+                re_allowed_ids = [u.keycloak_id for u in users_to_modify]
+                await self._unprohibit_resource_pool_users(api_user, resource_pool_id, re_allowed_ids, session=session)
                 return await gather(
                     *[
                         self.update_user(
@@ -964,9 +1011,41 @@ class UserRepository(_Base):
                 rp_user_ids = {rp.id for rp in rp.users}
                 users_to_add = [u for u in list(users_to_add_exist) + users_to_add_missing if u.id not in rp_user_ids]
                 rp.users.extend(users_to_add)
+                await self._grant_resource_pool_members(api_user, resource_pool_id, user_ids, session=session)
             else:
                 rp.users = list(users_to_add_exist) + users_to_add_missing
             return [usr.dump() for usr in rp.users]
+
+    async def _write_resource_pool_user_relationship(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        if not user_ids:
+            return None
+        return models.ResourcePoolMembershipChange(resource_pool_id=resource_pool_id, user_ids=user_ids)
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_member)
+    async def _grant_resource_pool_members(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_prohibited)
+    async def _unprohibit_resource_pool_users(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool_prohibited)
+    async def _prohibit_resource_pool_user(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
+
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool_member)
+    async def _revoke_resource_pool_member(
+        self, api_user: base_models.APIUser, resource_pool_id: int, user_ids: Collection[str], session: AsyncSession
+    ) -> models.ResourcePoolMembershipChange | None:
+        return await self._write_resource_pool_user_relationship(api_user, resource_pool_id, user_ids, session=session)
 
     @_only_admins
     async def update_user(self, api_user: base_models.APIUser, keycloak_id: str, **kwargs: Any) -> base_models.User:
@@ -985,6 +1064,15 @@ class UserRepository(_Base):
                 )
             if (no_default_access := kwargs.get("no_default_access")) is not None:
                 user.no_default_access = no_default_access
+                default_rps_stmt = select(schemas.ResourcePoolORM.id).where(schemas.ResourcePoolORM.default == true())
+                default_rps_res = await session.execute(default_rps_stmt)
+                default_rp_ids = [row[0] for row in default_rps_res.all()]
+
+                for rp_id in default_rp_ids:
+                    if no_default_access:
+                        await self._prohibit_resource_pool_user(api_user, rp_id, [keycloak_id], session=session)
+                    else:
+                        await self._unprohibit_resource_pool_users(api_user, rp_id, [keycloak_id], session=session)
             return user.dump()
 
 

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -118,10 +118,10 @@ class ResourcePoolRepository(_Base):
             res = await session.execute(stmt)
             default_rp = res.scalars().first()
             if default_rp is None:
-                await self._create_rp(rp, session=session)
+                await self._create_default_rp(rp, session=session)
 
     @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
-    async def _create_rp(self, rp: models.UnsavedResourcePool, session: AsyncSession) -> models.ResourcePool:
+    async def _create_default_rp(self, rp: models.UnsavedResourcePool, session: AsyncSession) -> models.ResourcePool:
         default_rp = schemas.ResourcePoolORM.from_unsaved_model(new_resource_pool=rp, quota=None, cluster=None)
         session.add(default_rp)
         await session.flush()

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from math import ceil
@@ -11,6 +11,7 @@ from typing import Any, Final, Optional, Protocol, Self
 from kubernetes.utils import parse_quantity
 
 from renku_data_services import errors
+from renku_data_services.authz.models import MembershipChange
 from renku_data_services.base_models import ResetType
 from renku_data_services.k8s.constants import DEFAULT_K8S_CLUSTER, ClusterId
 from renku_data_services.k8s.models import K8sPatch, K8sResourceQuota
@@ -485,5 +486,4 @@ class DeletedResourcePool:
 class ResourcePoolMembershipChange:
     """Returned by user-management methods so the authz_change decorator knows what to sync to SpiceDB."""
 
-    resource_pool_id: int
-    user_ids: Collection[str]
+    changes: list[MembershipChange]

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from math import ceil
@@ -472,3 +472,18 @@ class RemoteConfigurationRunaiPatch:
 
 
 RemoteConfigurationPatch = ResetType | RemoteConfigurationFirecrestPatch | RemoteConfigurationRunaiPatch
+
+
+@dataclass(frozen=True, eq=True, kw_only=True)
+class DeletedResourcePool:
+    """A resource pool that has been deleted."""
+
+    id: int
+
+
+@dataclass(frozen=True, eq=True, kw_only=True)
+class ResourcePoolMembershipChange:
+    """Returned by user-management methods so the authz_change decorator knows what to sync to SpiceDB."""
+
+    resource_pool_id: int
+    user_ids: Collection[str]

--- a/components/renku_data_services/migrations/versions/cd424c01676e_add_resource_pool_authorization_schema.py
+++ b/components/renku_data_services/migrations/versions/cd424c01676e_add_resource_pool_authorization_schema.py
@@ -1,0 +1,161 @@
+"""Add resource pool authorization schema
+
+Revision ID: cd424c01676e
+Revises: c6af6a1088f1
+Create Date: 2026-03-26 15:30:31.073961
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from authzed.api.v1 import (
+    ObjectReference,
+    Relationship,
+    RelationshipUpdate,
+    SubjectReference,
+    WriteRelationshipsRequest,
+)
+from sqlalchemy.sql import text
+
+from renku_data_services.app_config import logging
+from renku_data_services.authz.authz import _AuthzConverter, _Relation
+from renku_data_services.authz.config import AuthzConfig
+from renku_data_services.authz.schemas import v9
+from renku_data_services.base_models.core import ResourceType
+
+logger = logging.getLogger(__name__)
+
+# revision identifiers, used by Alembic.
+revision = "cd424c01676e"
+down_revision = "68d751fb3525"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    config = AuthzConfig.from_env()
+    client = config.authz_client()
+
+    # Schema must always come first
+    client.WriteSchema(v9.up[0])
+    logger.info("Upgraded Authzed schema to v9")
+
+    inspector = sa.inspect(conn)
+
+    if "resource_pools" not in inspector.get_schema_names():
+        logger.info("resource_pools schema does not exist, skipping data migration")
+        return
+
+    if "resource_pools" not in inspector.get_table_names(schema="resource_pools"):
+        logger.info("resource_pools.resource_pools table does not exist, skipping data migration")
+        return
+
+    platform_ref = _AuthzConverter.platform()
+    user_wildcard = SubjectReference(object=ObjectReference(object_type=ResourceType.user, object_id="*"))
+    anon_wildcard = SubjectReference(object=ObjectReference(object_type=ResourceType.anonymous_user, object_id="*"))
+
+    pools = conn.execute(text('SELECT id, public, "default" FROM resource_pools.resource_pools')).fetchall()
+
+    if not pools:
+        logger.info("No resource pools found, skipping data migration")
+        return
+
+    updates: list[RelationshipUpdate] = []
+    default_pool_id: int | None = None
+    for row in pools:
+        pool_id, is_public, is_default = int(row[0]), row[1], row[2]
+        pool_ref = _AuthzConverter.resource_pool(pool_id)
+        if is_default:
+            default_pool_id = pool_id
+
+        # Every pool needs to be linked to the platform
+        updates.append(
+            RelationshipUpdate(
+                operation=RelationshipUpdate.OPERATION_TOUCH,
+                relationship=Relationship(
+                    resource=pool_ref,
+                    relation="resource_pool_platform",
+                    subject=SubjectReference(object=platform_ref),
+                ),
+            )
+        )
+
+        if is_public:
+            updates.extend(
+                [
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=Relationship(resource=pool_ref, relation="public_viewer", subject=user_wildcard),
+                    ),
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.OPERATION_TOUCH,
+                        relationship=Relationship(resource=pool_ref, relation="public_viewer", subject=anon_wildcard),
+                    ),
+                ]
+            )
+
+    # Migrate existing pool viewers via the resource_pools_users join table
+    # keycloak_id is the user identifier used in Authzed
+    viewers = conn.execute(
+        text("""
+        SELECT rpu.resource_pool_id, u.keycloak_id
+        FROM resource_pools.resource_pools_users rpu
+        JOIN resource_pools.users u ON u.id = rpu.user_id
+    """)
+    ).fetchall()
+
+    for row in viewers:
+        pool_ref = _AuthzConverter.resource_pool(int(row[0]))
+        user_ref = SubjectReference(object=ObjectReference(object_type=ResourceType.user, object_id=row[1]))
+        updates.append(
+            RelationshipUpdate(
+                operation=RelationshipUpdate.OPERATION_TOUCH,
+                relationship=Relationship(resource=pool_ref, relation=_Relation.viewer.value, subject=user_ref),
+            )
+        )
+
+    # Users with no_default_access must be prohibited from the default pool.
+    # The default pool is public, so without a "prohibited" relation these
+    # users would still pass the public_viewer wildcard check.
+    if default_pool_id is not None:
+        no_access_users = conn.execute(
+            text("SELECT keycloak_id FROM resource_pools.users WHERE no_default_access = true")
+        ).fetchall()
+
+        default_pool_ref = _AuthzConverter.resource_pool(default_pool_id)
+        for user_row in no_access_users:
+            user_ref = SubjectReference(object=ObjectReference(object_type=ResourceType.user, object_id=user_row[0]))
+            updates.append(
+                RelationshipUpdate(
+                    operation=RelationshipUpdate.OPERATION_TOUCH,
+                    relationship=Relationship(
+                        resource=default_pool_ref,
+                        relation=_Relation.prohibited.value,
+                        subject=user_ref,
+                    ),
+                )
+            )
+
+        logger.info(f"Marked {len(no_access_users)} user(s) as prohibited on default pool {default_pool_id}")
+
+    BATCH_SIZE = 500
+    for i in range(0, len(updates), BATCH_SIZE):
+        batch = updates[i : i + BATCH_SIZE]
+        try:
+            client.WriteRelationships(WriteRelationshipsRequest(updates=batch))
+        except Exception as e:
+            logger.error(
+                f"Failed writing batch {i // BATCH_SIZE + 1}. "
+                "This migration is idempotent. Re-run via `alembic upgrade`."
+            )
+            raise e
+
+    logger.info(f"Migrated {len(pools)} resource pools and {len(viewers)} memberships to Authzed")
+
+
+def downgrade() -> None:
+    config = AuthzConfig.from_env()
+    client = config.authz_client()
+    responses = v9.downgrade(client)
+    logger.info(f"Downgraded Authzed schema from v9: {responses}")

--- a/components/renku_data_services/notebooks/config/__init__.py
+++ b/components/renku_data_services/notebooks/config/__init__.py
@@ -7,6 +7,8 @@ from typing import Any, Protocol, Self
 
 import kr8s
 
+from renku_data_services.authz.authz import Authz
+from renku_data_services.authz.config import AuthzConfig
 from renku_data_services.base_models import APIUser
 from renku_data_services.crc.db import ClusterRepository, QuotaRepository, ResourcePoolRepository
 from renku_data_services.crc.models import ClusterSettings, ResourceClass, SessionProtocol
@@ -147,7 +149,7 @@ class NotebooksConfig:
     local_cluster_session_service_account: str | None = None
 
     @classmethod
-    def from_env(cls, db_config: DBConfig, enable_internal_gitlab: bool) -> Self:
+    def from_env(cls, db_config: DBConfig, authz_config: AuthzConfig, enable_internal_gitlab: bool) -> Self:
         """Create a configuration object from environment variables."""
         enable_internal_gitlab = os.getenv("ENABLE_INTERNAL_GITLAB", "false").lower() == "true"
         dummy_stores = _parse_str_as_bool(os.environ.get("DUMMY_STORES", False))
@@ -182,8 +184,9 @@ class NotebooksConfig:
         )
         secrets_client = K8sSecretClient(client)
 
+        authz = Authz(authz_config)
         quota_repo = QuotaRepository(K8sResourceQuotaClient(client), K8sPriorityClassClient(client))
-        rp_repo = ResourcePoolRepository(db_config.async_session_maker, quota_repo)
+        rp_repo = ResourcePoolRepository(db_config.async_session_maker, quota_repo, authz=authz)
         crc_validator = CRCValidator(rp_repo)
         k8s_v2_client = NotebookK8sClient(
             client=client,

--- a/test/bases/renku_data_services/data_api/test_migrations.py
+++ b/test/bases/renku_data_services/data_api/test_migrations.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import random
 import string
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any, cast
+from uuid import uuid4
 
 import pytest
 import sqlalchemy as sa
 from alembic.script import ScriptDirectory
+from authzed.api.v1 import ReadRelationshipsRequest, RelationshipFilter
 from sanic_testing.testing import SanicASGITestClient
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import IntegrityError
@@ -15,7 +19,7 @@ from sqlalchemy.sql import bindparam
 from ulid import ULID
 
 from renku_data_services import errors
-from renku_data_services.base_models.core import Slug
+from renku_data_services.base_models.core import ResourceType, Slug
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import downgrade_migrations_for_app, get_alembic_config, run_migrations_for_app
 from renku_data_services.namespace import orm as ns_schemas
@@ -743,3 +747,199 @@ async def test_migration_to_66e2f1271cf6(app_manager_instance: DependencyManager
     async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
         with pytest.raises(IntegrityError):
             await insert_slug(session, "dc_in_p", admin_user.namespace.id, p_for_dc_id, p_dc2_id)
+
+
+async def _seed_resource_pool_authz_migration_data(
+    app_manager_instance: DependencyManager,
+) -> dict[str, Any]:
+    token = uuid4().hex[:10]
+
+    pool_count = 34
+    public_pool_count = 5
+    membership_count = 598
+    no_default_access_count = 17
+    user_count = 620
+
+    user_prefix = f"migration-user-{token}"
+
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        await session.execute(
+            sa.text(
+                """
+                INSERT INTO resource_pools.resource_pools (name, public, "default", platform)
+                VALUES (:name, :public, :default, :platform)
+                RETURNING id, public, "default"
+                """
+            ),
+            [
+                {
+                    "name": f"migration-pool-{token}-{i}",
+                    "public": i < public_pool_count,
+                    "default": i == 0,
+                    "platform": "linux_amd64",
+                }
+                for i in range(pool_count)
+            ],
+        )
+
+        pool_rows = (
+            await session.execute(
+                sa.text(
+                    """
+                    SELECT id, name, public, "default"
+                    FROM resource_pools.resource_pools
+                    WHERE name LIKE :prefix
+                    ORDER BY id
+                    """
+                ),
+                {"prefix": f"migration-pool-{token}-%"},
+            )
+        ).all()
+
+        pool_ids = [row.id for row in pool_rows]
+
+        await session.execute(
+            sa.text(
+                """
+                INSERT INTO resource_pools.users (keycloak_id, no_default_access)
+                VALUES (:keycloak_id, :no_default_access)
+                RETURNING id
+                """
+            ),
+            [
+                {
+                    "keycloak_id": f"{user_prefix}-{i}",
+                    "no_default_access": i < no_default_access_count,
+                }
+                for i in range(user_count)
+            ],
+        )
+
+        user_rows = (
+            await session.execute(
+                sa.text(
+                    """
+                    SELECT id, keycloak_id, no_default_access
+                    FROM resource_pools.users
+                    WHERE keycloak_id LIKE :prefix
+                    ORDER BY id
+                    """
+                ),
+                {"prefix": f"{user_prefix}-%"},
+            )
+        ).all()
+
+        user_ids = [row.id for row in user_rows]
+
+        await session.execute(
+            sa.text(
+                """
+                INSERT INTO resource_pools.resource_pools_users (user_id, resource_pool_id)
+                VALUES (:user_id, :resource_pool_id)
+                """
+            ),
+            [
+                {
+                    "user_id": user_ids[i],
+                    "resource_pool_id": pool_ids[i % pool_count],
+                }
+                for i in range(membership_count)
+            ],
+        )
+
+    return {
+        "pool_ids": [str(pid) for pid in pool_ids],
+        "public_pool_ids": [str(row.id) for row in pool_rows if row.public],
+        "default_pool_id": str(next(row.id for row in pool_rows if row.default)),
+        "membership_count": membership_count,
+        "no_default_access_count": no_default_access_count,
+        "user_prefix": user_prefix,
+        "prohibited_user_ids": {f"{user_prefix}-{i}" for i in range(no_default_access_count)},
+    }
+
+
+async def _read_resource_pool_relationships(authz: Any) -> list[Any]:
+    request = ReadRelationshipsRequest(relationship_filter=RelationshipFilter(resource_type=ResourceType.resource_pool))
+    return [resp async for resp in authz.client.ReadRelationships(request)]
+
+
+def _is_seeded_pool(relationship: Any, seeded: dict[str, Any]) -> bool:
+    return relationship.relationship.resource.object_id in seeded["pool_ids"]
+
+
+def _is_seeded_user_subject(relationship: Any, seeded: dict[str, Any]) -> bool:
+    subject = relationship.relationship.subject
+    return subject.object.object_type == ResourceType.user and subject.object.object_id.startswith(
+        seeded["user_prefix"]
+    )
+
+
+def _count_seeded_relationships(
+    relationships: list[Any],
+    relation: str,
+    seeded: dict[str, Any],
+) -> int:
+    total = 0
+    for row in relationships:
+        rel = row.relationship
+        if rel.relation != relation:
+            continue
+        if not _is_seeded_pool(row, seeded):
+            continue
+        total += 1
+    return total
+
+
+def _count_seeded_user_relationships(
+    relationships: list[Any],
+    relation: str,
+    seeded: dict[str, Any],
+) -> int:
+    total = 0
+    for row in relationships:
+        rel = row.relationship
+        if rel.relation != relation:
+            continue
+        if not _is_seeded_pool(row, seeded):
+            continue
+        if not _is_seeded_user_subject(row, seeded):
+            continue
+        total += 1
+    return total
+
+
+@pytest.mark.asyncio
+async def test_migration_cd424c01676e_resource_pool_authz(
+    app_manager_instance: DependencyManager,
+    admin_user: UserInfo,
+) -> None:
+    RESOURCE_POOL_AUTHZ_PREV_REVISION = "68d751fb3525"
+    RESOURCE_POOL_AUTHZ_REVISION = "cd424c01676e"
+
+    # Arrange: move the DB to the revision right before the migration.
+    run_migrations_for_app("common", RESOURCE_POOL_AUTHZ_PREV_REVISION)
+
+    # Arrange: seed old-state data.
+    seeded = await _seed_resource_pool_authz_migration_data(app_manager_instance)
+
+    # Act: apply the target migration.
+    run_migrations_for_app("common", RESOURCE_POOL_AUTHZ_REVISION)
+
+    # Assert: relationships were created for the seeded pools/users.
+    relationships = await _read_resource_pool_relationships(app_manager_instance.authz)
+
+    assert _count_seeded_relationships(relationships, "resource_pool_platform", seeded) == len(seeded["pool_ids"])
+
+    assert _count_seeded_user_relationships(relationships, "viewer", seeded) == seeded["membership_count"]
+
+    assert _count_seeded_relationships(relationships, "public_viewer", seeded) == 2 * len(seeded["public_pool_ids"])
+
+    prohibited = [
+        row
+        for row in relationships
+        if row.relationship.relation == "prohibited"
+        and row.relationship.resource.object_id == seeded["default_pool_id"]
+        and row.relationship.subject.object.object_type == ResourceType.user
+        and row.relationship.subject.object.object_id in seeded["prohibited_user_ids"]
+    ]
+    assert len(prohibited) == seeded["no_default_access_count"]

--- a/test/bases/renku_data_services/data_api/test_resource_pools.py
+++ b/test/bases/renku_data_services/data_api/test_resource_pools.py
@@ -548,8 +548,8 @@ async def test_restricted_default_resource_pool_access(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 2
-    # Restrict one user to not have access to the default pool
-    no_default_user = existing_users[0]
+    # Restrict one user to not have access to the default pool (not user[0] who is admin)
+    no_default_user = existing_users[1]
     no_default_user_id = no_default_user["id"]
     no_default_access_token = json.dumps({"id": no_default_user_id})
     _, res = await sanic_client.delete(
@@ -558,7 +558,7 @@ async def test_restricted_default_resource_pool_access(
     )
     assert res.status_code == 204
     # The other user in the db should be able to access the default pool
-    default_access_user = existing_users[1]
+    default_access_user = existing_users[2]
     user_id = default_access_user["id"]
     access_token = json.dumps({"id": user_id})
     # Ensure non-authenticated users have access to the default pool
@@ -618,8 +618,8 @@ async def test_restricted_default_resource_pool_access_changes(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 2
-    # Restrict one user to not have access to the default pool
-    no_default_user = existing_users[0]
+    # Restrict one user to not have access to the default pool (not user[0] who is admin)
+    no_default_user = existing_users[1]
     no_default_user_id = no_default_user["id"]
     no_default_access_token = json.dumps({"id": no_default_user_id})
     _, res = await sanic_client.delete(
@@ -665,8 +665,8 @@ async def test_private_resource_pool_access(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 2
-    # Select one user that has no access
-    restricted_user = existing_users[0]
+    # Select one user that has no access (not user[0] who is admin)
+    restricted_user = existing_users[3]
     restricted_user_id = restricted_user["id"]
     restricted_access_token = json.dumps({"id": restricted_user_id})
     # Give another user access to the private pool
@@ -801,7 +801,8 @@ async def test_user_resource_pools(
     existing_users = res.json
     assert res.status_code == 200
     assert len(existing_users) >= 1
-    user = existing_users[0]
+    # not user[0] who is admin
+    user = existing_users[1]
     user_id = user["id"]
     user_access_token = json.dumps({"id": user_id})
     user_headers = {"Authorization": f"Bearer {user_access_token}"}
@@ -1644,3 +1645,51 @@ async def test_resource_class_empty_patch_noop(
     assert res.json is not None
     rc = res.json
     assert rc == default_rc
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_visibility_toggle(
+    sanic_client: SanicASGITestClient,
+    admin_headers: dict[str, str],
+    valid_resource_pool_payload: dict[str, Any],
+    cluster: KindCluster,
+) -> None:
+    """E2E: toggling the public flag via PATCH updates Authzed access for non-admin users."""
+    valid_resource_pool_payload["default"] = False
+    valid_resource_pool_payload["public"] = True
+
+    _, res = await create_rp(valid_resource_pool_payload, sanic_client)
+    assert res.status_code == 201
+    rp_id = res.json["id"]
+
+    # Pick a regular user (not user[0] who is admin)
+    _, res = await sanic_client.get("/api/data/users", headers=admin_headers)
+    assert res.status_code == 200
+    assert len(res.json) >= 1
+    user_id = res.json[1]["id"]
+    user_headers = {"Authorization": f"Bearer {json.dumps({'id': user_id})}"}
+
+    # Visible while public
+    _, res = await sanic_client.get(f"/api/data/resource_pools/{rp_id}", headers=user_headers)
+    assert res.status_code == 200
+
+    # PATCH → private
+    _, res = await sanic_client.patch(
+        f"/api/data/resource_pools/{rp_id}", headers=admin_headers, json={"public": False}
+    )
+    assert res.status_code == 200
+    assert res.json["public"] is False
+
+    # Hidden after going private
+    _, res = await sanic_client.get(f"/api/data/resource_pools/{rp_id}", headers=user_headers)
+    assert res.status_code == 404
+
+    # PATCH → public again
+    _, res = await sanic_client.patch(f"/api/data/resource_pools/{rp_id}", headers=admin_headers, json={"public": True})
+    assert res.status_code == 200
+    assert res.json["public"] is True
+
+    # Visible again
+    _, res = await sanic_client.get(f"/api/data/resource_pools/{rp_id}", headers=user_headers)
+    assert res.status_code == 200

--- a/test/components/renku_data_services/authz/test_authorization.py
+++ b/test/components/renku_data_services/authz/test_authorization.py
@@ -1,6 +1,9 @@
+from types import SimpleNamespace
+
 import pytest
 import pytest_asyncio
 from authzed.api.v1 import (
+    ObjectReference,
     Relationship,
     RelationshipUpdate,
     SubjectReference,
@@ -8,10 +11,11 @@ from authzed.api.v1 import (
 )
 from ulid import ULID
 
-from renku_data_services.authz.authz import _AuthzConverter
+from renku_data_services.authz.authz import _AuthzConverter, _Relation
 from renku_data_services.authz.models import Member, Role, Scope, Visibility
 from renku_data_services.base_models import APIUser
 from renku_data_services.base_models.core import NamespacePath, ResourceType
+from renku_data_services.crc.models import DeletedResourcePool
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.errors import errors
 from renku_data_services.migrations.core import run_migrations_for_app
@@ -23,6 +27,51 @@ admin_user = APIUser(is_admin=True, id="admin-id", access_token="some-token", fu
 anon_user = APIUser(is_admin=False)
 regular_user1 = APIUser(is_admin=False, id="user1-id", access_token="some-token1", full_name="some-user1")  # nosec B106
 regular_user2 = APIUser(is_admin=False, id="user2-id", access_token="some-token2", full_name="some-user2")  # nosec B106
+regular_user3 = APIUser(is_admin=False, id="user3-id", access_token="some-token3", full_name="some-user3")  # nosec B106
+
+
+POOL_ID = 9001
+
+
+def _pool_updates(pool_id: int, *, public: bool) -> list[RelationshipUpdate]:
+    """Build all relationship updates needed to create a resource pool in Authzed."""
+    pool_ref = _AuthzConverter.resource_pool(pool_id)
+    updates = [
+        RelationshipUpdate(
+            operation=RelationshipUpdate.OPERATION_TOUCH,
+            relationship=Relationship(
+                resource=pool_ref,
+                relation="resource_pool_platform",
+                subject=SubjectReference(object=_AuthzConverter.platform()),
+            ),
+        ),
+    ]
+    if public:
+        for obj_type in (ResourceType.user, ResourceType.anonymous_user):
+            updates.append(
+                RelationshipUpdate(
+                    operation=RelationshipUpdate.OPERATION_TOUCH,
+                    relationship=Relationship(
+                        resource=pool_ref,
+                        relation="public_viewer",
+                        subject=SubjectReference(object=ObjectReference(object_type=obj_type, object_id="*")),
+                    ),
+                )
+            )
+    return updates
+
+
+def _rel(
+    pool_id: int, relation: str, user_id: str, *, op: int = RelationshipUpdate.OPERATION_TOUCH
+) -> RelationshipUpdate:
+    return RelationshipUpdate(
+        operation=op,
+        relationship=Relationship(
+            resource=_AuthzConverter.resource_pool(pool_id),
+            relation=relation,
+            subject=SubjectReference(object=_AuthzConverter.user(user_id)),
+        ),
+    )
 
 
 @pytest_asyncio.fixture
@@ -370,3 +419,311 @@ async def test_listing_non_public_projects(app_manager_instance: DependencyManag
     assert private_project_id2_str in set(ids_user2)
     assert private_project_id1_str not in set(ids_user2)
     assert public_project_id_str not in set(ids_user2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_pool", [True, False])
+async def test_resource_pool_base_access(
+    app_manager_instance: DependencyManager, bootstrap_admins, public_pool: bool
+) -> None:
+    """Base access: public pools are open to everyone; private pools block non-members."""
+    authz = app_manager_instance.authz
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(POOL_ID, public=public_pool)))
+
+    # Admin can always use and write
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, POOL_ID, Scope.READ)
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, POOL_ID, Scope.WRITE)
+
+    # Regular user and anon: use depends on public, write is always denied
+    assert public_pool == await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+    assert public_pool == await authz.has_permission(anon_user, ResourceType.resource_pool, POOL_ID, Scope.READ)
+    assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.WRITE)
+    assert not await authz.has_permission(anon_user, ResourceType.resource_pool, POOL_ID, Scope.WRITE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_pool", [True, False])
+async def test_resource_pool_member_access(
+    app_manager_instance: DependencyManager, bootstrap_admins, public_pool: bool
+) -> None:
+    """An explicit member can use a pool regardless of visibility; non-members still follow public rules."""
+    authz = app_manager_instance.authz
+    updates = _pool_updates(POOL_ID, public=public_pool) + [_rel(POOL_ID, _Relation.viewer.value, regular_user1.id)]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=updates))
+
+    # Member can always use
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+    # Member still cannot write
+    assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.WRITE)
+    # Non-member follows public rules
+    assert public_pool == await authz.has_permission(regular_user2, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_pool", [True, False])
+@pytest.mark.parametrize("is_member", [True, False])
+async def test_resource_pool_prohibited_blocks_access(
+    app_manager_instance: DependencyManager, bootstrap_admins, public_pool: bool, is_member: bool
+) -> None:
+    """A prohibited user is blocked regardless of public visibility or membership."""
+    authz = app_manager_instance.authz
+    updates = _pool_updates(POOL_ID, public=public_pool) + [_rel(POOL_ID, _Relation.prohibited.value, regular_user1.id)]
+    if is_member:
+        updates.append(_rel(POOL_ID, _Relation.viewer.value, regular_user1.id))
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=updates))
+
+    assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_admin_bypasses_prohibited(
+    app_manager_instance: DependencyManager, bootstrap_admins
+) -> None:
+    """Admin bypasses the prohibited flag via the platform->is_admin union."""
+    authz = app_manager_instance.authz
+    updates = _pool_updates(POOL_ID, public=True) + [_rel(POOL_ID, _Relation.prohibited.value, admin_user.id)]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=updates))
+
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_add_remove_member(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """Adding and removing a member dynamically grants and revokes access."""
+    authz = app_manager_instance.authz
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(POOL_ID, public=False)))
+
+    assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(updates=[_rel(POOL_ID, _Relation.viewer.value, regular_user1.id)])
+    )
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(
+            updates=[_rel(POOL_ID, _Relation.viewer.value, regular_user1.id, op=RelationshipUpdate.OPERATION_DELETE)]
+        )
+    )
+    assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_add_remove_prohibited(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """Adding and removing a prohibited relation dynamically blocks and restores access."""
+    authz = app_manager_instance.authz
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(POOL_ID, public=True)))
+
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(updates=[_rel(POOL_ID, _Relation.prohibited.value, regular_user1.id)])
+    )
+    assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(
+            updates=[
+                _rel(POOL_ID, _Relation.prohibited.value, regular_user1.id, op=RelationshipUpdate.OPERATION_DELETE)
+            ]
+        )
+    )
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, POOL_ID, Scope.READ)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_isolation(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """Membership and prohibition on one pool do not leak to another."""
+    pool_a, pool_b = 9001, 9002
+    authz = app_manager_instance.authz
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(
+            updates=_pool_updates(pool_a, public=False)
+            + _pool_updates(pool_b, public=True)
+            + [
+                _rel(pool_a, _Relation.viewer.value, regular_user1.id),
+                _rel(pool_b, _Relation.prohibited.value, regular_user1.id),
+            ]
+        )
+    )
+
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_a, Scope.READ)
+    assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_b, Scope.READ)
+
+
+# Unique ID ranges per test — avoids cross-test interference in shared SpiceDB
+_ADD_DELETE_BASE = 9100
+_UNDO_BASE = 9110
+_VISIBILITY_BASE = 9120
+_LOOKUP_BASE = 9130
+_CLEANUP_BASE = 9140
+
+
+async def _assert_pool_access(
+    authz,
+    pool_id: int,
+    *,
+    admin_use: bool = True,
+    admin_write: bool = True,
+    user_use: bool,
+    anon_use: bool,
+) -> None:
+    """Assert USE / WRITE for admin, regular_user1 and anon_user on *pool_id*.
+
+    regular_user1 and anon_user are never expected to have WRITE — those two
+    assertions are always ``False`` and included automatically.
+    """
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, pool_id, Scope.READ) is admin_use
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, pool_id, Scope.WRITE) is admin_write
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_id, Scope.READ) is user_use
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_id, Scope.WRITE) is False
+    assert await authz.has_permission(anon_user, ResourceType.resource_pool, pool_id, Scope.READ) is anon_use
+    assert await authz.has_permission(anon_user, ResourceType.resource_pool, pool_id, Scope.WRITE) is False
+
+
+async def _create_pool_in_authz(authz, pool_id: int, *, public: bool) -> None:
+    """Shorthand: call ``_add_resource_pool`` and write the result to SpiceDB."""
+    change = authz._add_resource_pool(SimpleNamespace(id=pool_id, public=public))
+    await authz.client.WriteRelationships(change.apply)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_pool", [True, False], ids=["public", "private"])
+async def test_resource_pool_add_delete_authz(
+    app_manager_instance: DependencyManager, bootstrap_admins, public_pool: bool
+) -> None:
+    """_add_resource_pool creates correct rels; _remove_resource_pool cleans them all."""
+    authz = app_manager_instance.authz
+    pool_id = _ADD_DELETE_BASE + int(public_pool)
+
+    await _create_pool_in_authz(authz, pool_id, public=public_pool)
+    await _assert_pool_access(authz, pool_id, user_use=public_pool, anon_use=public_pool)
+
+    remove_change = await authz._remove_resource_pool(admin_user, DeletedResourcePool(id=pool_id))
+    await authz.client.WriteRelationships(remove_change.apply)
+
+    await _assert_pool_access(authz, pool_id, admin_use=False, admin_write=False, user_use=False, anon_use=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_pool", [True, False], ids=["public", "private"])
+async def test_resource_pool_add_undo(
+    app_manager_instance: DependencyManager, bootstrap_admins, public_pool: bool
+) -> None:
+    """Applying the undo payload from _add_resource_pool fully reverses creation."""
+    authz = app_manager_instance.authz
+    pool_id = _UNDO_BASE + int(public_pool)
+
+    change = authz._add_resource_pool(SimpleNamespace(id=pool_id, public=public_pool))
+    await authz.client.WriteRelationships(change.apply)
+    await _assert_pool_access(authz, pool_id, user_use=public_pool, anon_use=public_pool)
+
+    # Undo — simulates DB-rollback recovery path
+    await authz.client.WriteRelationships(change.undo)
+    await _assert_pool_access(authz, pool_id, admin_use=False, admin_write=False, user_use=False, anon_use=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_public,new_public",
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+        (False, False),
+    ],
+    ids=["public_to_private", "private_to_public", "public_to_public(noop)", "private_to_private(noop)"],
+)
+async def test_resource_pool_visibility_update(
+    app_manager_instance: DependencyManager,
+    bootstrap_admins,
+    initial_public: bool,
+    new_public: bool,
+) -> None:
+    """_update_resource_pool_visibility adds/removes public_viewer wildcards correctly."""
+    authz = app_manager_instance.authz
+    pool_id = _VISIBILITY_BASE + int(initial_public) * 2 + int(new_public)
+
+    await _create_pool_in_authz(authz, pool_id, public=initial_public)
+    await _assert_pool_access(authz, pool_id, user_use=initial_public, anon_use=initial_public)
+
+    vis_change = await authz._update_resource_pool_visibility(
+        admin_user, SimpleNamespace(id=pool_id, public=new_public)
+    )
+    await authz.client.WriteRelationships(vis_change.apply)
+
+    await _assert_pool_access(authz, pool_id, user_use=new_public, anon_use=new_public)
+
+    if initial_public == new_public:
+        assert len(vis_change.apply.updates) == 0, "No-op transition should produce no apply ops"
+        assert len(vis_change.undo.updates) == 0, (
+            f"No-op transition ({initial_public}->{new_public}) produced "
+            f"{len(vis_change.undo.updates)} undo op(s) that would corrupt state on rollback"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_lookup_resources(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """resources_with_permission returns correct pool IDs per user role."""
+    authz = app_manager_instance.authz
+    public_id, private_id = _LOOKUP_BASE, _LOOKUP_BASE + 1
+
+    for pid, public in [(public_id, True), (private_id, False)]:
+        await _create_pool_in_authz(authz, pid, public=public)
+
+    # Admin sees both
+    admin_pools = set(
+        await authz.resources_with_permission(admin_user, admin_user.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert {str(public_id), str(private_id)}.issubset(admin_pools)
+
+    # Regular user sees only public
+    user_pools = set(
+        await authz.resources_with_permission(regular_user1, regular_user1.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert str(public_id) in user_pools
+    assert str(private_id) not in user_pools
+
+    # Add regular_user1 as member → now sees both
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(updates=[_rel(private_id, _Relation.viewer, regular_user1.id)])
+    )
+    user_pools = set(
+        await authz.resources_with_permission(regular_user1, regular_user1.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert str(private_id) in user_pools
+
+    # Anon still only sees public
+    anon_pools = set(
+        await authz.resources_with_permission(anon_user, anon_user.id, ResourceType.resource_pool, Scope.READ)
+    )
+    assert str(public_id) in anon_pools
+    assert str(private_id) not in anon_pools
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_delete_cleans_all_relations(
+    app_manager_instance: DependencyManager, bootstrap_admins
+) -> None:
+    """_remove_resource_pool removes ALL rels including member and prohibited."""
+    authz = app_manager_instance.authz
+    pool_id = _CLEANUP_BASE
+
+    await _create_pool_in_authz(authz, pool_id, public=True)
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(
+            updates=[
+                _rel(pool_id, _Relation.viewer, regular_user1.id),
+                _rel(pool_id, _Relation.prohibited, regular_user2.id),
+            ]
+        )
+    )
+
+    assert await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_id, Scope.READ)
+    assert not await authz.has_permission(regular_user2, ResourceType.resource_pool, pool_id, Scope.READ)
+
+    remove_change = await authz._remove_resource_pool(admin_user, DeletedResourcePool(id=pool_id))
+    await authz.client.WriteRelationships(remove_change.apply)
+
+    await _assert_pool_access(authz, pool_id, admin_use=False, admin_write=False, user_use=False, anon_use=False)
+    assert not await authz.has_permission(regular_user2, ResourceType.resource_pool, pool_id, Scope.READ)

--- a/test/components/renku_data_services/authz/test_schemas.py
+++ b/test/components/renku_data_services/authz/test_schemas.py
@@ -513,6 +513,68 @@ def v7_schema() -> SpiceDBSchema:
     )
 
 
+@pytest.fixture
+def v9_schema() -> SpiceDBSchema:
+    return SpiceDBSchema(
+        schemas._v9,
+        relationships=[
+            "platform:renku#admin@user:admin1",
+            # pool1: public
+            "resource_pool:pool1#public_viewer@user:*",
+            "resource_pool:pool1#public_viewer@anonymous_user:*",
+            "resource_pool:pool1#prohibited@user:user2",
+            "resource_pool:pool1#resource_pool_platform@platform:renku",
+            # pool2: private, only user3 is a viewer
+            "resource_pool:pool2#viewer@user:user3",
+            "resource_pool:pool2#resource_pool_platform@platform:renku",
+            "resource_pool:pool2#prohibited@user:user2",
+        ],
+        assertions={
+            "assertTrue": [
+                # pool1 public: prove the pool is public
+                "resource_pool:pool1#read@user:user1",
+                "resource_pool:pool1#read@anonymous_user:anon1",
+                "resource_pool:pool1#read@user:admin1",
+                # pool2: pool is only usable by select users
+                "resource_pool:pool2#read@user:user3",
+                "resource_pool:pool2#read@user:admin1",
+                # admin can write
+                "resource_pool:pool1#write@user:admin1",
+            ],
+            "assertFalse": [
+                # prohibited user blocked
+                "resource_pool:pool1#read@user:user2",
+                "resource_pool:pool2#read@user:user2",
+                # non-viewer or anon can't use private pool
+                "resource_pool:pool2#read@user:user1",
+                "resource_pool:pool2#read@anonymous_user:anon1",
+                # viewer and random can't write
+                "resource_pool:pool2#write@user:user3",
+                "resource_pool:pool1#write@user:user1",
+            ],
+        },
+        validation={
+            # pool1: (public) list all resolution paths
+            "resource_pool:pool1#read": [
+                "[user:* - {user:user2}] is <resource_pool:pool1#public_viewer>",
+                "[anonymous_user:*] is <resource_pool:pool1#public_viewer>",
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            # pool2: (private) only viewer + admin, no wildcards
+            "resource_pool:pool2#read": [
+                "[user:user3] is <resource_pool:pool2#viewer>",
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            "resource_pool:pool1#write": [
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            "resource_pool:pool2#write": [
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+        },
+    )
+
+
 def test_v1_schema(tmp_path: Path, v1_schema: SpiceDBSchema) -> None:
     validation_file = tmp_path / "validate.yaml"
     v1_schema.to_yaml(validation_file)
@@ -540,4 +602,10 @@ def test_v6_schema(tmp_path: Path, v6_schema: SpiceDBSchema) -> None:
 def test_v7_schema(tmp_path: Path, v7_schema: SpiceDBSchema) -> None:
     validation_file = tmp_path / "validate.yaml"
     v7_schema.to_yaml(validation_file)
+    check_call(["zed", "validate", validation_file.as_uri()])
+
+
+def test_v9_schema(tmp_path: Path, v9_schema: SpiceDBSchema) -> None:
+    validation_file = tmp_path / "validate.yaml"
+    v9_schema.to_yaml(validation_file)
     check_call(["zed", "validate", validation_file.as_uri()])

--- a/test/utils.py
+++ b/test/utils.py
@@ -262,6 +262,8 @@ class TestDependencyManager(DependencyManager):
         gitlab_authenticator: base_models.Authenticator
         gitlab_client: base_models.GitlabAPIProtocol
         config.authz_config = AuthzConfigStack.from_env()
+        nb_authz = NonCachingAuthz(config.authz_config)
+        config.nb_config.k8s_v2_client._NotebookK8sClient__rp_repo.authz = nb_authz
         kc_api: IKeycloakAPI
 
         default_kubeconfig = KubeConfigEnv()
@@ -333,8 +335,11 @@ class TestDependencyManager(DependencyManager):
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
+            authz=authz,
         )
-        rp_repo = ResourcePoolRepository(session_maker=config.db.async_session_maker, quotas_repo=quota_repo)
+        rp_repo = ResourcePoolRepository(
+            session_maker=config.db.async_session_maker, quotas_repo=quota_repo, authz=authz
+        )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,
             gitlab_client=gitlab_client,


### PR DESCRIPTION
## Summary:

Migrates ResourcePool access control from SQL-based checks to Authzed/SpiceDB, combining two PRs:

- **#1248** — Adds Authzed schema v9, supporting code, and an Alembic migration that both deploys the schema and backfills relations from existing DB data.
- **#1256** — Switches runtime access control to Authzed and auto-syncs DB changes to SpiceDB.

## Key Changes

- **Schema v9**: New `resource_pool` type with `viewer`, `prohibited`, `public_viewer` (wildcards), and `resource_pool_platform` relations; `read` and `write` permissions with admin bypass.
- **Migration `cd424c01676e`**: Deploys schema and backfills viewers, prohibited users, platform links, and public wildcards using `OPERATION_TOUCH` in batches of 500 (idempotent).
- **Runtime**: Replaced legacy access-control helpers with `_filter_by_authz`, which resolves permissions via Authzed and filters SQL queries by allowed IDs.
- **Sync**: `@Authz.authz_change` decorators on `ResourcePoolRepository` and `UserRepository` keep SpiceDB in sync for pool create/update/delete and member/prohibited changes.
- **DI**: `Config` and `DependencyManager` now inject `Authz` into repositories.

## Notes

- Public access via `user:*` / `anonymous_user:*` wildcards.
- `no_default_access` enforced through `prohibited` on the default (public) pool.
- All writes idempotent; migration safely re-runnable.

## Deferred

- cleanup of old DB tables
- extending authz to groups/projects.

---

/deploy renku=salimkayal-add-AUTHZ-config-to-k8s-watcher