### PR TITLE
feat: add group and projects to resource pool authz

### DIFF
--- a/bases/renku_data_services/data_api/app.py
+++ b/bases/renku_data_services/data_api/app.py
@@ -80,7 +80,7 @@ def register_all_handlers(app: Sanic, dm: DependencyManager) -> Sanic:
         url_prefix=url_prefix,
         rp_repo=dm.rp_repo,
         authenticator=dm.authenticator,
-        user_repo=dm.user_repo,
+        member_repo=dm.member_repo,
         cluster_repo=dm.cluster_repo,
     )
     classes = ClassesBP(name="classes", url_prefix=url_prefix, repo=dm.rp_repo, authenticator=dm.authenticator)
@@ -100,14 +100,14 @@ def register_all_handlers(app: Sanic, dm: DependencyManager) -> Sanic:
     resource_pools_users = ResourcePoolUsersBP(
         name="resource_pool_users",
         url_prefix=url_prefix,
-        repo=dm.user_repo,
+        repo=dm.member_repo,
         authenticator=dm.authenticator,
         kc_user_repo=dm.kc_user_repo,
     )
     user_resource_pools = UserResourcePoolsBP(
         name="user_resource_pools",
         url_prefix=url_prefix,
-        repo=dm.user_repo,
+        repo=dm.member_repo,
         authenticator=dm.authenticator,
         kc_user_repo=dm.kc_user_repo,
     )

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -335,10 +335,19 @@ class DependencyManager:
             authz=authz,
         )
 
+        project_repo = ProjectRepository(
+            session_maker=config.db.async_session_maker,
+            authz=authz,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+        )
+
         member_repo = MemberRepository(
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
+            group_repo=group_repo,
+            project_repo=project_repo,
             authz=authz,
         )
         resource_requests_repo = ResourceRequestsRepo(
@@ -359,12 +368,6 @@ class DependencyManager:
             secret_service_public_key=config.secrets.public_key,
         )
         reprovisioning_repo = ReprovisioningRepository(session_maker=config.db.async_session_maker)
