### PR TITLE
fix: set priority class name when resuming a session

### DIFF
--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -799,6 +799,7 @@ class Authz:
                     result = await f(db_repo, *args, **kwargs)
                     authz_change = await _get_authz_change(db_repo, op, resource, result, *args, **kwargs)
                     await db_repo.authz.client.WriteRelationships(authz_change.apply)
+                    await session.commit()
                     return result
                 except Exception as err:
                     db_rollback_err = None

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1169,8 +1169,7 @@ async def patch_session(
         # Affinities
         patch.spec.affinity = node_affinity_patch_from_resource_class(rc, nb_config.sessions.affinity_model)
         # Priority class (if a quota is being used)
-        if rc.quota is None:
-            patch.spec.priorityClassName = RESET
+        patch.spec.priorityClassName = rc.quota if rc.quota else RESET
         # Service account name
         if rp.cluster is not None:
             patch.spec.service_account_name = (

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -83,6 +83,8 @@ from renku_data_services.notebooks.crs import (
     State,
     Storage,
     Template,
+    TemplateMetadataPatch,
+    TemplatePatch,
     TlsSecret,
 )
 from renku_data_services.notebooks.data_sources import DataSourceRepository
@@ -1158,14 +1160,23 @@ async def patch_session(
         if not patch.metadata:
             patch.metadata = AmaltheaSessionV1Alpha1MetadataPatch()
         # Patch the resource pool and class ID in the annotations
-        patch.metadata.annotations = {"renku.io/resource_pool_id": str(rp.id)}
-        patch.metadata.annotations = {"renku.io/resource_class_id": str(body.resource_class_id)}
+        annotations: dict[str, str | ResetType] = dict()
+        annotations.update(session.metadata.annotations)
+        annotations["renku.io/resource_class_id"] = str(rc.id)
+        annotations["renku.io/resource_pool_id"] = str(rp.id)
+        patch.metadata.annotations = annotations
+        # Patch the resource pool and class ID in the template annotations
+        annotations: dict[str, str | ResetType] = dict()
+        if session.spec.template and session.spec.template.metadata and session.spec.template.metadata.annotations:
+            annotations.update(session.spec.template.metadata.annotations)
+        annotations["renku.io/resource_class_id"] = str(rc.id)
+        annotations["renku.io/resource_pool_id"] = str(rp.id)
+        patch.spec.template = TemplatePatch(metadata=TemplateMetadataPatch(annotations=annotations))
         if not patch.spec.session:
             patch.spec.session = AmaltheaSessionV1Alpha1SpecSessionPatch()
         patch.spec.session.resources = resources_patch_from_resource_class(rc)
         # Tolerations
-        tolerations = tolerations_from_resource_class(rc, nb_config.sessions.tolerations_model)
-        patch.spec.tolerations = tolerations
+        patch.spec.tolerations = tolerations_from_resource_class(rc, nb_config.sessions.tolerations_model)
         # Affinities
         patch.spec.affinity = node_affinity_patch_from_resource_class(rc, nb_config.sessions.affinity_model)
         # Priority class (if a quota is being used)

--- a/components/renku_data_services/notebooks/crs.py
+++ b/components/renku_data_services/notebooks/crs.py
@@ -450,6 +450,19 @@ class CullingPatch(CullingDurationParsingMixin):
     lastInteraction: datetime | ResetType | None = None
 
 
+class TemplateMetadataPatch(BaseCRD):
+    """Patch for the session template metadata."""
+
+    annotations: dict[str, str | ResetType] | ResetType | None = None
+    labels: dict[str, str | ResetType] | ResetType | None = None
+
+
+class TemplatePatch(BaseCRD):
+    """Patch for the session template."""
+
+    metadata: TemplateMetadataPatch | ResetType | None = None
+
+
 class AmaltheaSessionV1Alpha1SpecPatch(BaseCRD):
     """Patch for the spec of an amalthea session."""
 
@@ -464,6 +477,7 @@ class AmaltheaSessionV1Alpha1SpecPatch(BaseCRD):
     session: AmaltheaSessionV1Alpha1SpecSessionPatch | None = None
     culling: CullingPatch | ResetType | None = None
     service_account_name: str | ResetType | None = None
+    template: TemplatePatch | ResetType | None = None
 
 
 class AmaltheaSessionV1Alpha1Patch(BaseCRD):


### PR DESCRIPTION
Closes #1287.

Also, ensure the annotations are updated when resuming.

/deploy renku=release-2.17.0