### PR TITLE
fix(sessions): use image pull secret from private build registry correctly

### DIFF
--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -928,8 +928,8 @@ async def start_session(
         image_check_repo=image_check_repo,
         builds_config=builds_config,
     )
-    # Adopt being false means the returned secret already exists and should be used as is
-    if image_secret and image_secret.adopt:
+
+    if image_secret and image_secret.secret.data is not None:
         session_extras = session_extras.concat(SessionExtraResources(secrets=[image_secret]))
 
     # Remote session configuration
@@ -1244,8 +1244,7 @@ async def patch_session(
         builds_config=builds_config,
     )
     if image_pull_secret:
-        # Adopt being false means the returned secret already exists and should be used as is
-        if image_pull_secret.adopt:
+        if image_pull_secret.secret.data is not None:
             session_extras = session_extras.concat(SessionExtraResources(secrets=[image_pull_secret]))
         patch.spec.imagePullSecrets = [ImagePullSecret(name=image_pull_secret.name, adopt=image_pull_secret.adopt)]
     else:

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -928,7 +928,8 @@ async def start_session(
         image_check_repo=image_check_repo,
         builds_config=builds_config,
     )
-    if image_secret:
+    # Adopt being false means the returned secret already exists and should be used as is
+    if image_secret and image_secret.adopt:
         session_extras = session_extras.concat(SessionExtraResources(secrets=[image_secret]))
 
     # Remote session configuration
@@ -1243,7 +1244,9 @@ async def patch_session(
         builds_config=builds_config,
     )
     if image_pull_secret:
-        session_extras = session_extras.concat(SessionExtraResources(secrets=[image_pull_secret]))
+        # Adopt being false means the returned secret already exists and should be used as is
+        if image_pull_secret.adopt:
+            session_extras = session_extras.concat(SessionExtraResources(secrets=[image_pull_secret]))
         patch.spec.imagePullSecrets = [ImagePullSecret(name=image_pull_secret.name, adopt=image_pull_secret.adopt)]
     else:
         patch.spec.imagePullSecrets = RESET


### PR DESCRIPTION
## Describe your changes

When retrieving the image pull secret to be used by a session, if
it's an existing secret, do not add it to the extra resources to
be created.

This is the case for the registry used to store the images built
out of private repositories.