-        project_repo = ProjectRepository(
-            session_maker=config.db.async_session_maker,
-            authz=authz,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-        )
 
         git_repositories_repo = GitRepositoriesRepository(
             session_maker=config.db.async_session_maker,

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -32,7 +32,7 @@ from renku_data_services.connected_services.db import ConnectedServicesRepositor
 from renku_data_services.connected_services.oauth_http import DefaultOAuthHttpClientFactory, OAuthHttpClientFactory
 from renku_data_services.crc import models as crc_models
 from renku_data_services.crc.constants import DEFAULT_RUNTIME_PLATFORM
-from renku_data_services.crc.db import ClusterRepository, QuotaRepository, ResourcePoolRepository, UserRepository
+from renku_data_services.crc.db import ClusterRepository, MemberRepository, QuotaRepository, ResourcePoolRepository
 from renku_data_services.data_api.config import Config
 from renku_data_services.data_connectors.db import (
     DataConnectorRepository,
@@ -135,7 +135,7 @@ class DependencyManager:
     gitlab_client: base_models.GitlabAPIProtocol
     kc_api: IKeycloakAPI
     authz: Authz
-    user_repo: UserRepository
+    member_repo: MemberRepository
     rp_repo: ResourcePoolRepository
     storage_repo: StorageRepository
     project_repo: ProjectRepository
@@ -335,7 +335,7 @@ class DependencyManager:
             authz=authz,
         )
 
-        user_repo = UserRepository(
+        member_repo = MemberRepository(
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
@@ -469,7 +469,7 @@ class DependencyManager:
             user_store=user_store,
             quota_repo=quota_repo,
             kc_api=kc_api,
-            user_repo=user_repo,
+            member_repo=member_repo,
             rp_repo=rp_repo,
             storage_repo=storage_repo,
             reprovisioning_repo=reprovisioning_repo,

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -1,7 +1,7 @@
 """Projects authorization adapter."""
 
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable, Collection
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -46,7 +46,11 @@ from renku_data_services.authz.models import (
     Visibility,
 )
 from renku_data_services.base_models.core import InternalServiceAdmin, ResourceType
-from renku_data_services.crc.models import DeletedResourcePool, ResourcePool, ResourcePoolMembershipChange
+from renku_data_services.crc.models import (
+    DeletedResourcePool,
+    ResourcePool,
+    ResourcePoolMembershipChange,
+)
 from renku_data_services.data_connectors.models import (
     DataConnector,
     DataConnectorToProjectLink,
@@ -136,6 +140,8 @@ class _Relation(StrEnum):
     editor = "editor"
     viewer = "viewer"
     public_viewer = "public_viewer"
+    group_viewer = "group_viewer"
+    project_viewer = "project_viewer"
     admin = "admin"
     project_platform = "project_platform"
     group_platform = "group_platform"
@@ -187,7 +193,7 @@ class AuthzOperation(StrEnum):
 
 class _AuthzConverter:
     @staticmethod
-    def project(id: ULID) -> ObjectReference:
+    def project(id: str | ULID) -> ObjectReference:
         return ObjectReference(object_type=ResourceType.project.value, object_id=str(id))
 
     @staticmethod
@@ -217,17 +223,17 @@ class _AuthzConverter:
         return ObjectReference(object_type=ResourceType.user, object_id="*")
 
     @staticmethod
-    def group(id: ULID) -> ObjectReference:
+    def group(id: str | ULID) -> ObjectReference:
         """The id should be the id of the GroupORM object in the DB."""
         return ObjectReference(object_type=ResourceType.group, object_id=str(id))
 
     @staticmethod
-    def user_namespace(id: ULID) -> ObjectReference:
+    def user_namespace(id: str | ULID) -> ObjectReference:
         """The id should be the id of the NamespaceORM object in the DB."""
         return ObjectReference(object_type=ResourceType.user_namespace, object_id=str(id))
 
     @staticmethod
-    def data_connector(id: ULID) -> ObjectReference:
+    def data_connector(id: str | ULID) -> ObjectReference:
         return ObjectReference(object_type=ResourceType.data_connector.value, object_id=str(id))
 
     @staticmethod
@@ -239,17 +245,17 @@ class _AuthzConverter:
     def to_object(resource_type: ResourceType, resource_id: _ID) -> ObjectReference:
         """Convert a resource type and ID to an Authzed ObjectReference."""
         match (resource_type, resource_id):
-            case (ResourceType.project, sid) if isinstance(sid, ULID):
+            case (ResourceType.project, sid) if isinstance(sid, (ULID, str)):
                 return _AuthzConverter.project(sid)
             case (ResourceType.user, sid) if isinstance(sid, str) or sid is None:
                 return _AuthzConverter.user(sid)
             case (ResourceType.anonymous_user, _):
                 return _AuthzConverter.anonymous_users()
-            case (ResourceType.user_namespace, rid) if isinstance(rid, ULID):
+            case (ResourceType.user_namespace, rid) if isinstance(rid, (ULID, str)):
                 return _AuthzConverter.user_namespace(rid)
-            case (ResourceType.group, rid) if isinstance(rid, ULID):
+            case (ResourceType.group, rid) if isinstance(rid, (ULID, str)):
                 return _AuthzConverter.group(rid)
-            case (ResourceType.data_connector, dcid) if isinstance(dcid, ULID):
+            case (ResourceType.data_connector, dcid) if isinstance(dcid, (ULID, str)):
                 return _AuthzConverter.data_connector(dcid)
             case (ResourceType.resource_pool, rid) if isinstance(rid, int):
                 return _AuthzConverter.resource_pool(rid)
@@ -1468,7 +1474,17 @@ class Authz:
             member = mc.member
             relation = _Relation.from_role(member.role).value
             resource = _AuthzConverter.resource_pool(cast(int, member.resource_id))
-            subject = _AuthzConverter.user_subject(member.user_id)
+
+            match member.subject_type:
+                case ResourceType.group if member.role == Role.VIEWER:
+                    relation = _Relation.group_viewer.value
+                    subject = SubjectReference(object=_AuthzConverter.to_object(ResourceType.group, member.user_id))
+                case ResourceType.project if member.role == Role.VIEWER:
+                    relation = _Relation.project_viewer.value
+                    subject = SubjectReference(object=_AuthzConverter.to_object(ResourceType.project, member.user_id))
+                case _:
+                    subject = _AuthzConverter.user_subject(member.user_id)
+
             rel = Relationship(resource=resource, relation=relation, subject=subject)
 
             if operation == AuthzOperation.create:

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -193,7 +193,7 @@ class AuthzOperation(StrEnum):
 
 class _AuthzConverter:
     @staticmethod
-    def project(id: str | ULID) -> ObjectReference:
+    def project(id: ULID) -> ObjectReference:
         return ObjectReference(object_type=ResourceType.project.value, object_id=str(id))
 
     @staticmethod
@@ -223,17 +223,17 @@ class _AuthzConverter:
         return ObjectReference(object_type=ResourceType.user, object_id="*")
 
     @staticmethod
-    def group(id: str | ULID) -> ObjectReference:
+    def group(id: ULID) -> ObjectReference:
         """The id should be the id of the GroupORM object in the DB."""
         return ObjectReference(object_type=ResourceType.group, object_id=str(id))
 
     @staticmethod
-    def user_namespace(id: str | ULID) -> ObjectReference:
+    def user_namespace(id: ULID) -> ObjectReference:
         """The id should be the id of the NamespaceORM object in the DB."""
         return ObjectReference(object_type=ResourceType.user_namespace, object_id=str(id))
 
     @staticmethod
-    def data_connector(id: str | ULID) -> ObjectReference:
+    def data_connector(id: ULID) -> ObjectReference:
         return ObjectReference(object_type=ResourceType.data_connector.value, object_id=str(id))
 
     @staticmethod
@@ -245,17 +245,17 @@ class _AuthzConverter:
     def to_object(resource_type: ResourceType, resource_id: _ID) -> ObjectReference:
         """Convert a resource type and ID to an Authzed ObjectReference."""
         match (resource_type, resource_id):
-            case (ResourceType.project, sid) if isinstance(sid, (ULID, str)):
+            case (ResourceType.project, sid) if isinstance(sid, ULID):
                 return _AuthzConverter.project(sid)
             case (ResourceType.user, sid) if isinstance(sid, str) or sid is None:
                 return _AuthzConverter.user(sid)
             case (ResourceType.anonymous_user, _):
                 return _AuthzConverter.anonymous_users()
-            case (ResourceType.user_namespace, rid) if isinstance(rid, (ULID, str)):
+            case (ResourceType.user_namespace, rid) if isinstance(rid, ULID):
                 return _AuthzConverter.user_namespace(rid)
-            case (ResourceType.group, rid) if isinstance(rid, (ULID, str)):
+            case (ResourceType.group, rid) if isinstance(rid, ULID):
                 return _AuthzConverter.group(rid)
-            case (ResourceType.data_connector, dcid) if isinstance(dcid, (ULID, str)):
+            case (ResourceType.data_connector, dcid) if isinstance(dcid, ULID):
                 return _AuthzConverter.data_connector(dcid)
             case (ResourceType.resource_pool, rid) if isinstance(rid, int):
                 return _AuthzConverter.resource_pool(rid)
@@ -1478,10 +1478,10 @@ class Authz:
             match member.subject_type:
                 case ResourceType.group if member.role == Role.VIEWER:
                     relation = _Relation.group_viewer.value
-                    subject = SubjectReference(object=_AuthzConverter.to_object(ResourceType.group, member.user_id))
+                    subject = SubjectReference(object=_AuthzConverter.group(ULID.from_str(member.user_id)))
                 case ResourceType.project if member.role == Role.VIEWER:
                     relation = _Relation.project_viewer.value
-                    subject = SubjectReference(object=_AuthzConverter.to_object(ResourceType.project, member.user_id))
+                    subject = SubjectReference(object=_AuthzConverter.project(ULID.from_str(member.user_id)))
                 case _:
                     subject = _AuthzConverter.user_subject(member.user_id)
 

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -1,7 +1,7 @@
 """Projects authorization adapter."""
 
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable, Collection
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps

--- a/components/renku_data_services/authz/models.py
+++ b/components/renku_data_services/authz/models.py
@@ -75,6 +75,19 @@ class UnsavedMember:
             user_id=self.user_id,
             resource_id=group_id,
             resource_type=ResourceType.group,
+            subject_type=ResourceType.user,
+        )
+
+    def with_resource_pool(
+        self, resource_id: ULID | int, resource_type: ResourceType, subject_type: ResourceType
+    ) -> "Member":
+        """Turn to member with group."""
+        return Member(
+            role=self.role,
+            user_id=self.user_id,
+            resource_id=resource_id,
+            resource_type=resource_type,
+            subject_type=subject_type,
         )
 
 
@@ -84,6 +97,7 @@ class Member(UnsavedMember):
 
     resource_id: ULID | int
     resource_type: ResourceType = ResourceType.group
+    subject_type: ResourceType = ResourceType.user
 
 
 class Change(Enum):

--- a/components/renku_data_services/authz/schemas.py
+++ b/components/renku_data_services/authz/schemas.py
@@ -966,7 +966,7 @@ definition resource_pool {
 v10 = AuthzSchemaMigration(
     up=[WriteSchemaRequest(schema=_v10)],
     down=[
-        DeleteRelationshipsRequest(relationship_filter=RelationshipFilter(resource_type="resource_pool_v10")),
+        DeleteRelationshipsRequest(relationship_filter=RelationshipFilter(resource_type=ResourceType.resource_pool.value)),
         WriteSchemaRequest(schema=_v9),
     ],
 )

--- a/components/renku_data_services/authz/schemas.py
+++ b/components/renku_data_services/authz/schemas.py
@@ -863,3 +863,103 @@ v9 = AuthzSchemaMigration(
         WriteSchemaRequest(schema=_v8),
     ],
 )
+
+_v10: str = """\
+definition user {}
+
+definition group {
+    relation group_platform: platform
+    relation owner: user
+    relation editor: user
+    relation viewer: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + read_children
+    permission read_children = viewer + write
+    permission write = editor + delete
+    permission change_membership = delete
+    permission delete = owner + group_platform->is_admin
+    permission non_public_read = owner + editor + viewer - public_viewer
+    permission exclusive_owner = owner
+    permission exclusive_editor = editor
+    permission exclusive_member = viewer + editor + owner
+    permission direct_member = owner + editor + viewer
+}
+
+definition user_namespace {
+    relation user_namespace_platform: platform
+    relation owner: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + read_children
+    permission read_children = delete
+    permission write = delete
+    permission delete = owner + user_namespace_platform->is_admin
+    permission non_public_read = owner - public_viewer
+    permission exclusive_owner = owner
+    permission exclusive_member = owner
+    permission direct_member = owner
+}
+
+definition anonymous_user {}
+
+definition platform {
+    relation admin: user
+    permission is_admin = admin
+}
+
+definition project {
+    relation project_platform: platform
+    relation project_namespace: user_namespace | group
+    relation owner: user
+    relation editor: user
+    relation viewer: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + read_children
+    permission read_children = viewer + write + project_namespace->read_children
+    permission write = editor + delete + project_namespace->write
+    permission change_membership = delete
+    permission delete = owner + project_platform->is_admin + project_namespace->delete
+    permission non_public_read = owner + editor + viewer + project_namespace->read_children - public_viewer
+    permission exclusive_owner = owner + project_namespace->exclusive_owner
+    permission exclusive_editor = editor
+    permission exclusive_member = owner + editor + viewer + project_namespace->exclusive_member
+    permission direct_member = owner + editor + viewer
+}
+
+definition data_connector {
+    relation data_connector_platform: platform
+    relation data_connector_namespace: user_namespace | group | project
+    relation linked_to: project
+    relation owner: user
+    relation editor: user
+    relation viewer: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = public_viewer + viewer + write + data_connector_namespace->read_children
+    permission write = editor + delete + data_connector_namespace->write
+    permission change_membership = delete
+    permission delete = owner + data_connector_platform->is_admin + data_connector_namespace->delete
+    permission non_public_read = owner + editor + viewer + data_connector_namespace->read_children - public_viewer
+    permission exclusive_owner = owner + data_connector_namespace->exclusive_owner
+    permission exclusive_editor = editor
+    permission exclusive_member = owner + editor + viewer + data_connector_namespace->exclusive_member
+    permission direct_member = owner + editor + viewer
+}
+
+definition resource_pool {
+    relation resource_pool_platform: platform
+    relation viewer: user
+    relation group_viewer: group
+    relation project_viewer: project
+    relation prohibited: user
+    relation public_viewer: user:* | anonymous_user:*
+    permission read = (viewer + group_viewer->direct_member + project_viewer->direct_member + public_viewer - prohibited) + resource_pool_platform->is_admin
+    permission write = resource_pool_platform->is_admin
+}"""
+"""Adds the resource_pool definition for Authzed authorization with groups and projects."""
+
+v10 = AuthzSchemaMigration(
+    up=[WriteSchemaRequest(schema=_v10)],
+    down=[
+        DeleteRelationshipsRequest(relationship_filter=RelationshipFilter(resource_type="resource_pool_v10")),
+        WriteSchemaRequest(schema=_v9),
+    ],
+)

--- a/components/renku_data_services/authz/schemas.py
+++ b/components/renku_data_services/authz/schemas.py
@@ -915,7 +915,7 @@ definition project {
     relation public_viewer: user:* | anonymous_user:*
     permission read = public_viewer + read_children
     permission read_children = viewer + write + project_namespace->read_children
-    permission write = editor + delete + project_namespace->write
+    permission write = editor + delete
     permission change_membership = delete
     permission delete = owner + project_platform->is_admin + project_namespace->delete
     permission non_public_read = owner + editor + viewer + project_namespace->read_children - public_viewer
@@ -934,7 +934,7 @@ definition data_connector {
     relation viewer: user
     relation public_viewer: user:* | anonymous_user:*
     permission read = public_viewer + viewer + write + data_connector_namespace->read_children
-    permission write = editor + delete + data_connector_namespace->write
+    permission write = editor + delete
     permission change_membership = delete
     permission delete = owner + data_connector_platform->is_admin + data_connector_namespace->delete
     permission non_public_read = owner + editor + viewer + data_connector_namespace->read_children - public_viewer
@@ -966,7 +966,9 @@ definition resource_pool {
 v10 = AuthzSchemaMigration(
     up=[WriteSchemaRequest(schema=_v10)],
     down=[
-        DeleteRelationshipsRequest(relationship_filter=RelationshipFilter(resource_type=ResourceType.resource_pool.value)),
+        DeleteRelationshipsRequest(
+            relationship_filter=RelationshipFilter(resource_type=ResourceType.resource_pool.value)
+        ),
         WriteSchemaRequest(schema=_v9),
     ],
 )

--- a/components/renku_data_services/authz/schemas.py
+++ b/components/renku_data_services/authz/schemas.py
@@ -951,7 +951,14 @@ definition resource_pool {
     relation project_viewer: project
     relation prohibited: user
     relation public_viewer: user:* | anonymous_user:*
-    permission read = (viewer + group_viewer->direct_member + project_viewer->direct_member + public_viewer - prohibited) + resource_pool_platform->is_admin
+    permission read = ( \
+            viewer \
+            + group_viewer->direct_member\
+            + project_viewer->direct_member \
+            + public_viewer \
+            - prohibited \
+            ) \
+            + resource_pool_platform->is_admin
     permission write = resource_pool_platform->is_admin
 }"""
 """Adds the resource_pool definition for Authzed authorization with groups and projects."""

--- a/components/renku_data_services/crc/blueprints.py
+++ b/components/renku_data_services/crc/blueprints.py
@@ -23,7 +23,7 @@ from renku_data_services.crc.core import (
     validate_resource_pool_post,
     validate_resource_pool_put_or_patch,
 )
-from renku_data_services.crc.db import ClusterRepository, ResourcePoolRepository, UserRepository
+from renku_data_services.crc.db import ClusterRepository, MemberRepository, ResourcePoolRepository
 from renku_data_services.users.db import UserRepo as KcUserRepo
 from renku_data_services.users.models import UserInfo
 
@@ -33,7 +33,7 @@ class ResourcePoolsBP(CustomBlueprint):
     """Handlers for manipulating resource pools."""
 
     rp_repo: ResourcePoolRepository
-    user_repo: UserRepository
+    member_repo: MemberRepository
     cluster_repo: ClusterRepository
     authenticator: base_models.Authenticator
 
@@ -126,7 +126,7 @@ class ResourcePoolsBP(CustomBlueprint):
 class ResourcePoolUsersBP(CustomBlueprint):
     """Handlers for dealing with the users of individual resource pools."""
 
-    repo: UserRepository
+    repo: MemberRepository
     kc_user_repo: KcUserRepo
     authenticator: base_models.Authenticator
 
@@ -485,7 +485,7 @@ class QuotaBP(CustomBlueprint):
 class UserResourcePoolsBP(CustomBlueprint):
     """Handlers for dealing with the resource pools of a specific user."""
 
-    repo: UserRepository
+    repo: MemberRepository
     kc_user_repo: KcUserRepo
     authenticator: base_models.Authenticator
 

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -12,7 +12,7 @@ from asyncio import gather
 from collections.abc import AsyncGenerator, Callable, Collection, Coroutine, Sequence
 from dataclasses import asdict, dataclass, field, replace
 from functools import wraps
-from typing import Any, Concatenate, Optional, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate, Optional, ParamSpec, TypeVar
 from uuid import uuid4
 
 from sqlalchemy import NullPool, delete, false, select, true
@@ -46,6 +46,10 @@ from renku_data_services.users.db import UserRepo
 from renku_data_services.utils.core import with_db_transaction
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from renku_data_services.namespace.db import GroupRepository
+    from renku_data_services.project.db import ProjectRepository
 
 
 class _Base:
@@ -915,10 +919,14 @@ class MemberRepository(_Base):
         session_maker: Callable[..., AsyncSession],
         quotas_repo: QuotaRepository,
         user_repo: UserRepo,
+        group_repo: GroupRepository,
+        project_repo: ProjectRepository,
         authz: Authz,
     ) -> None:
         super().__init__(session_maker, quotas_repo, authz)
         self.kc_user_repo = user_repo
+        self.group_repo = group_repo
+        self.project_repo = project_repo
 
     @_only_admins
     async def get_resource_pool_users(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1073,6 +1073,7 @@ class MemberRepository(_Base):
                 user.resource_pools = list(rps_to_add)
             # TODO: the authz changes below are done in separate db transactions,
             # TODO: use only one (collect everything into a single authz change)
+            member_identifier = ResourcePoolMemberIdentifier(member_id=keycloak_id, member_type=MemberType.USER)
             for rp in rps_to_add:
                 await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
                 if rp.default or rp.public:
@@ -1255,7 +1256,7 @@ class MemberRepository(_Base):
         api_user: base_models.APIUser,
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
-        session: AsyncSession,
+        session: AsyncSession | None = None,
     ) -> models.ResourcePoolMembershipChange | None:
         specs = await self._resolve_members(api_user, members)
         return self._build_pool_membership_changes(
@@ -1271,7 +1272,7 @@ class MemberRepository(_Base):
         api_user: base_models.APIUser,
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
-        session: AsyncSession,
+        session: AsyncSession | None = None,
     ) -> models.ResourcePoolMembershipChange | None:
         specs = await self._resolve_members(api_user, members)
         return self._build_pool_membership_changes(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -907,7 +907,7 @@ class Repository2Users:
     disallowed: list[base_models.User] = field(default_factory=list)
 
 
-class UserRepository(_Base):
+class MemberRepository(_Base):
     """The adapter used for accessing resource pool users with SQLAlchemy."""
 
     def __init__(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -35,7 +35,14 @@ from renku_data_services.crc.core import (
     validate_resource_class_update,
     validate_resource_pool_update,
 )
-from renku_data_services.crc.models import ClusterPatch, ClusterSettings, SavedClusterSettings, SessionProtocol
+from renku_data_services.crc.models import (
+    ClusterPatch,
+    ClusterSettings,
+    MemberType,
+    ResourcePoolMemberIdentifier,
+    SavedClusterSettings,
+    SessionProtocol,
+)
 from renku_data_services.crc.orm import ClusterORM
 from renku_data_services.k8s.client_interfaces import PriorityClassClient, ResourceQuotaClient
 from renku_data_services.k8s.constants import DEFAULT_K8S_CLUSTER, ClusterId
@@ -485,7 +492,7 @@ class ResourcePoolRepository(_Base):
         api_user: base_models.APIUser,
         new_resource_class: models.UnsavedResourceClass,
         *,
-        resource_pool_id: Optional[int] = None,
+        resource_pool_id: int | None = None,
     ) -> models.ResourceClass:
         """Insert a resource class in the database."""
         async with self.session_maker() as session, session.begin():
@@ -1067,13 +1074,13 @@ class MemberRepository(_Base):
             # TODO: the authz changes below are done in separate db transactions,
             # TODO: use only one (collect everything into a single authz change)
             for rp in rps_to_add:
-                await self._grant_resource_pool_members(api_user, rp.id, [keycloak_id])
+                await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
                 if rp.default or rp.public:
                     await self._unprohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
             for rp in removed_rps:
-                await self._revoke_resource_pool_member(api_user, rp.id, [keycloak_id])
+                await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
                 if rp.default or rp.public:
-                    await self._prohibit_resource_pool_user(api_user, rp.id, [keycloak_id])
+                    await self._prohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
             output: list[models.ResourcePool] = []
             for rp in rps_to_add:
                 quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
@@ -1101,9 +1108,10 @@ class MemberRepository(_Base):
             )
             stmt = delete(schemas.resource_pools_users).where(schemas.resource_pools_users.c.user_id.in_(sub))
             await session.execute(stmt)
-            await self._revoke_resource_pool_member(api_user, resource_pool_id, [keycloak_id], session=session)
+            member_identifier = ResourcePoolMemberIdentifier(member_id=keycloak_id, member_type=MemberType.USER)
+            await self._revoke_resource_pool_members(api_user, resource_pool_id, [member_identifier], session=session)
             if rp.default or rp.public:
-                await self._prohibit_resource_pool_user(api_user, resource_pool_id, [keycloak_id], session=session)
+                await self._prohibit_resource_pool_users(api_user, resource_pool_id, [keycloak_id], session=session)
 
     @_only_admins
     async def update_resource_pool_users(
@@ -1153,38 +1161,77 @@ class MemberRepository(_Base):
                 rp_user_ids = {rp.id for rp in rp.users}
                 users_to_add = [u for u in list(users_to_add_exist) + users_to_add_missing if u.id not in rp_user_ids]
                 rp.users.extend(users_to_add)
-                await self._grant_resource_pool_members(api_user, resource_pool_id, user_ids, session=session)
+                member_ids = [
+                    ResourcePoolMemberIdentifier(member_id=uid, member_type=MemberType.USER) for uid in user_ids
+                ]
+                await self._grant_resource_pool_members(api_user, resource_pool_id, member_ids, session=session)
             else:
                 rp.users = list(users_to_add_exist) + users_to_add_missing
             return [usr.dump() for usr in rp.users]
 
-    def _build_pool_membership_change(
-        self, user_ids: Collection[str], resource_pool_id: int, role: Role, change: Change
+    def _build_pool_membership_changes(
+        self,
+        resource_pool_id: int,
+        specs: Collection[tuple[str, ResourceType, Role]],
+        change: Change,
     ) -> models.ResourcePoolMembershipChange | None:
-        if not user_ids:
+        if not specs:
             return None
         return models.ResourcePoolMembershipChange(
             changes=[
                 MembershipChange(
                     Member(
-                        role=role, user_id=uid, resource_id=resource_pool_id, resource_type=ResourceType.resource_pool
+                        role=role,
+                        user_id=member_id,
+                        resource_id=resource_pool_id,
+                        resource_type=ResourceType.resource_pool,
+                        subject_type=subject_type,
                     ),
                     change,
                 )
-                for uid in user_ids
+                for member_id, subject_type, role in specs
             ]
         )
 
-    @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
-    async def _grant_resource_pool_members(
+    async def _resolve_members(
         self,
         api_user: base_models.APIUser,
-        resource_pool_id: int,
-        user_ids: Collection[str],
-        session: AsyncSession | None = None,
-    ) -> models.ResourcePoolMembershipChange | None:
-        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.VIEWER, Change.ADD)
+        members: Collection[ResourcePoolMemberIdentifier],
+    ) -> list[tuple[str, ResourceType]]:
+        """Resolve ResourcePoolMemberIdentifiers to (internal_id, subject_type) tuples."""
+        resolved: list[tuple[str, ResourceType]] = []
+        for member in members:
+            match member.member_type:
+                case MemberType.USER:
+                    kc_user = await self.kc_user_repo.get_user(id=member.member_id)
+                    if kc_user is None:
+                        raise errors.MissingResourceError(message=f"User with ID {member.member_id} does not exist")
+                    resolved.append((kc_user.id, ResourceType.user))
+
+                case MemberType.GROUP:
+                    slug = member.group_slug
+                    assert slug is not None  # guaranteed by __post_init__
+                    group = await self.group_repo.get_group(api_user, slug)
+                    if group is None:
+                        raise errors.MissingResourceError(
+                            message=f"Group with slug {member.member_id!r} does not exist"
+                        )
+                    resolved.append((str(group.id), ResourceType.group))
+
+                case MemberType.PROJECT:
+                    path = member.project_path
+                    assert path is not None  # guaranteed by __post_init__
+                    ns_slug, proj_slug = path
+                    project = await self.project_repo.get_project_by_namespace_slug(
+                        user=api_user,
+                        namespace=ns_slug.value,
+                        slug=proj_slug,
+                    )
+                    if project is None:
+                        raise errors.MissingResourceError(message=f"Project {member.member_id!r} does not exist")
+                    resolved.append((str(project.id), ResourceType.project))
+
+        return resolved
 
     @with_db_transaction
     @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
@@ -1195,7 +1242,8 @@ class MemberRepository(_Base):
         user_ids: Collection[str],
         session: AsyncSession | None = None,
     ) -> models.ResourcePoolMembershipChange | None:
-        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.PROHIBITED, Change.REMOVE)
+        specs = [(uid, ResourceType.user, Role.PROHIBITED) for uid in user_ids]
+        return self._build_pool_membership_changes(resource_pool_id, specs, Change.REMOVE)
 
     @with_db_transaction
     @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
@@ -1206,18 +1254,63 @@ class MemberRepository(_Base):
         user_ids: Collection[str],
         session: AsyncSession | None = None,
     ) -> models.ResourcePoolMembershipChange | None:
-        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.PROHIBITED, Change.ADD)
+        specs = [(uid, ResourceType.user, Role.PROHIBITED) for uid in user_ids]
+        return self._build_pool_membership_changes(resource_pool_id, specs, Change.ADD)
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
-    async def _revoke_resource_pool_member(
+    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    async def _grant_resource_pool_members(
         self,
         api_user: base_models.APIUser,
         resource_pool_id: int,
-        user_ids: Collection[str],
-        session: AsyncSession | None = None,
+        members: Collection[ResourcePoolMemberIdentifier],
+        session: AsyncSession,
     ) -> models.ResourcePoolMembershipChange | None:
-        return self._build_pool_membership_change(user_ids, resource_pool_id, Role.VIEWER, Change.REMOVE)
+        specs = await self._resolve_members(api_user, members)
+        return self._build_pool_membership_changes(
+            resource_pool_id,
+            [(member_id, subject_type, Role.VIEWER) for member_id, subject_type in specs],
+            Change.ADD,
+        )
+
+    @with_db_transaction
+    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
+    async def _revoke_resource_pool_members(
+        self,
+        api_user: base_models.APIUser,
+        resource_pool_id: int,
+        members: Collection[ResourcePoolMemberIdentifier],
+        session: AsyncSession,
+    ) -> models.ResourcePoolMembershipChange | None:
+        specs = await self._resolve_members(api_user, members)
+        return self._build_pool_membership_changes(
+            resource_pool_id,
+            [(member_id, subject_type, Role.VIEWER) for member_id, subject_type in specs],
+            Change.REMOVE,
+        )
+
+    @_only_admins
+    async def grant_resource_pool_members(
+        self,
+        api_user: base_models.APIUser,
+        resource_pool_id: int,
+        members: Collection[ResourcePoolMemberIdentifier],
+        append: bool = True,
+    ) -> None:
+        """Grant access to a resource pool for a collection of members (Users, Groups, Projects)."""
+        async with self.session_maker() as session, session.begin():
+            await self._grant_resource_pool_members(api_user, resource_pool_id, members, session=session)
+
+    @_only_admins
+    async def revoke_resource_pool_members(
+        self,
+        api_user: base_models.APIUser,
+        resource_pool_id: int,
+        members: Collection[ResourcePoolMemberIdentifier],
+    ) -> None:
+        """Revoke access to a resource pool for a collection of members (Users, Groups, Projects)."""
+        async with self.session_maker() as session, session.begin():
+            await self._revoke_resource_pool_members(api_user, resource_pool_id, members, session=session)
 
     @_only_admins
     async def update_user(self, api_user: base_models.APIUser, keycloak_id: str, **kwargs: Any) -> base_models.User:
@@ -1242,7 +1335,7 @@ class MemberRepository(_Base):
 
                 for rp_id in default_rp_ids:
                     if no_default_access:
-                        await self._prohibit_resource_pool_user(api_user, rp_id, [keycloak_id], session=session)
+                        await self._prohibit_resource_pool_users(api_user, rp_id, [keycloak_id], session=session)
                     else:
                         await self._unprohibit_resource_pool_users(api_user, rp_id, [keycloak_id], session=session)
             return user.dump()

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1239,7 +1239,7 @@ class MemberRepository(_Base):
 
     @with_db_transaction
     @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
-    async def _prohibit_resource_pool_user(
+    async def _prohibit_resource_pool_users(
         self,
         api_user: base_models.APIUser,
         resource_pool_id: int,

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1209,24 +1209,15 @@ class MemberRepository(_Base):
                     resolved.append((kc_user.id, ResourceType.user))
 
                 case MemberType.GROUP:
-                    slug = member.group_slug
-                    assert slug is not None  # guaranteed by __post_init__
-                    group = await self.group_repo.get_group(api_user, slug)
+                    group_id = ULID.from_str(member.member_id)
+                    group = await self.group_repo.get_group_by_id(api_user, group_id)
                     if group is None:
-                        raise errors.MissingResourceError(
-                            message=f"Group with slug {member.member_id!r} does not exist"
-                        )
+                        raise errors.MissingResourceError(message=f"Group with id {member.member_id!r} does not exist")
                     resolved.append((str(group.id), ResourceType.group))
 
                 case MemberType.PROJECT:
-                    path = member.project_path
-                    assert path is not None  # guaranteed by __post_init__
-                    ns_slug, proj_slug = path
-                    project = await self.project_repo.get_project_by_namespace_slug(
-                        user=api_user,
-                        namespace=ns_slug.value,
-                        slug=proj_slug,
-                    )
+                    project_id = ULID.from_str(member.member_id)
+                    project = await self.project_repo.get_project_by_id(api_user, project_id)
                     if project is None:
                         raise errors.MissingResourceError(message=f"Project {member.member_id!r} does not exist")
                     resolved.append((str(project.id), ResourceType.project))

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from math import ceil

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from math import ceil

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -14,7 +14,7 @@ from ulid import ULID
 from renku_data_services import errors
 from renku_data_services.authz.models import MembershipChange
 from renku_data_services.base_models import ResetType
-from renku_data_services.base_models.core import ResourceType, Slug
+from renku_data_services.base_models.core import ResourceType
 from renku_data_services.k8s.constants import DEFAULT_K8S_CLUSTER, ClusterId
 from renku_data_services.k8s.models import K8sPatch, K8sResourceQuota
 
@@ -508,12 +508,8 @@ class ResourcePoolMemberIdentifier:
 
     Identifier semantics by member_type:
       - USER    : Keycloak user id (string)
-      - GROUP   : group slug, e.g. "my-group"
-      - PROJECT : project path slug, e.g. "my-group/my-project"
-
-    Groups and projects are addressed by their human-readable slug rather than
-    by internal id (ULID). This mirrors how they are referenced elsewhere in the
-    public API and avoids leaking storage identifiers into admin workflows.
+      - GROUP   : group id (ULID)
+      - PROJECT : project id (ULID)
     """
 
     member_id: str
@@ -523,49 +519,19 @@ class ResourcePoolMemberIdentifier:
         if not self.member_id or not self.member_id.strip():
             raise errors.ValidationError(message="member_id must be a non-empty string")
         match self.member_type:
-            case MemberType.GROUP:
-                Slug(self.member_id)
-            case MemberType.PROJECT:
-                # Expect exactly "<namespace-slug>/<project-slug>".
-                parts = self.member_id.split("/")
-                if len(parts) != 2 or not all(parts):
+            case MemberType.GROUP | MemberType.PROJECT:
+                try:
+                    ULID.from_str(self.member_id)
+                except ValueError as e:
                     raise errors.ValidationError(
-                        message=(
-                            f"Project identifier {self.member_id!r} must be of the form "
-                            "'<namespace-slug>/<project-slug>'"
-                        )
-                    )
-                Slug(parts[0])
-                Slug(parts[1])
+                        message=f"Member identifier {self.member_id!r} must be a valid ULID"
+                    ) from e
             case MemberType.USER:
                 pass
 
-    @property
-    def project_path(self) -> tuple[Slug, Slug] | None:
-        """Return (namespace_slug, project_slug) for PROJECT members, else None."""
-        if self.member_type is not MemberType.PROJECT:
-            return None
-        ns, proj = self.member_id.split("/", 1)
-        return Slug(ns), Slug(proj)
-
-    @property
-    def group_slug(self) -> Slug | None:
-        """Return the group Slug for GROUP members, else None."""
-        if self.member_type is not MemberType.GROUP:
-            return None
-        return Slug(self.member_id)
-
     @classmethod
     def from_resource(cls, resource_type: ResourceType, resource_id: ULID) -> ResourcePoolMemberIdentifier:
-        """Create a member identifier from an authz-backed resource reference.
-
-        .. warning::
-            This is a read-path helper. SpiceDB stores groups and projects by
-            internal id (ULID for projects), not by slug. The caller is
-            responsible for resolving those ids to slugs *before* constructing
-            a write-path identifier; otherwise the resulting object will fail
-            validation at construction time for PROJECT (and possibly GROUP).
-        """
+        """Create a member identifier from an authz-backed resource reference."""
         if resource_type == ResourceType.group:
             return cls(member_id=str(resource_id), member_type=MemberType.GROUP)
         if resource_type == ResourceType.project:

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -556,7 +556,7 @@ class ResourcePoolMemberIdentifier:
         return Slug(self.member_id)
 
     @classmethod
-    def from_resource(cls, resource_type: ResourceType, resource_id: str | ULID) -> ResourcePoolMemberIdentifier:
+    def from_resource(cls, resource_type: ResourceType, resource_id: ULID) -> ResourcePoolMemberIdentifier:
         """Create a member identifier from an authz-backed resource reference.
 
         .. warning::

--- a/components/renku_data_services/crc/models.py
+++ b/components/renku_data_services/crc/models.py
@@ -9,10 +9,12 @@ from math import ceil
 from typing import Any, Final, Optional, Protocol, Self
 
 from kubernetes.utils import parse_quantity
+from ulid import ULID
 
 from renku_data_services import errors
 from renku_data_services.authz.models import MembershipChange
 from renku_data_services.base_models import ResetType
+from renku_data_services.base_models.core import ResourceType, Slug
 from renku_data_services.k8s.constants import DEFAULT_K8S_CLUSTER, ClusterId
 from renku_data_services.k8s.models import K8sPatch, K8sResourceQuota
 
@@ -490,3 +492,82 @@ class ResourcePoolMembershipChange:
     """Returned by user-management methods so the authz_change decorator knows what to sync to SpiceDB."""
 
     changes: list[MembershipChange]
+
+
+class MemberType(StrEnum):
+    """Types of members for resource pool."""
+
+    USER = "user"
+    GROUP = "group"
+    PROJECT = "project"
+
+
+@dataclass(frozen=True, eq=True, kw_only=True)
+class ResourcePoolMemberIdentifier:
+    """Identifier for a member in a resource pool.
+
+    Identifier semantics by member_type:
+      - USER    : Keycloak user id (string)
+      - GROUP   : group slug, e.g. "my-group"
+      - PROJECT : project path slug, e.g. "my-group/my-project"
+
+    Groups and projects are addressed by their human-readable slug rather than
+    by internal id (ULID). This mirrors how they are referenced elsewhere in the
+    public API and avoids leaking storage identifiers into admin workflows.
+    """
+
+    member_id: str
+    member_type: MemberType
+
+    def __post_init__(self) -> None:
+        if not self.member_id or not self.member_id.strip():
+            raise errors.ValidationError(message="member_id must be a non-empty string")
+        match self.member_type:
+            case MemberType.GROUP:
+                Slug(self.member_id)
+            case MemberType.PROJECT:
+                # Expect exactly "<namespace-slug>/<project-slug>".
+                parts = self.member_id.split("/")
+                if len(parts) != 2 or not all(parts):
+                    raise errors.ValidationError(
+                        message=(
+                            f"Project identifier {self.member_id!r} must be of the form "
+                            "'<namespace-slug>/<project-slug>'"
+                        )
+                    )
+                Slug(parts[0])
+                Slug(parts[1])
+            case MemberType.USER:
+                pass
+
+    @property
+    def project_path(self) -> tuple[Slug, Slug] | None:
+        """Return (namespace_slug, project_slug) for PROJECT members, else None."""
+        if self.member_type is not MemberType.PROJECT:
+            return None
+        ns, proj = self.member_id.split("/", 1)
+        return Slug(ns), Slug(proj)
+
+    @property
+    def group_slug(self) -> Slug | None:
+        """Return the group Slug for GROUP members, else None."""
+        if self.member_type is not MemberType.GROUP:
+            return None
+        return Slug(self.member_id)
+
+    @classmethod
+    def from_resource(cls, resource_type: ResourceType, resource_id: str | ULID) -> ResourcePoolMemberIdentifier:
+        """Create a member identifier from an authz-backed resource reference.
+
+        .. warning::
+            This is a read-path helper. SpiceDB stores groups and projects by
+            internal id (ULID for projects), not by slug. The caller is
+            responsible for resolving those ids to slugs *before* constructing
+            a write-path identifier; otherwise the resulting object will fail
+            validation at construction time for PROJECT (and possibly GROUP).
+        """
+        if resource_type == ResourceType.group:
+            return cls(member_id=str(resource_id), member_type=MemberType.GROUP)
+        if resource_type == ResourceType.project:
+            return cls(member_id=str(resource_id), member_type=MemberType.PROJECT)
+        return cls(member_id=str(resource_id), member_type=MemberType.USER)

--- a/components/renku_data_services/migrations/versions/65f8330c4d25_authz_migrate_to_v10.py
+++ b/components/renku_data_services/migrations/versions/65f8330c4d25_authz_migrate_to_v10.py
@@ -1,0 +1,33 @@
+"""authz: migrate to v10
+
+Revision ID: 65f8330c4d25
+Revises: cd424c01676e
+Create Date: 2026-04-21 17:22:21.640693
+
+"""
+
+from renku_data_services.app_config import logging
+from renku_data_services.authz.config import AuthzConfig
+from renku_data_services.authz.schemas import v10
+
+logger = logging.getLogger(__name__)
+
+# revision identifiers, used by Alembic.
+revision = "65f8330c4d25"
+down_revision = "cd424c01676e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    config = AuthzConfig.from_env()
+    client = config.authz_client()
+    responses = v10.upgrade(client)
+    logger.info(f"Upgraded Authzed schema to v10: {responses}")
+
+
+def downgrade() -> None:
+    config = AuthzConfig.from_env()
+    client = config.authz_client()
+    responses = v10.downgrade(client)
+    logger.info(f"Downgraded Authzed schema from v10: {responses}")

--- a/components/renku_data_services/namespace/db.py
+++ b/components/renku_data_services/namespace/db.py
@@ -202,6 +202,15 @@ class GroupRepository:
             group_orm, _ = await self._get_group(session, user, slug)
         return group_orm.dump()
 
+    async def get_group_by_id(self, user: base_models.APIUser, group_id: ULID) -> models.Group:
+        """Get a group from the DB by its ID."""
+        async with self.session_maker() as session:
+            stmt = select(schemas.GroupORM).where(schemas.GroupORM.id == group_id)
+            group = await session.scalar(stmt)
+            if not group:
+                raise errors.MissingResourceError(message=f"The group with id {group_id} does not exist")
+            return group.dump()
+
     @with_db_transaction
     async def get_group_members(
         self, user: base_models.APIUser, slug: Slug, *, session: AsyncSession | None = None

--- a/components/renku_data_services/project/db.py
+++ b/components/renku_data_services/project/db.py
@@ -124,6 +124,25 @@ class ProjectRepository:
 
             return project_orm.dump(with_documentation=with_documentation)
 
+    async def get_project_by_id(self, user: base_models.APIUser, project_id: ULID) -> models.Project:
+        """Get one project from the database by ID without checking permissions.
+
+        This is intended for admin-only use cases such as resolving SpiceDB
+        subject references back to human-readable paths.
+        """
+        if not user.is_admin:
+            raise errors.ForbiddenError(message="You do not have the required permissions for this operation.")
+
+        async with self.session_maker() as session:
+            stmt = select(schemas.ProjectORM).where(schemas.ProjectORM.id == project_id)
+            result = await session.execute(stmt)
+            project_orm = result.scalars().first()
+
+            if project_orm is None:
+                raise errors.MissingResourceError(message=f"Project with id '{project_id}' does not exist.")
+
+            return project_orm.dump()
+
     async def get_all_copied_projects(
         self, user: base_models.APIUser, project_id: ULID, only_writable: bool
     ) -> list[models.Project]:

--- a/test/components/renku_data_services/authz/test_authorization.py
+++ b/test/components/renku_data_services/authz/test_authorization.py
@@ -610,6 +610,8 @@ async def test_resource_pool_member_relationships_subject_types(app_manager_inst
     """Verify that _resource_pool_membership_changes_to_authz_change uses correct subject types."""
     authz = app_manager_instance.authz
     pool_id = 9999
+    group_id = str(ULID())
+    project_id = str(ULID())
 
     pool_change = ResourcePoolMembershipChange(
         changes=[
@@ -626,7 +628,7 @@ async def test_resource_pool_member_relationships_subject_types(app_manager_inst
             MembershipChange(
                 Member(
                     role=Role.VIEWER,
-                    user_id="group-1",
+                    user_id=group_id,
                     resource_id=pool_id,
                     resource_type=ResourceType.resource_pool,
                     subject_type=ResourceType.group,
@@ -636,7 +638,7 @@ async def test_resource_pool_member_relationships_subject_types(app_manager_inst
             MembershipChange(
                 Member(
                     role=Role.VIEWER,
-                    user_id="project-1",
+                    user_id=project_id,
                     resource_id=pool_id,
                     resource_type=ResourceType.resource_pool,
                     subject_type=ResourceType.project,
@@ -659,12 +661,12 @@ async def test_resource_pool_member_relationships_subject_types(app_manager_inst
     # Group subject
     assert updates[1].relationship.relation == _Relation.group_viewer.value
     assert updates[1].relationship.subject.object.object_type == ResourceType.group
-    assert updates[1].relationship.subject.object.object_id == "group-1"
+    assert updates[1].relationship.subject.object.object_id == group_id
 
     # Project subject
     assert updates[2].relationship.relation == _Relation.project_viewer.value
     assert updates[2].relationship.subject.object.object_type == ResourceType.project
-    assert updates[2].relationship.subject.object.object_id == "project-1"
+    assert updates[2].relationship.subject.object.object_id == project_id
 
 
 _ADD_DELETE_BASE = 9100

--- a/test/components/renku_data_services/authz/test_authorization.py
+++ b/test/components/renku_data_services/authz/test_authorization.py
@@ -11,11 +11,14 @@ from authzed.api.v1 import (
 )
 from ulid import ULID
 
-from renku_data_services.authz.authz import _AuthzConverter, _Relation
-from renku_data_services.authz.models import Member, Role, Scope, Visibility
+from renku_data_services.authz.authz import AuthzOperation, _AuthzConverter, _Relation
+from renku_data_services.authz.models import Change, Member, MembershipChange, Role, Scope, Visibility
 from renku_data_services.base_models import APIUser
 from renku_data_services.base_models.core import NamespacePath, ResourceType
-from renku_data_services.crc.models import DeletedResourcePool
+from renku_data_services.crc.models import (
+    DeletedResourcePool,
+    ResourcePoolMembershipChange,
+)
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.errors import errors
 from renku_data_services.migrations.core import run_migrations_for_app
@@ -70,6 +73,57 @@ def _rel(
             resource=_AuthzConverter.resource_pool(pool_id),
             relation=relation,
             subject=SubjectReference(object=_AuthzConverter.user(user_id)),
+        ),
+    )
+
+
+def _rel_member(
+    pool_id: int,
+    relation: str,
+    member_id: str,
+    member_type: ResourceType,
+    *,
+    op: int = RelationshipUpdate.OPERATION_TOUCH,
+) -> RelationshipUpdate:
+    """Helper to create a relationship for a polymorphic member."""
+    return RelationshipUpdate(
+        operation=op,
+        relationship=Relationship(
+            resource=_AuthzConverter.resource_pool(pool_id),
+            relation=relation,
+            subject=SubjectReference(object=ObjectReference(object_type=member_type, object_id=member_id)),
+        ),
+    )
+
+
+def _rel_generic(
+    res_type: ResourceType,
+    res_id: str | int,
+    relation: str,
+    sub_type: ResourceType,
+    sub_id: str,
+    *,
+    op: int = RelationshipUpdate.OPERATION_TOUCH,
+) -> RelationshipUpdate:
+    """Helper to create any relationship in Authzed."""
+    # Use converter for type-specific object references if available, otherwise fallback
+    res_ref = (
+        _AuthzConverter.get_resource_ref(res_type, res_id)
+        if hasattr(_AuthzConverter, "get_resource_ref")
+        else ObjectReference(object_type=res_type, object_id=str(res_id))
+    )
+    sub_ref = (
+        _AuthzConverter.get_resource_ref(sub_type, sub_id)
+        if hasattr(_AuthzConverter, "get_resource_ref")
+        else ObjectReference(object_type=sub_type, object_id=sub_id)
+    )
+
+    return RelationshipUpdate(
+        operation=op,
+        relationship=Relationship(
+            resource=res_ref,
+            relation=relation,
+            subject=SubjectReference(object=sub_ref),
         ),
     )
 
@@ -551,7 +605,68 @@ async def test_resource_pool_isolation(app_manager_instance: DependencyManager, 
     assert not await authz.has_permission(regular_user1, ResourceType.resource_pool, pool_b, Scope.READ)
 
 
-# Unique ID ranges per test — avoids cross-test interference in shared SpiceDB
+@pytest.mark.asyncio
+async def test_resource_pool_member_relationships_subject_types(app_manager_instance: DependencyManager):
+    """Verify that _resource_pool_membership_changes_to_authz_change uses correct subject types."""
+    authz = app_manager_instance.authz
+    pool_id = 9999
+
+    pool_change = ResourcePoolMembershipChange(
+        changes=[
+            MembershipChange(
+                Member(
+                    role=Role.VIEWER,
+                    user_id="user-1",
+                    resource_id=pool_id,
+                    resource_type=ResourceType.resource_pool,
+                    subject_type=None,
+                ),
+                Change.ADD,
+            ),
+            MembershipChange(
+                Member(
+                    role=Role.VIEWER,
+                    user_id="group-1",
+                    resource_id=pool_id,
+                    resource_type=ResourceType.resource_pool,
+                    subject_type=ResourceType.group,
+                ),
+                Change.ADD,
+            ),
+            MembershipChange(
+                Member(
+                    role=Role.VIEWER,
+                    user_id="project-1",
+                    resource_id=pool_id,
+                    resource_type=ResourceType.resource_pool,
+                    subject_type=ResourceType.project,
+                ),
+                Change.ADD,
+            ),
+        ]
+    )
+
+    authz_change = authz._resource_pool_membership_changes_to_authz_change(pool_change, AuthzOperation.create)
+
+    updates = authz_change.apply.updates
+    assert len(updates) == 3
+
+    # User subject
+    assert updates[0].relationship.relation == _Relation.viewer.value
+    assert updates[0].relationship.subject.object.object_type == ResourceType.user
+    assert updates[0].relationship.subject.object.object_id == "user-1"
+
+    # Group subject
+    assert updates[1].relationship.relation == _Relation.group_viewer.value
+    assert updates[1].relationship.subject.object.object_type == ResourceType.group
+    assert updates[1].relationship.subject.object.object_id == "group-1"
+
+    # Project subject
+    assert updates[2].relationship.relation == _Relation.project_viewer.value
+    assert updates[2].relationship.subject.object.object_type == ResourceType.project
+    assert updates[2].relationship.subject.object.object_id == "project-1"
+
+
 _ADD_DELETE_BASE = 9100
 _UNDO_BASE = 9110
 _VISIBILITY_BASE = 9120
@@ -727,3 +842,93 @@ async def test_resource_pool_delete_cleans_all_relations(
 
     await _assert_pool_access(authz, pool_id, admin_use=False, admin_write=False, user_use=False, anon_use=False)
     assert not await authz.has_permission(regular_user2, ResourceType.resource_pool, pool_id, Scope.READ)
+
+
+_POLY_BASE = 9500
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_polymorphic_inheritance(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """Verify that members of a group or project gain access via direct_member traversal."""
+    authz = app_manager_instance.authz
+    pool_id = _POLY_BASE + 1
+    user_id = "user_poly_1"
+    group_id = "group_poly_1"
+    project_id = "project_poly_1"
+
+    # Setup: Admin and basic pool setup
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(pool_id, public=False)))
+
+    # 1. Group inheritance: pool -> group_viewer -> group -> user
+    updates = [
+        _rel_member(pool_id, "group_viewer", group_id, ResourceType.group),
+        _rel_generic(ResourceType.group, group_id, "viewer", ResourceType.user, user_id),
+    ]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=updates))
+    assert await authz.has_permission(APIUser(id=user_id), ResourceType.resource_pool, pool_id, Scope.READ)
+
+    # 2. Project inheritance: pool -> project_viewer -> project -> user
+    pool_id2 = _POLY_BASE + 2
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(pool_id2, public=False)))
+    updates = [
+        _rel_member(pool_id2, "project_viewer", project_id, ResourceType.project),
+        _rel_generic(ResourceType.project, project_id, "viewer", ResourceType.user, user_id),
+    ]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=updates))
+    assert await authz.has_permission(APIUser(id=user_id), ResourceType.resource_pool, pool_id2, Scope.READ)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_polymorphic_prohibition(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """Verify that the prohibited relation blocks access regardless of membership type."""
+    authz = app_manager_instance.authz
+    pool_id = _POLY_BASE + 3
+    user_id = "user_prohibit_1"
+    group_id = "group_prohibit_1"
+
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(pool_id, public=False)))
+
+    # Setup: user is in group, group is a viewer of pool, but user is prohibited
+    updates = [
+        _rel_member(pool_id, "group_viewer", group_id, ResourceType.group),
+        _rel_generic(ResourceType.group, group_id, "viewer", ResourceType.user, user_id),
+        _rel(pool_id, "prohibited", user_id),
+    ]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=updates))
+    assert not await authz.has_permission(APIUser(id=user_id), ResourceType.resource_pool, pool_id, Scope.READ)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_admin_bypass_polymorphic(
+    app_manager_instance: DependencyManager, bootstrap_admins
+) -> None:
+    """Verify that admins still bypass prohibition even in polymorphic pools."""
+    authz = app_manager_instance.authz
+    pool_id = _POLY_BASE + 4
+
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(pool_id, public=False)))
+    await authz.client.WriteRelationships(
+        WriteRelationshipsRequest(updates=[_rel(pool_id, "prohibited", admin_user.id)])
+    )
+    assert await authz.has_permission(admin_user, ResourceType.resource_pool, pool_id, Scope.READ)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_no_indirect_inheritance(app_manager_instance: DependencyManager, bootstrap_admins) -> None:
+    """Verify that only direct_member is traversed, not nested namespaces."""
+    authz = app_manager_instance.authz
+    pool_id = _POLY_BASE + 5
+    user_id = "user_indirect_1"
+    project_id = "project_indirect_1"
+    ns_id = "ns_indirect_1"
+
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=_pool_updates(pool_id, public=False)))
+
+    # Setup: pool -> project_viewer -> project -> namespace -> user
+    updates = [
+        _rel_member(pool_id, "project_viewer", project_id, ResourceType.project),
+        _rel_generic(ResourceType.project, project_id, "project_namespace", ResourceType.user_namespace, ns_id),
+        _rel_generic(ResourceType.user_namespace, ns_id, "owner", ResourceType.user, user_id),
+    ]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=updates))
+    assert not await authz.has_permission(APIUser(id=user_id), ResourceType.resource_pool, pool_id, Scope.READ)

--- a/test/components/renku_data_services/authz/test_schemas.py
+++ b/test/components/renku_data_services/authz/test_schemas.py
@@ -575,6 +575,138 @@ def v9_schema() -> SpiceDBSchema:
     )
 
 
+@pytest.fixture
+def v10_schema() -> SpiceDBSchema:
+    return SpiceDBSchema(
+        schemas._v10,
+        relationships=[
+            "platform:renku#admin@user:admin1",
+            # pool1: public
+            "resource_pool:pool1#public_viewer@user:*",
+            "resource_pool:pool1#public_viewer@anonymous_user:*",
+            "resource_pool:pool1#prohibited@user:user2",
+            "resource_pool:pool1#resource_pool_platform@platform:renku",
+            # pool2: private, only user3 is a direct viewer
+            "resource_pool:pool2#viewer@user:user3",
+            "resource_pool:pool2#resource_pool_platform@platform:renku",
+            "resource_pool:pool2#prohibited@user:user2",
+            # pool3: private, accessible via a group
+            "resource_pool:pool3#resource_pool_platform@platform:renku",
+            "resource_pool:pool3#group_viewer@group:group1",
+            "resource_pool:pool3#prohibited@user:user2",
+            # group1 members: user4 (owner), user5 (editor), user6 (viewer)
+            # user2 is also a viewer of the group, but prohibited on the pool
+            "group:group1#owner@user:user4",
+            "group:group1#editor@user:user5",
+            "group:group1#viewer@user:user6",
+            "group:group1#viewer@user:user2",
+            # pool4: private, accessible via a project
+            "resource_pool:pool4#resource_pool_platform@platform:renku",
+            "resource_pool:pool4#project_viewer@project:project1",
+            "resource_pool:pool4#prohibited@user:user2",
+            # project1 members: user7 (owner), user8 (editor), user9 (viewer)
+            # user2 is also a viewer on the project, but prohibited on the pool
+            "project:project1#owner@user:user7",
+            "project:project1#editor@user:user8",
+            "project:project1#viewer@user:user9",
+            "project:project1#viewer@user:user2",
+            # project1 is in a namespace where user10 is the owner; note that
+            # namespace-inherited membership must NOT grant pool access because
+            # resource_pool uses direct_member (not exclusive_member).
+            "user_namespace:ns1#owner@user:user10",
+            "project:project1#project_namespace@user_namespace:ns1",
+        ],
+        assertions={
+            "assertTrue": [
+                # pool1 public: prove the pool is public
+                "resource_pool:pool1#read@user:user1",
+                "resource_pool:pool1#read@anonymous_user:anon1",
+                "resource_pool:pool1#read@user:admin1",
+                # pool2: pool is only usable by select users
+                "resource_pool:pool2#read@user:user3",
+                "resource_pool:pool2#read@user:admin1",
+                # pool3: group members get access via group_viewer->direct_member
+                "resource_pool:pool3#read@user:user4",
+                "resource_pool:pool3#read@user:user5",
+                "resource_pool:pool3#read@user:user6",
+                "resource_pool:pool3#read@user:admin1",
+                # pool4: project members get access via project_viewer->direct_member
+                "resource_pool:pool4#read@user:user7",
+                "resource_pool:pool4#read@user:user8",
+                "resource_pool:pool4#read@user:user9",
+                "resource_pool:pool4#read@user:admin1",
+                # admin can write
+                "resource_pool:pool1#write@user:admin1",
+                "resource_pool:pool3#write@user:admin1",
+                "resource_pool:pool4#write@user:admin1",
+            ],
+            "assertFalse": [
+                # prohibited user blocked on all pools
+                "resource_pool:pool1#read@user:user2",
+                "resource_pool:pool2#read@user:user2",
+                "resource_pool:pool3#read@user:user2",
+                "resource_pool:pool4#read@user:user2",
+                # non-viewer or anon can't use private pool
+                "resource_pool:pool2#read@user:user1",
+                "resource_pool:pool2#read@anonymous_user:anon1",
+                # non-group-member can't access pool3
+                "resource_pool:pool3#read@user:user1",
+                "resource_pool:pool3#read@anonymous_user:anon1",
+                # non-project-member can't access pool4
+                "resource_pool:pool4#read@user:user1",
+                "resource_pool:pool4#read@anonymous_user:anon1",
+                # namespace owner is not a direct_member of the project,
+                # so they do NOT get pool4 access
+                "resource_pool:pool4#read@user:user10",
+                # viewer and random can't write
+                "resource_pool:pool2#write@user:user3",
+                "resource_pool:pool1#write@user:user1",
+                "resource_pool:pool3#write@user:user4",
+                "resource_pool:pool4#write@user:user7",
+            ],
+        },
+        validation={
+            # pool1: (public) list all resolution paths
+            "resource_pool:pool1#read": [
+                "[user:* - {user:user2}] is <resource_pool:pool1#public_viewer>",
+                "[anonymous_user:*] is <resource_pool:pool1#public_viewer>",
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            # pool2: (private) only viewer + admin, no wildcards
+            "resource_pool:pool2#read": [
+                "[user:user3] is <resource_pool:pool2#viewer>",
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            # pool3: (private) access via group_viewer->direct_member + admin
+            "resource_pool:pool3#read": [
+                "[user:user4] is <group:group1#owner>",
+                "[user:user5] is <group:group1#editor>",
+                "[user:user6] is <group:group1#viewer>",
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            # pool4: (private) access via project_viewer->direct_member + admin
+            "resource_pool:pool4#read": [
+                "[user:user7] is <project:project1#owner>",
+                "[user:user8] is <project:project1#editor>",
+                "[user:user9] is <project:project1#viewer>",
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            "resource_pool:pool1#write": [
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            "resource_pool:pool2#write": [
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            "resource_pool:pool3#write": [
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+            "resource_pool:pool4#write": [
+                "[user:admin1] is <platform:renku#admin>",
+            ],
+        },
+    )
+
+
 def test_v1_schema(tmp_path: Path, v1_schema: SpiceDBSchema) -> None:
     validation_file = tmp_path / "validate.yaml"
     v1_schema.to_yaml(validation_file)
@@ -608,4 +740,10 @@ def test_v7_schema(tmp_path: Path, v7_schema: SpiceDBSchema) -> None:
 def test_v9_schema(tmp_path: Path, v9_schema: SpiceDBSchema) -> None:
     validation_file = tmp_path / "validate.yaml"
     v9_schema.to_yaml(validation_file)
+    check_call(["zed", "validate", validation_file.as_uri()])
+
+
+def test_v10_schema(tmp_path: Path, v10_schema: SpiceDBSchema) -> None:
+    validation_file = tmp_path / "validate.yaml"
+    v10_schema.to_yaml(validation_file)
     check_call(["zed", "validate", validation_file.as_uri()])

--- a/test/components/renku_data_services/data_api/test_config.py
+++ b/test/components/renku_data_services/data_api/test_config.py
@@ -32,7 +32,7 @@ def test_config_dummy(dependencies_dummy_fixture: DependencyManager) -> None:
     assert isinstance(dm.authenticator, DummyAuthenticator)
     assert dm.storage_repo is not None
     assert dm.rp_repo is not None
-    assert dm.user_repo is not None
+    assert dm.member_repo is not None
     assert dm.project_repo is not None
     assert dm.session_repo is not None
     assert dm.user_preferences_repo is not None
@@ -86,7 +86,7 @@ def test_config_no_dummy(config_no_dummy_fixture: DependencyManager) -> None:
     assert config.authenticator is not None
     assert config.storage_repo is not None
     assert config.rp_repo is not None
-    assert config.user_repo is not None
+    assert config.member_repo is not None
     assert config.project_repo is not None
     assert config.session_repo is not None
     assert config.user_preferences_repo is not None

--- a/test/components/renku_data_services/data_api/test_config.py
+++ b/test/components/renku_data_services/data_api/test_config.py
@@ -19,6 +19,7 @@ from renku_data_services.users.dummy_kc_api import DummyKeycloakAPI
 async def dependencies_dummy_fixture(monkeypatch):
     monkeypatch.setenv("DUMMY_STORES", "true")
     monkeypatch.setenv("VERSION", "9.9.9")
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "default")
     yield DependencyManager.from_env()
     # NOTE: _async_engine is a class variable and it persist across tests because pytest loads
     # all things once at the beginning of hte tests. So we reset it here so that it does not affect

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -477,7 +477,7 @@ async def test_resource_pools_access_control(
     inserted_public_rp = None
     inserted_private_rp = None
     pool_repo = app_manager_instance.rp_repo
-    user_repo = app_manager_instance.user_repo
+    member_repo = app_manager_instance.member_repo
     try:
         inserted_public_rp = await create_rp(public_rp, pool_repo, admin_user)
         assert inserted_public_rp.id is not None
@@ -491,11 +491,11 @@ async def test_resource_pools_access_control(
         assert any(inserted_private_rp.id == rp.id for rp in admin_rps)
         assert loggedin_user.id is not None
         user_to_add = base_models.User(keycloak_id=loggedin_user.id)
-        updated_users = await user_repo.update_resource_pool_users(
+        updated_members = await member_repo.update_resource_pool_users(
             admin_user, inserted_private_rp.id, [loggedin_user.id], append=True
         )
 
-        assert user_to_add in [remove_id_from_user(user) for user in updated_users]
+        assert user_to_add in [remove_id_from_user(user) for user in updated_members]
         loggedin_user_rps = await pool_repo.get_resource_pools(loggedin_user)
         assert any(inserted_private_rp.id == rp.id for rp in loggedin_user_rps)
     except (ValidationError, errors.ValidationError):

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -572,30 +572,17 @@ async def test_classes_filtering(
 async def test_member_repository_polymorphic_membership(
     app_manager_instance: DependencyManager,
     admin_user: base_models.APIUser,
+    cluster: KindCluster,
 ) -> None:
     run_migrations_for_app("common")
-
-    # Mock quotas_repo to avoid K8s client errors
-    mock_quotas_repo = AsyncMock()
-    mock_quota = models.Quota(cpu=10.0, memory=100, gpu=0, id="mock-quota-id")
-
-    # Configure async methods
-    mock_quotas_repo.create_quota = AsyncMock(return_value=mock_quota)
-    mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
-
-    app_manager_instance.quotas_repo = mock_quotas_repo
-    app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
-
-    # Ensure admin user exists in the database
-    await app_manager_instance.kc_user_repo._add_api_user(admin_user)
-
     member_repo = app_manager_instance.member_repo
-
     pool_repo = app_manager_instance.rp_repo
     group_repo = app_manager_instance.group_repo
     project_repo = app_manager_instance.project_repo
 
-    # Create a resource pool
+    # Ensure admin user exists in the database
+    await app_manager_instance.kc_user_repo._add_api_user(admin_user)
+
     rp = models.UnsavedResourcePool(
         name="test-poly-pool",
         classes=[],
@@ -617,17 +604,24 @@ async def test_member_repository_polymorphic_membership(
 
     # 2. Test Group membership
     group_slug = "group-456"
-    member_group = ResourcePoolMemberIdentifier(member_type=MemberType.GROUP, member_id=group_slug)
+    # Group doesn't exist yet, should fail
+    group_ulid = str(ULID())
+    member_group = ResourcePoolMemberIdentifier(member_type=MemberType.GROUP, member_id=group_ulid)
     with pytest.raises(errors.MissingResourceError):
         await member_repo.grant_resource_pool_members(admin_user, rp_id, [member_group])
 
-    await group_repo.insert_group(admin_user, namespace_models.UnsavedGroup(slug=group_slug, name="Test Group"))
+    # Now insert the group and retry with its actual ULID
+    inserted_group = await group_repo.insert_group(
+        admin_user, namespace_models.UnsavedGroup(slug=group_slug, name="Test Group")
+    )
 
-    group_member = models.ResourcePoolMemberIdentifier(member_type=models.MemberType.GROUP, member_id=group_slug)
+    group_member = models.ResourcePoolMemberIdentifier(
+        member_type=models.MemberType.GROUP, member_id=str(inserted_group.id)
+    )
     await member_repo.grant_resource_pool_members(admin_user, rp_id, [group_member])
 
-    # 3. Test Project membership (addressed as "<namespace-slug>/<project-slug>")
-    await project_repo.insert_project(
+    # 3. Test Project membership
+    inserted_project = await project_repo.insert_project(
         admin_user,
         project_models.UnsavedProject(
             name="Test Project",
@@ -638,19 +632,16 @@ async def test_member_repository_polymorphic_membership(
         ),
     )
 
-    project_path = f"{group_slug}/test-proj"
-    project_member = ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id=project_path)
+    project_member = ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id=str(inserted_project.id))
     await member_repo.grant_resource_pool_members(admin_user, rp_id, [project_member])
 
-    # 4. Test failure for non-existent group
+    # 4. Test failure for non-existent group (valid ULID format, but not in DB)
     with pytest.raises(errors.MissingResourceError):
-        bad_group = models.ResourcePoolMemberIdentifier(
-            member_type=models.MemberType.GROUP, member_id="non-existent-group"
-        )
+        bad_group = models.ResourcePoolMemberIdentifier(member_type=models.MemberType.GROUP, member_id=str(ULID()))
         await member_repo.grant_resource_pool_members(admin_user, rp_id, [bad_group])
 
     # 5. Test failure for non-existent project
-    # 5a. Non-existent project (well-formed path, but not in DB)
+    # 5a. Non-existent project (valid ULID, but not in DB)
     with pytest.raises(errors.MissingResourceError):
         await member_repo.grant_resource_pool_members(
             admin_user,
@@ -658,13 +649,13 @@ async def test_member_repository_polymorphic_membership(
             [
                 ResourcePoolMemberIdentifier(
                     member_type=MemberType.PROJECT,
-                    member_id=f"{group_slug}/does-not-exist",
+                    member_id=str(ULID()),
                 )
             ],
         )
 
-    # 5b. Malformed project identifier (ULID, bare slug, empty segment) rejected at construction.
-    for bad in (str(ULID()), "just-a-slug", "ns/", "/proj", "ns//proj"):
+    # 5b. Malformed project identifier (not a ULID) rejected at construction.
+    for bad in ("not-a-ulid", "just-a-slug", "ns/", "/proj", "ns//proj"):
         with pytest.raises(errors.ValidationError):
             ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id=bad)
 
@@ -792,48 +783,3 @@ async def test_member_repository_rejects_bad_project_id(
             inserted_rp.id,
             [ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id="not-a-ulid")],
         )
-
-
-@pytest.mark.asyncio
-@pytest.mark.xdist_group("sessions")
-async def test_member_repository_accepts_group_by_either_identifier(
-    app_manager_instance: DependencyManager,
-    admin_user: base_models.APIUser,
-) -> None:
-    run_migrations_for_app("common")
-
-    mock_quotas_repo = AsyncMock()
-    mock_quota = models.Quota(cpu=10.0, memory=100, gpu=0, id="mock-quota-id")
-    mock_quotas_repo.create_quota = AsyncMock(return_value=mock_quota)
-    mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
-    app_manager_instance.quotas_repo = mock_quotas_repo
-    app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
-
-    await app_manager_instance.kc_user_repo._add_api_user(admin_user)
-
-    member_repo = app_manager_instance.member_repo
-    pool_repo = app_manager_instance.rp_repo
-    group_repo = app_manager_instance.group_repo
-
-    rp = models.UnsavedResourcePool(
-        name="test-group-ident-pool",
-        classes=[],
-        quota=models.UnsavedQuota(cpu=10.0, memory=100, gpu=0),
-        public=False,
-        default=False,
-        platform=models.RuntimePlatform.linux_amd64,
-    )
-    inserted_rp = await create_rp(rp, pool_repo, admin_user)
-
-    group_slug = "group-ident"
-    await group_repo.insert_group(
-        admin_user,
-        namespace_models.UnsavedGroup(slug=group_slug, name="Ident Group"),
-    )
-
-    ident = group_slug
-    await member_repo.grant_resource_pool_members(
-        admin_user,
-        inserted_rp.id,
-        [ResourcePoolMemberIdentifier(member_type=MemberType.GROUP, member_id=ident)],
-    )

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -1,15 +1,22 @@
 from dataclasses import asdict
+from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
+from ulid import ULID
 
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
+from renku_data_services.authz.models import Visibility
+from renku_data_services.base_models import APIUser
 from renku_data_services.crc import models
+from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
+from renku_data_services.namespace import models as namespace_models
+from renku_data_services.project import models as project_models
 from test.components.renku_data_services.crc_models.hypothesis import (
     a_name,
     a_uuid_string,
@@ -490,6 +497,7 @@ async def test_resource_pools_access_control(
         assert all(inserted_private_rp.id != rp.id for rp in loggedin_user_rps)
         assert any(inserted_private_rp.id == rp.id for rp in admin_rps)
         assert loggedin_user.id is not None
+        await app_manager_instance.kc_user_repo._add_api_user(loggedin_user)
         user_to_add = base_models.User(keycloak_id=loggedin_user.id)
         updated_members = await member_repo.update_resource_pool_users(
             admin_user, inserted_private_rp.id, [loggedin_user.id], append=True
@@ -557,3 +565,275 @@ async def test_classes_filtering(
             await pool_repo.delete_resource_pool(admin_user, inserted_rp1.id)
         if inserted_rp2 is not None:
             await pool_repo.delete_resource_pool(admin_user, inserted_rp2.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_member_repository_polymorphic_membership(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+) -> None:
+    run_migrations_for_app("common")
+
+    # Mock quotas_repo to avoid K8s client errors
+    mock_quotas_repo = AsyncMock()
+    mock_quota = models.Quota(cpu=10.0, memory=100, gpu=0, id="mock-quota-id")
+
+    # Configure async methods
+    mock_quotas_repo.create_quota = AsyncMock(return_value=mock_quota)
+    mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
+
+    app_manager_instance.quotas_repo = mock_quotas_repo
+    app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
+
+    # Ensure admin user exists in the database
+    await app_manager_instance.kc_user_repo._add_api_user(admin_user)
+
+    member_repo = app_manager_instance.member_repo
+
+    pool_repo = app_manager_instance.rp_repo
+    group_repo = app_manager_instance.group_repo
+    project_repo = app_manager_instance.project_repo
+
+    # Create a resource pool
+    rp = models.UnsavedResourcePool(
+        name="test-poly-pool",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=10.0, memory=100, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+    inserted_rp = await create_rp(rp, pool_repo, admin_user)
+
+    rp_id = inserted_rp.id
+
+    # 1. Test User membership
+    user_id = "user-123"
+    # Ensure user exists in the database
+    await app_manager_instance.kc_user_repo._add_api_user(APIUser(id=user_id, full_name="Test User"))
+    member = models.ResourcePoolMemberIdentifier(member_type=models.MemberType.USER, member_id=user_id)
+    await member_repo.grant_resource_pool_members(admin_user, rp_id, [member])
+
+    # 2. Test Group membership
+    group_slug = "group-456"
+    member_group = ResourcePoolMemberIdentifier(member_type=MemberType.GROUP, member_id=group_slug)
+    with pytest.raises(errors.MissingResourceError):
+        await member_repo.grant_resource_pool_members(admin_user, rp_id, [member_group])
+
+    await group_repo.insert_group(admin_user, namespace_models.UnsavedGroup(slug=group_slug, name="Test Group"))
+
+    group_member = models.ResourcePoolMemberIdentifier(member_type=models.MemberType.GROUP, member_id=group_slug)
+    await member_repo.grant_resource_pool_members(admin_user, rp_id, [group_member])
+
+    # 3. Test Project membership (addressed as "<namespace-slug>/<project-slug>")
+    await project_repo.insert_project(
+        admin_user,
+        project_models.UnsavedProject(
+            name="Test Project",
+            slug="test-proj",
+            namespace=group_slug,
+            visibility=Visibility.PUBLIC,
+            created_by=admin_user.id,
+        ),
+    )
+
+    project_path = f"{group_slug}/test-proj"
+    project_member = ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id=project_path)
+    await member_repo.grant_resource_pool_members(admin_user, rp_id, [project_member])
+
+    # 4. Test failure for non-existent group
+    with pytest.raises(errors.MissingResourceError):
+        bad_group = models.ResourcePoolMemberIdentifier(
+            member_type=models.MemberType.GROUP, member_id="non-existent-group"
+        )
+        await member_repo.grant_resource_pool_members(admin_user, rp_id, [bad_group])
+
+    # 5. Test failure for non-existent project
+    # 5a. Non-existent project (well-formed path, but not in DB)
+    with pytest.raises(errors.MissingResourceError):
+        await member_repo.grant_resource_pool_members(
+            admin_user,
+            rp_id,
+            [
+                ResourcePoolMemberIdentifier(
+                    member_type=MemberType.PROJECT,
+                    member_id=f"{group_slug}/does-not-exist",
+                )
+            ],
+        )
+
+    # 5b. Malformed project identifier (ULID, bare slug, empty segment) rejected at construction.
+    for bad in (str(ULID()), "just-a-slug", "ns/", "/proj", "ns//proj"):
+        with pytest.raises(errors.ValidationError):
+            ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id=bad)
+
+    # 5c. Malformed group identifier rejected at construction.
+    with pytest.raises(errors.ValidationError):
+        ResourcePoolMemberIdentifier(member_type=MemberType.GROUP, member_id="not a slug!")
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_member_repository_revoke_membership(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    member_repo = app_manager_instance.member_repo
+    pool_repo = app_manager_instance.rp_repo
+
+    # Create a resource pool
+    rp = models.UnsavedResourcePool(
+        name="test-revoke-pool",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=10.0, memory=100, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+    inserted_rp = await create_rp(rp, pool_repo, admin_user)
+    rp_id = inserted_rp.id
+
+    user_id = "user-revoke"
+    # Ensure user exists in the database
+    await app_manager_instance.kc_user_repo._add_api_user(APIUser(id=user_id, full_name="Revoke User"))
+    member_user = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=user_id)
+
+    # Grant
+    await member_repo.grant_resource_pool_members(admin_user, rp_id, [member_user])
+
+    # Revoke
+    await member_repo.revoke_resource_pool_members(admin_user, rp_id, [member_user])
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_member_repository_rejects_unknown_user(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+) -> None:
+    run_migrations_for_app("common")
+
+    mock_quotas_repo = AsyncMock()
+    mock_quota = models.Quota(cpu=10.0, memory=100, gpu=0, id="mock-quota-id")
+    mock_quotas_repo.create_quota = AsyncMock(return_value=mock_quota)
+    mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
+    app_manager_instance.quotas_repo = mock_quotas_repo
+    app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
+
+    await app_manager_instance.kc_user_repo._add_api_user(admin_user)
+
+    member_repo = app_manager_instance.member_repo
+    pool_repo = app_manager_instance.rp_repo
+
+    rp = models.UnsavedResourcePool(
+        name="test-user-validation-pool",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=10.0, memory=100, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+    inserted_rp = await create_rp(rp, pool_repo, admin_user)
+
+    # Empty id -> ValidationError
+    with pytest.raises(errors.ValidationError):
+        await member_repo.grant_resource_pool_members(
+            admin_user,
+            inserted_rp.id,
+            [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id="")],
+        )
+
+    # Unknown keycloak id -> MissingResourceError
+    with pytest.raises(errors.MissingResourceError):
+        await member_repo.grant_resource_pool_members(
+            admin_user,
+            inserted_rp.id,
+            [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id="does-not-exist")],
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_member_repository_rejects_bad_project_id(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+) -> None:
+    run_migrations_for_app("common")
+
+    mock_quotas_repo = AsyncMock()
+    mock_quota = models.Quota(cpu=10.0, memory=100, gpu=0, id="mock-quota-id")
+    mock_quotas_repo.create_quota = AsyncMock(return_value=mock_quota)
+    mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
+    app_manager_instance.quotas_repo = mock_quotas_repo
+    app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
+
+    await app_manager_instance.kc_user_repo._add_api_user(admin_user)
+
+    member_repo = app_manager_instance.member_repo
+    pool_repo = app_manager_instance.rp_repo
+
+    rp = models.UnsavedResourcePool(
+        name="test-bad-project-id-pool",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=10.0, memory=100, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+    inserted_rp = await create_rp(rp, pool_repo, admin_user)
+
+    # Malformed ULID -> ValidationError
+    with pytest.raises(errors.ValidationError):
+        await member_repo.grant_resource_pool_members(
+            admin_user,
+            inserted_rp.id,
+            [ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id="not-a-ulid")],
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_member_repository_accepts_group_by_either_identifier(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+) -> None:
+    run_migrations_for_app("common")
+
+    mock_quotas_repo = AsyncMock()
+    mock_quota = models.Quota(cpu=10.0, memory=100, gpu=0, id="mock-quota-id")
+    mock_quotas_repo.create_quota = AsyncMock(return_value=mock_quota)
+    mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
+    app_manager_instance.quotas_repo = mock_quotas_repo
+    app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
+
+    await app_manager_instance.kc_user_repo._add_api_user(admin_user)
+
+    member_repo = app_manager_instance.member_repo
+    pool_repo = app_manager_instance.rp_repo
+    group_repo = app_manager_instance.group_repo
+
+    rp = models.UnsavedResourcePool(
+        name="test-group-ident-pool",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=10.0, memory=100, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+    inserted_rp = await create_rp(rp, pool_repo, admin_user)
+
+    group_slug = "group-ident"
+    await group_repo.insert_group(
+        admin_user,
+        namespace_models.UnsavedGroup(slug=group_slug, name="Ident Group"),
+    )
+
+    ident = group_slug
+    await member_repo.grant_resource_pool_members(
+        admin_user,
+        inserted_rp.id,
+        [ResourcePoolMemberIdentifier(member_type=MemberType.GROUP, member_id=ident)],
+    )

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -713,6 +713,7 @@ async def test_member_repository_rejects_unknown_user(
     mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
     app_manager_instance.quotas_repo = mock_quotas_repo
     app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
+    app_manager_instance.rp_repo._ResourcePoolRepository__query_repository.quotas_repo = mock_quotas_repo
 
     await app_manager_instance.kc_user_repo._add_api_user(admin_user)
 
@@ -760,6 +761,7 @@ async def test_member_repository_rejects_bad_project_id(
     mock_quotas_repo.get_quota = AsyncMock(return_value=mock_quota)
     app_manager_instance.quotas_repo = mock_quotas_repo
     app_manager_instance.rp_repo.quotas_repo = mock_quotas_repo
+    app_manager_instance.rp_repo._ResourcePoolRepository__query_repository.quotas_repo = mock_quotas_repo
 
     await app_manager_instance.kc_user_repo._add_api_user(admin_user)
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -343,10 +343,18 @@ class TestDependencyManager(DependencyManager):
             metrics=metrics_mock,
             authz=authz,
         )
+        project_repo = ProjectRepository(
+            session_maker=config.db.async_session_maker,
+            authz=authz,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+        )
         member_repo = MemberRepository(
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
+            group_repo=group_repo,
+            project_repo=project_repo,
             authz=authz,
         )
         resource_requests_repo = ResourceRequestsRepo(session_maker=config.db.async_session_maker)
@@ -365,12 +373,6 @@ class TestDependencyManager(DependencyManager):
             secret_service_public_key=config.secrets.public_key,
         )
         reprovisioning_repo = ReprovisioningRepository(session_maker=config.db.async_session_maker)
-        project_repo = ProjectRepository(
-            session_maker=config.db.async_session_maker,
-            authz=authz,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-        )
 
         git_repositories_repo = gitrepositoriesrepository_class(
             session_maker=config.db.async_session_maker,

--- a/test/utils.py
+++ b/test/utils.py
@@ -33,7 +33,7 @@ from renku_data_services.capacity_reservation.db import CapacityReservationRepos
 from renku_data_services.connected_services.db import ConnectedServicesRepository
 from renku_data_services.connected_services.oauth_http import DefaultOAuthHttpClientFactory
 from renku_data_services.crc import models as rp_models
-from renku_data_services.crc.db import ClusterRepository, QuotaRepository, ResourcePoolRepository, UserRepository
+from renku_data_services.crc.db import ClusterRepository, MemberRepository, QuotaRepository, ResourcePoolRepository
 from renku_data_services.data_api.config import Config
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.data_connectors.db import DataConnectorRepository, DataConnectorSecretRepository
@@ -343,8 +343,7 @@ class TestDependencyManager(DependencyManager):
             metrics=metrics_mock,
             authz=authz,
         )
-
-        user_repo = UserRepository(
+        member_repo = MemberRepository(
             session_maker=config.db.async_session_maker,
             quotas_repo=quota_repo,
             user_repo=kc_user_repo,
@@ -480,7 +479,7 @@ class TestDependencyManager(DependencyManager):
             user_store=user_store,
             quota_repo=quota_repo,
             kc_api=kc_api,
-            user_repo=user_repo,
+            member_repo=member_repo,
             rp_repo=rp_repo,
             storage_repo=storage_repo,
             reprovisioning_repo=reprovisioning_repo,


### PR DESCRIPTION
## Summary

This PR extends resource pool authorization to support **group-level and project-level membership**, in addition to individual users. It introduces a new Authzed schema (v10) with `group_viewer` and `project_viewer` relations, refactors the CRC user repository into a polymorphic `MemberRepository`, and adds comprehensive tests for inheritance, prohibition, and edge cases.

## Motivation

Previously, resource pools could only be shared with individual users via direct `viewer` relations or blocked via `prohibited`. This did not scale for organizations that manage access through Renku groups or projects. By allowing groups and projects as first-class members of resource pools, access control becomes declarative and maintainable at the team level.

## Changes

### Authz / SpiceDB Schema
- **New schema v10** (`components/renku_data_services/authz/schemas.py`):
  - Added `group_viewer` and `project_viewer` relations on `resource_pool`.
  - `read` permission now traverses `group_viewer->direct_member` and `project_viewer->direct_member` to resolve inherited access.
  - Preserved existing `viewer`, `public_viewer`, `prohibited`, and `resource_pool_platform->is_admin` semantics.
- **Migration** (`migrations/versions/65f8330c4d25_authz_migrate_to_v10.py`):
  - Upgrades/downgrades Authzed schema with proper relationship cleanup on rollback.

### Domain Models
- Added `MemberType` enum and `ResourcePoolMemberIdentifier` dataclass (`crc/models.py`) to represent polymorphic members (USER, GROUP, PROJECT) with ULID validation for non-user types.
- Extended `Member` model with `subject_type` field (`authz/models.py`) so membership changes carry the target resource type.
- Added `Member.with_resource_pool()` factory for building resource-pool-specific members.

### Repository Refactor
- Renamed `UserRepository` → `MemberRepository` (`crc/db.py`) to reflect its broader scope.
- Injected `GroupRepository` and `ProjectRepository` into `MemberRepository` for resolving group/project identifiers.
- Refactored internal methods:
  - `_grant_resource_pool_members`, `_revoke_resource_pool_members`, `_prohibit_resource_pool_users`, `_unprohibit_resource_pool_users` now accept `ResourcePoolMemberIdentifier` collections.
  - Added `_resolve_members()` to validate and map members to `(id, ResourceType)` tuples, rejecting missing groups/projects with `MissingResourceError`.
- Added public `grant_resource_pool_members` / `revoke_resource_pool_members` admin-only methods.

### Dependency Wiring
- Updated `DependencyManager`, blueprints, and app registration to use `member_repo` instead of `user_repo` throughout `data_api`.

### Supporting Queries
- Added `GroupRepository.get_group_by_id()` (used internally for member resolution).
- Added `ProjectRepository.get_project_by_id()` (admin-only, for resolving project references back to human-readable paths).

### Tests
- **Schema tests** (`test_schemas.py`): Full v10 fixture with `assertTrue`/`assertFalse` and validation paths for public, private, group-inherited, and project-inherited pools.
- **Authorization tests** (`test_authorization.py`):
  - `test_resource_pool_member_relationships_subject_types`: verifies correct subject types in authz updates.
  - `test_resource_pool_polymorphic_inheritance`: confirms group/project members gain access via `direct_member`.
  - `test_resource_pool_polymorphic_prohibition`: confirms `prohibited` still blocks regardless of membership type.
  - `test_resource_pool_admin_bypass_polymorphic`: confirms admin bypass.
  - `test_resource_pool_no_indirect_inheritance`: confirms only `direct_member` is traversed (not namespace owners).

## Backward Compatibility

- Existing user-only pools continue to work unchanged.
- The old `viewer` relation on `resource_pool` is preserved; only `group_viewer` and `project_viewer` are new.
- The DB migration is reversible (downgrade restores v9 and deletes v10 resource_pool relationships).
- **Warning**: Downgrading removes the group_viewer and project_viewer relationship, revoking access to the resource pool.

## Checklist

- [x] Authzed schema v10 defined and migrated
- [x] `MemberRepository` supports user/group/project identifiers
- [x] Admin-only grant/revoke API surface ready
- [x] SpiceDB schema tests pass for inheritance and prohibition
- [x] Authorization integration tests pass

## PR Stack

* base: #1311 
  * [this](#1267)
    * #1299 
  
/deploy