### PR TITLE
fix: error type when rejecting session start

### DIFF
--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -799,6 +799,7 @@ class Authz:
                     result = await f(db_repo, *args, **kwargs)
                     authz_change = await _get_authz_change(db_repo, op, resource, result, *args, **kwargs)
                     await db_repo.authz.client.WriteRelationships(authz_change.apply)
+                    await session.commit()
                     return result
                 except Exception as err:
                     db_rollback_err = None

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -799,7 +799,6 @@ class Authz:
                     result = await f(db_repo, *args, **kwargs)
                     authz_change = await _get_authz_change(db_repo, op, resource, result, *args, **kwargs)
                     await db_repo.authz.client.WriteRelationships(authz_change.apply)
-                    await session.commit()
                     return result
                 except Exception as err:
                     db_rollback_err = None

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -830,7 +830,13 @@ async def start_session(
     git_providers = await git_provider_helper.get_providers(user=user)
     repositories = repositories_from_project(project, git_providers)
 
-    if environment.build_parameters is not None:
+    #    and builds_config.build_output_private_image_prefix is not None
+    #         and image.startswith(builds_config.build_output_private_image_prefix)
+    if (
+        environment.build_parameters is not None
+        and builds_config.build_output_private_image_prefix
+        and image.startswith(builds_config.build_output_private_image_prefix)
+    ):
         build_repository = environment.build_parameters.repository
         if build_repository not in [repository.url for repository in repositories]:
             raise errors.ValidationError(message="Image was not built from a repository in this project")
@@ -839,14 +845,14 @@ async def start_session(
             repository_url=build_repository, user=user, etag=None, internal_gitlab_user=internal_gitlab_user
         )
 
-        logger.info(f"environment.build_parameters.repository => repo_data = {repo_data}")
-
-        if repo_data.is_error:
-            raise errors.ValidationError(message=str(repo_data.error))
-        if isinstance(repo_data.metadata, RepoMetadata):
-            metadata: RepoMetadata = repo_data.metadata
-            if not metadata.pull_permission:
-                raise errors.ForbiddenError(message="User does not have access to image repository")
+        if (
+            repo_data.is_error
+            or not isinstance(repo_data.metadata, RepoMetadata)
+            or not repo_data.metadata.pull_permission
+        ):
+            raise errors.ForbiddenError(
+                message="You do not have pull access to the code repository used for this session."
+            )
 
     # User secrets
     session_extras = SessionExtraResources()

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -830,8 +830,6 @@ async def start_session(
     git_providers = await git_provider_helper.get_providers(user=user)
     repositories = repositories_from_project(project, git_providers)
 
-    #    and builds_config.build_output_private_image_prefix is not None
-    #         and image.startswith(builds_config.build_output_private_image_prefix)
     if (
         environment.build_parameters is not None
         and builds_config.build_output_private_image_prefix

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -843,7 +843,7 @@ async def start_session(
         if isinstance(repo_data.metadata, RepoMetadata):
             metadata: RepoMetadata = repo_data.metadata
             if not metadata.pull_permission:
-                raise errors.ValidationError(message="User does not have access to image repository")
+                raise errors.ForbiddenError(message="User does not have access to image repository")
 
     # User secrets
     session_extras = SessionExtraResources()

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -838,6 +838,9 @@ async def start_session(
         repo_data = await git_repositories_repo.get_repository(
             repository_url=build_repository, user=user, etag=None, internal_gitlab_user=internal_gitlab_user
         )
+
+        logger.info(f"environment.build_parameters.repository => repo_data = {repo_data}")
+
         if repo_data.is_error:
             raise errors.ValidationError(message=str(repo_data.error))
         if isinstance(repo_data.metadata, RepoMetadata):


### PR DESCRIPTION
Closes #1270.

<code>
/deploy renku=feat/private-repository-build renku-ui=feat/build-private-repositories extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-ci-private-images-build-public-project/,dataService.imageBuilders.outputPrivateImagePrefix=harbor.dev.renku.ch/renku-ci-private-images-build-private-project/,dataService.imageBuilders.pushSecretName=harbor-public-session,dataService.imageBuilders.pushPrivateSecretName=harbor-private-session,dataService.imageBuilders.pullPrivateSecretName=harbor-private-session,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user
</code>