### PR TITLE
feat: auto-grant/revoke resource pool viewer access on CRUD based on OAuth2 provider linkage

### DIFF
--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -360,6 +360,7 @@ class DependencyManager:
             authz=authz,
             resource_usage_service=resource_usage_service,
             resource_requests_repo=resource_requests_repo,
+            member_repo=member_repo,
         )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -244,11 +244,31 @@ class DependencyManager:
             config.secrets.encryption_key, config.db.async_session_maker
         )
 
-        connected_services_repo = ConnectedServicesRepository(
+        metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
+        metrics = StagingMetricsService(enabled=config.posthog.enabled, metrics_repo=metrics_repo)
+        search_updates_repo = SearchUpdatesRepo(session_maker=config.db.async_session_maker)
+        authz = Authz(config.authz_config)
+        group_repo = GroupRepository(
             session_maker=config.db.async_session_maker,
-            encryption_key=config.secrets.encryption_key,
-            oauth_client_factory=oauth_http_client_factory,
+            group_authz=authz,
+            search_updates_repo=search_updates_repo,
         )
+        kc_user_repo = KcUserRepo(
+            session_maker=config.db.async_session_maker,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+            encryption_key=config.secrets.encryption_key,
+            metrics=metrics,
+            authz=authz,
+        )
+
+        project_repo = ProjectRepository(
+            session_maker=config.db.async_session_maker,
+            authz=authz,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+        )
+
         k8s_db_cache = K8sDbCache(config.db.async_session_maker)
         default_kubeconfig = KubeConfigEnv()
         client = K8sClusterClientsPool(
@@ -260,7 +280,22 @@ class DependencyManager:
                 kinds_to_cache=[AMALTHEA_SESSION_GVK, JUPYTER_SESSION_GVK, BUILD_RUN_GVK, TASK_RUN_GVK],
             ),
         )
+
         quota_repo = QuotaRepository(K8sResourceQuotaClient(client), K8sPriorityClassClient(client))
+        member_repo = MemberRepository(
+            session_maker=config.db.async_session_maker,
+            quotas_repo=quota_repo,
+            user_repo=kc_user_repo,
+            group_repo=group_repo,
+            project_repo=project_repo,
+            authz=authz,
+        )
+        connected_services_repo = ConnectedServicesRepository(
+            session_maker=config.db.async_session_maker,
+            encryption_key=config.secrets.encryption_key,
+            oauth_client_factory=oauth_http_client_factory,
+            member_repo=member_repo,
+        )
         job_client = DepositUploadJobClient(client)
         secret_client = K8sSecretClient(client)
 
@@ -310,45 +345,12 @@ class DependencyManager:
                     namespace=config.k8s_namespace,
                 )
 
-        authz = Authz(config.authz_config)
         internal_authenticator = RenkuSelfAuthenticator.from_config(config=config.internal_authn_config)
         internal_token_mint = RenkuSelfTokenMint.from_config(config=config.internal_authn_config)
         internal_scope_verifier = ScopeVerifier(
             deposit_config=config.deposit_config,
             notebook_k8s_client=config.nb_config.k8s_v2_client,
             job_client=job_client,
-        )
-        search_updates_repo = SearchUpdatesRepo(session_maker=config.db.async_session_maker)
-        metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
-        metrics = StagingMetricsService(enabled=config.posthog.enabled, metrics_repo=metrics_repo)
-        group_repo = GroupRepository(
-            session_maker=config.db.async_session_maker,
-            group_authz=authz,
-            search_updates_repo=search_updates_repo,
-        )
-        kc_user_repo = KcUserRepo(
-            session_maker=config.db.async_session_maker,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-            encryption_key=config.secrets.encryption_key,
-            metrics=metrics,
-            authz=authz,
-        )
-
-        project_repo = ProjectRepository(
-            session_maker=config.db.async_session_maker,
-            authz=authz,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-        )
-
-        member_repo = MemberRepository(
-            session_maker=config.db.async_session_maker,
-            quotas_repo=quota_repo,
-            user_repo=kc_user_repo,
-            group_repo=group_repo,
-            project_repo=project_repo,
-            authz=authz,
         )
         resource_requests_repo = ResourceRequestsRepo(
             session_maker=config.db.async_session_maker,

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -189,6 +189,7 @@ class AuthzOperation(StrEnum):
     insert_many = "insert_many"
     create_link = "create_link"
     delete_link = "delete_link"
+    update_membership = "update_membership"
 
 
 class _AuthzConverter:
@@ -958,10 +959,9 @@ class Authz:
                     case AuthzOperation.delete, ResourceType.resource_pool if isinstance(result, DeletedResourcePool):
                         user = _extract_user_from_args(*func_args, **func_kwargs)
                         authz_change = await db_repo.authz._remove_resource_pool(user, result)
-                    case (
-                        (AuthzOperation.create | AuthzOperation.delete),
-                        ResourceType.resource_pool,
-                    ) if isinstance(result, ResourcePoolMembershipChange):
+                    case AuthzOperation.update_membership, ResourceType.resource_pool if isinstance(
+                        result, ResourcePoolMembershipChange
+                    ):
                         authz_change = db_repo.authz._resource_pool_membership_changes_to_authz_change(
                             result, operation
                         )
@@ -1693,7 +1693,7 @@ class Authz:
 
             rel = Relationship(resource=resource, relation=relation, subject=subject)
 
-            if operation == AuthzOperation.create:
+            if mc.change == Change.ADD:
                 apply_updates.append(RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=rel))
                 undo_updates.append(RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=rel))
             else:

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -154,6 +154,16 @@ class OAuth2ClientsBP(CustomBlueprint):
                     # TODO: redirect to a error page (that needs to be created)
                     raise errors.ForbiddenError(message="You do not have the required permissions for this operation.")
                 case _:
+                    user_id = client.connection.user_id
+                    provider_id = client.connection.client_id
+                    if user_id is not None and provider_id is not None:
+                        try:
+                            await self.connected_services_repo.on_oauth2_connected(user_id, provider_id)
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to sync resource pool memberships after OAuth2 connection for user "
+                                f"{user_id} and provider {provider_id}: {e}"
+                            )
                     next_url = client.connection.next_url
                     return redirect(to=next_url) if next_url else json({"status": "OK"})
 

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -1,6 +1,9 @@
 """Adapters for connected services database classes."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from sqlalchemy import and_, select
@@ -11,15 +14,21 @@ from ulid import ULID
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
 from renku_data_services.app_config import logging
+from renku_data_services.base_models.core import InternalServiceAdmin
 from renku_data_services.connected_services import models
 from renku_data_services.connected_services import orm as schemas
 from renku_data_services.connected_services.oauth_http import (
     OAuthHttpClientFactory,
     OAuthHttpFactoryError,
 )
+from renku_data_services.crc import orm as crc_schemas
 from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDockerAPI
 from renku_data_services.users.db import APIUser
+from renku_data_services.utils.core import with_db_transaction
 from renku_data_services.utils.cryptography import encrypt_string
+
+if TYPE_CHECKING:
+    from renku_data_services.crc.db import MemberRepository
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +41,50 @@ class ConnectedServicesRepository:
         session_maker: Callable[..., AsyncSession],
         oauth_client_factory: OAuthHttpClientFactory,
         encryption_key: bytes,
+        member_repo: MemberRepository,
     ):
         self.session_maker = session_maker
         self.encryption_key = encryption_key
         self.oauth_client_factory = oauth_client_factory
         self.supported_image_registry_providers = {models.ProviderKind.gitlab, models.ProviderKind.github}
+        self.member_repo = member_repo
+
+    async def _get_rp_ids_for_provider(self, client_id: str, session: AsyncSession) -> list[int]:
+        """Get all resource pool IDs linked to a given OAuth2 provider."""
+        rps = await session.scalars(
+            select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
+        )
+        return [rp.id for rp in rps]
+
+    @with_db_transaction
+    async def on_oauth2_connected(self, user_id: str, client_id: str, session: AsyncSession | None = None) -> None:
+        """Grant user viewer access to all RPs linked to the provider."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        admin = InternalServiceAdmin()
+        rp_ids = await self._get_rp_ids_for_provider(client_id, session)
+        if rp_ids:
+            try:
+                await self.member_repo.update_user_resource_pools(admin, user_id, rp_ids, append=True, session=session)
+            except errors.BaseError as e:
+                logger.warning(
+                    f"Failed to auto-grant member {user_id} to resource pools {rp_ids} for provider {client_id}: {e}"
+                )
+
+    @with_db_transaction
+    async def on_oauth2_disconnected(self, user_id: str, client_id: str, session: AsyncSession | None = None) -> None:
+        """Revoke user viewer access from all RPs linked to the provider."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        admin = InternalServiceAdmin()
+        rp_ids = await self._get_rp_ids_for_provider(client_id, session)
+        if rp_ids:
+            try:
+                await self.member_repo.remove_user_resource_pools(admin, user_id, rp_ids, session=session)
+            except errors.BaseError as e:
+                logger.warning(
+                    f"Failed to auto-revoke member {user_id} from resource pools {rp_ids} for provider {client_id}: {e}"
+                )
 
     async def get_oauth2_clients(
         self,
@@ -190,6 +238,16 @@ class ConnectedServicesRepository:
                 return False
 
             await session.delete(conn)
+            await session.flush()
+
+            try:
+                await self.on_oauth2_disconnected(conn.user_id, conn.client_id, session=session)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to sync resource pool memberships after OAuth2 disconnection for user "
+                    f"{conn.user_id} and provider {conn.client_id}: {e}"
+                )
+
             return True
 
     async def get_oauth2_connections(

--- a/components/renku_data_services/connected_services/models.py
+++ b/components/renku_data_services/connected_services/models.py
@@ -85,6 +85,8 @@ class OAuth2Connection:
     provider_id: str
     status: ConnectionStatus
     next_url: str | None
+    user_id: str | None = None
+    client_id: str | None = None
 
     def is_connected(self) -> bool:
         """Returns whether this connection is in status 'connected'."""

--- a/components/renku_data_services/connected_services/orm.py
+++ b/components/renku_data_services/connected_services/orm.py
@@ -110,5 +110,10 @@ class OAuth2ConnectionORM(BaseORM):
     def dump(self) -> models.OAuth2Connection:
         """Create an OAuth2 connection model from the OAuth2ConnectionORM."""
         return models.OAuth2Connection(
-            id=self.id, provider_id=self.client_id, status=self.status, next_url=self.next_url
+            id=self.id,
+            provider_id=self.client_id,
+            status=self.status,
+            next_url=self.next_url,
+            user_id=self.user_id,
+            client_id=self.client_id,
         )

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -476,6 +476,8 @@ class ResourcePoolRepository(_Base):
                 session=session,
             )
 
+            # TODO figure out how to ensure we can commit AUTHZ changes in the same DB session
+
             if members is not None and self.member_repo is not None:
                 try:
                     await self.member_repo.grant_resource_pool_members(api_user, result.id, members, skip_missing=True)

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -429,6 +429,17 @@ class ResourcePoolRepository(_Base):
         """Get the default resource class in the default resource pool."""
         return await self.__query_repository.get_default_resource_class()
 
+    async def filter_resource_pools(
+        self,
+        api_user: base_models.APIUser,
+        cpu: float = 0,
+        memory: int = 0,
+        max_storage: int = 0,
+        gpu: int = 0,
+    ) -> list[models.ResourcePool]:
+        """Get resource pools from database with indication of which resource class matches the specified criteria."""
+        return await self.__query_repository.filter_resource_pools(api_user, cpu, memory, max_storage, gpu)
+
     async def _get_connected_user_ids(self, provider_id: str) -> list[str]:
         """Query all users with a connected OAuth2 connection to the given provider."""
         async with self.session_maker() as session:

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -474,13 +474,13 @@ class ResourcePoolRepository(_Base):
 
         if provider_id and self.member_repo is not None:
             user_ids = await self._get_connected_user_ids(provider_id)
-            if user_ids:
-                members = [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in user_ids]
+            for uid in user_ids:
+                member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid)
                 try:
-                    await self.member_repo.grant_resource_pool_members(api_user, result.id, members)
+                    await self.member_repo.grant_resource_pool_members(api_user, result.id, [member])
                 except errors.BaseError as e:
                     logger.warning(
-                        f"Failed to auto-grant members to resource pool {result.id} for provider {provider_id}: {e}"
+                        f"Failed to auto-grant member {uid} to resource pool {result.id} for provider {provider_id}: {e}"
                     )
 
         return result
@@ -575,14 +575,6 @@ class ResourcePoolRepository(_Base):
         self, api_user: base_models.APIUser, resource_pool_id: int, update: models.ResourcePoolPatch
     ) -> models.ResourcePool:
         """Update an existing resource pool in the database."""
-        old_provider_id: str | None = None
-        async with self.session_maker() as session:
-            rp_old = await session.scalar(
-                select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == resource_pool_id)
-            )
-            if rp_old is not None:
-                old_provider_id = rp_old.remote_provider_id
-
         async with self.session_maker() as session, session.begin():
             stmt = (
                 select(schemas.ResourcePoolORM)
@@ -593,6 +585,7 @@ class ResourcePoolRepository(_Base):
             rp = res.one_or_none()
             if rp is None:
                 raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} cannot be found")
+            old_provider_id = rp.remote_provider_id
             quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
 
             validate_resource_pool_update(existing=rp.dump(quota=quota), update=update)
@@ -678,9 +671,18 @@ class ResourcePoolRepository(_Base):
                 rp.remote_provider_id = None
                 rp.remote_json = None
             elif update.remote is not None:
-                rp.remote_provider_id = (
+                new_provider_id = (
                     update.remote.provider_id if update.remote.provider_id is not None else rp.remote_provider_id
                 )
+                if new_provider_id is not None and new_provider_id != rp.remote_provider_id:
+                    from renku_data_services.connected_services.orm import OAuth2ClientORM
+
+                    client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == new_provider_id))
+                    if client is None:
+                        raise errors.MissingResourceError(
+                            message=f"OAuth2 Client with id '{new_provider_id}' does not exist."
+                        )
+                rp.remote_provider_id = new_provider_id
                 remote_json = rp.remote_json if rp.remote_json is not None else dict()
                 remote_json.update(update.remote.to_dict())
                 del remote_json["provider_id"]
@@ -704,29 +706,25 @@ class ResourcePoolRepository(_Base):
             # Revoke old
             if old_provider_id is not None:
                 old_user_ids = await self._get_connected_user_ids(old_provider_id)
-                if old_user_ids:
-                    old_members = [
-                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in old_user_ids
-                    ]
+                for uid in old_user_ids:
+                    member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid)
                     try:
-                        await self.member_repo.revoke_resource_pool_members(api_user, resource_pool_id, old_members)
+                        await self.member_repo.revoke_resource_pool_members(api_user, resource_pool_id, [member])
                     except errors.BaseError as e:
                         logger.warning(
-                            f"Failed to auto-revoke members from resource pool {resource_pool_id} "
+                            f"Failed to auto-revoke member {uid} from resource pool {resource_pool_id} "
                             f"for provider {old_provider_id}: {e}"
                         )
             # Grant new
             if new_provider_id is not None:
                 new_user_ids = await self._get_connected_user_ids(new_provider_id)
-                if new_user_ids:
-                    new_members = [
-                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in new_user_ids
-                    ]
+                for uid in new_user_ids:
+                    member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid)
                     try:
-                        await self.member_repo.grant_resource_pool_members(api_user, resource_pool_id, new_members)
+                        await self.member_repo.grant_resource_pool_members(api_user, resource_pool_id, [member])
                     except errors.BaseError as e:
                         logger.warning(
-                            f"Failed to auto-grant members to resource pool {resource_pool_id} "
+                            f"Failed to auto-grant member {uid} to resource pool {resource_pool_id} "
                             f"for provider {new_provider_id}: {e}"
                         )
 

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -461,7 +461,7 @@ class ResourcePoolRepository(_Base):
                 provider_id = new_resource_pool.remote.provider_id
                 client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == provider_id))
                 if client is None:
-                    raise errors.MissingResourceError(message=f"OAuth2 Client with id '{provider_id}' does not exist.")
+                    raise errors.ValidationError(message=f"Provider ID's value is incorrect: '{provider_id}'")
 
             result = await self._insert_resource_pool(
                 api_user=api_user,

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -440,15 +440,17 @@ class ResourcePoolRepository(_Base):
         """Get resource pools from database with indication of which resource class matches the specified criteria."""
         return await self.__query_repository.filter_resource_pools(api_user, cpu, memory, max_storage, gpu)
 
-    async def _get_connected_user_ids(self, provider_id: str) -> list[str]:
+    @with_db_transaction
+    async def _get_connected_user_ids(self, provider_id: str, session: AsyncSession | None = None) -> list[str]:
         """Query all users with a connected OAuth2 connection to the given provider."""
-        async with self.session_maker() as session:
-            result = await session.scalars(
-                select(OAuth2ConnectionORM.user_id)
-                .where(OAuth2ConnectionORM.client_id == provider_id)
-                .where(OAuth2ConnectionORM.status == ConnectionStatus.connected)
-            )
-            return list(result.all())
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        result = await session.scalars(
+            select(OAuth2ConnectionORM.user_id)
+            .where(OAuth2ConnectionORM.client_id == provider_id)
+            .where(OAuth2ConnectionORM.status == ConnectionStatus.connected)
+        )
+        return list(result.all())
 
     @_only_admins
     async def insert_resource_pool(
@@ -463,21 +465,24 @@ class ResourcePoolRepository(_Base):
                 if client is None:
                     raise errors.ValidationError(message=f"Provider ID's value is incorrect: '{provider_id}'")
 
+            members = None
+            if provider_id:
+                user_ids = await self._get_connected_user_ids(provider_id, session=session)
+                members = [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in user_ids]
+
             result = await self._insert_resource_pool(
                 api_user=api_user,
                 new_resource_pool=new_resource_pool,
                 session=session,
             )
 
-        if provider_id and self.member_repo is not None:
-            user_ids = await self._get_connected_user_ids(provider_id)
-            members = [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in user_ids]
-            try:
-                await self.member_repo.grant_resource_pool_members(api_user, result.id, members, skip_missing=True)
-            except errors.BaseError as e:
-                logger.warning(
-                    f"Failed to auto-grant members to resource pool {result.id} for provider {provider_id}: {e}"
-                )
+            if members is not None and self.member_repo is not None:
+                try:
+                    await self.member_repo.grant_resource_pool_members(api_user, result.id, members, skip_missing=True)
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-grant members to resource pool {result.id} for provider {provider_id}: {e}"
+                    )
 
         return result
 
@@ -685,39 +690,48 @@ class ResourcePoolRepository(_Base):
             await gather(*new_classes_coroutines)
             await session.flush()
             await session.refresh(rp)
-            result = rp.dump(quota=quota)
+            transaction_result = rp.dump(quota=quota)
+            new_provider_id = transaction_result.remote.provider_id if transaction_result.remote else None
+            old_members, new_members = None, None
+            if old_provider_id != new_provider_id:
+                # Get old
+                if old_provider_id is not None:
+                    old_user_ids = await self._get_connected_user_ids(old_provider_id, session=session)
+                    old_members = [
+                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in old_user_ids
+                    ]
+                # Get new
+                if new_provider_id is not None:
+                    new_user_ids = await self._get_connected_user_ids(new_provider_id, session=session)
+                    new_members = [
+                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in new_user_ids
+                    ]
             if update_authz:
-                result = await self._update_resource_pool(
+                transaction_result = await self._update_resource_pool(
                     api_user=api_user,
-                    rp=result,
+                    rp=transaction_result,
                     session=session,
                 )
-            transaction_result = result
 
         # After transaction, sync memberships
-        new_provider_id = transaction_result.remote.provider_id if transaction_result.remote else None
-        if old_provider_id != new_provider_id and self.member_repo is not None:
+        if self.member_repo is not None:
             # Revoke old
-            if old_provider_id is not None:
-                old_user_ids = await self._get_connected_user_ids(old_provider_id)
-                for uid in old_user_ids:
-                    member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid)
-                    try:
-                        await self.member_repo.revoke_resource_pool_members(api_user, resource_pool_id, [member])
-                    except errors.BaseError as e:
-                        logger.warning(
-                            f"Failed to auto-revoke member {uid} from resource pool {resource_pool_id} "
-                            f"for provider {old_provider_id}: {e}"
-                        )
+            if old_members is not None:
+                try:
+                    await self.member_repo.revoke_resource_pool_members(
+                        api_user, resource_pool_id, old_members, skip_missing=True
+                    )
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-revoke members from resource pool {resource_pool_id} "
+                        f"for provider {old_provider_id}: {e}"
+                    )
+
             # Grant new
-            if new_provider_id is not None:
-                new_user_ids = await self._get_connected_user_ids(new_provider_id)
-                members = [
-                    ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in new_user_ids
-                ]
+            if new_members is not None:
                 try:
                     await self.member_repo.grant_resource_pool_members(
-                        api_user, resource_pool_id, members, skip_missing=True
+                        api_user, resource_pool_id, new_members, skip_missing=True
                     )
                 except errors.BaseError as e:
                     logger.warning(
@@ -1499,10 +1513,13 @@ class MemberRepository(_Base):
         api_user: base_models.APIUser,
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
+        skip_missing: bool = False,
     ) -> None:
         """Revoke access to a resource pool for a collection of members (Users, Groups, Projects)."""
         async with self.session_maker() as session, session.begin():
-            await self._revoke_resource_pool_members(api_user, resource_pool_id, members, session=session)
+            await self._revoke_resource_pool_members(
+                api_user, resource_pool_id, members, session=session, skip_missing=skip_missing
+            )
 
     @_only_admins
     async def get_resource_pool_members(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -28,6 +28,8 @@ from renku_data_services.authz.authz import Authz, AuthzOperation
 from renku_data_services.authz.models import Change, Member, MembershipChange, Role, Scope
 from renku_data_services.base_models import RESET
 from renku_data_services.base_models.core import ResetType, ResourceType
+from renku_data_services.connected_services.models import ConnectionStatus
+from renku_data_services.connected_services.orm import OAuth2ConnectionORM
 from renku_data_services.crc import models
 from renku_data_services.crc import orm as schemas
 from renku_data_services.crc.core import (
@@ -52,11 +54,11 @@ from renku_data_services.resource_usage.db import ResourceRequestsRepo
 from renku_data_services.users.db import UserRepo
 from renku_data_services.utils.core import with_db_transaction
 
-logger = logging.getLogger(__name__)
-
 if TYPE_CHECKING:
     from renku_data_services.namespace.db import GroupRepository
     from renku_data_services.project.db import ProjectRepository
+
+logger = logging.getLogger(__name__)
 
 
 class _Base:
@@ -358,6 +360,7 @@ class ResourcePoolRepository(_Base):
         authz: Authz,
         resource_usage_service: ResourceUsageService | None = None,
         resource_requests_repo: ResourceRequestsRepo | None = None,
+        member_repo: MemberRepository | None = None,
     ):
         super().__init__(session_maker, quotas_repo, authz)
         self.__query_repository = ResourcePoolQueryRepository(
@@ -368,6 +371,7 @@ class ResourcePoolRepository(_Base):
             resource_requests_repo=resource_requests_repo,
         )
         self.__cluster_repo = ClusterRepository(session_maker=self.session_maker)
+        self.member_repo = member_repo
 
     async def initialize(self, async_connection_url: str, rp: models.UnsavedResourcePool) -> None:
         """Add the default resource pool if it does not already exist."""

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -29,7 +29,7 @@ from renku_data_services.authz.models import Change, Member, MembershipChange, R
 from renku_data_services.base_models import RESET
 from renku_data_services.base_models.core import ResetType, ResourceType
 from renku_data_services.connected_services.models import ConnectionStatus
-from renku_data_services.connected_services.orm import OAuth2ConnectionORM
+from renku_data_services.connected_services.orm import OAuth2ClientORM, OAuth2ConnectionORM
 from renku_data_services.crc import models
 from renku_data_services.crc import orm as schemas
 from renku_data_services.crc.core import (
@@ -455,17 +455,14 @@ class ResourcePoolRepository(_Base):
         self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool
     ) -> models.ResourcePool:
         """Insert resource pool into database."""
-        provider_id = None
-        if new_resource_pool.remote and new_resource_pool.remote.provider_id:
-            provider_id = new_resource_pool.remote.provider_id
-            async with self.session_maker() as session:
-                from renku_data_services.connected_services.orm import OAuth2ClientORM
-
+        async with self.session_maker() as session, session.begin():
+            provider_id = None
+            if new_resource_pool.remote and new_resource_pool.remote.provider_id:
+                provider_id = new_resource_pool.remote.provider_id
                 client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == provider_id))
                 if client is None:
                     raise errors.MissingResourceError(message=f"OAuth2 Client with id '{provider_id}' does not exist.")
 
-        async with self.session_maker() as session, session.begin():
             result = await self._insert_resource_pool(
                 api_user=api_user,
                 new_resource_pool=new_resource_pool,
@@ -479,7 +476,7 @@ class ResourcePoolRepository(_Base):
                 await self.member_repo.grant_resource_pool_members(api_user, result.id, members)
             except errors.BaseError as e:
                 logger.warning(
-                    f"Failed to auto-grant members  to resource pool {result.id} " f"for provider {provider_id}: {e}"
+                    f"Failed to auto-grant members to resource pool {result.id} " f"for provider {provider_id}: {e}"
                 )
 
         return result
@@ -674,8 +671,6 @@ class ResourcePoolRepository(_Base):
                     update.remote.provider_id if update.remote.provider_id is not None else rp.remote_provider_id
                 )
                 if new_provider_id is not None and new_provider_id != rp.remote_provider_id:
-                    from renku_data_services.connected_services.orm import OAuth2ClientORM
-
                     client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == new_provider_id))
                     if client is None:
                         raise errors.MissingResourceError(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -473,10 +473,10 @@ class ResourcePoolRepository(_Base):
             user_ids = await self._get_connected_user_ids(provider_id)
             members = [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in user_ids]
             try:
-                await self.member_repo.grant_resource_pool_members(api_user, result.id, members)
+                await self.member_repo.grant_resource_pool_members(api_user, result.id, members, skip_missing=True)
             except errors.BaseError as e:
                 logger.warning(
-                    f"Failed to auto-grant members to resource pool {result.id} " f"for provider {provider_id}: {e}"
+                    f"Failed to auto-grant members to resource pool {result.id} for provider {provider_id}: {e}"
                 )
 
         return result
@@ -716,10 +716,12 @@ class ResourcePoolRepository(_Base):
                     ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in new_user_ids
                 ]
                 try:
-                    await self.member_repo.grant_resource_pool_members(api_user, resource_pool_id, members)
+                    await self.member_repo.grant_resource_pool_members(
+                        api_user, resource_pool_id, members, skip_missing=True
+                    )
                 except errors.BaseError as e:
                     logger.warning(
-                        f"Failed to auto-grant member {uid} to resource pool {resource_pool_id} "
+                        f"Failed to auto-grant members to resource pool {resource_pool_id} "
                         f"for provider {new_provider_id}: {e}"
                     )
 
@@ -1343,28 +1345,30 @@ class MemberRepository(_Base):
         self,
         api_user: base_models.APIUser,
         members: Collection[ResourcePoolMemberIdentifier],
-    ) -> list[tuple[str, ResourceType, str]]:
-        """Resolve ResourcePoolMemberIdentifiers to (internal_id, subject_type, role) tuples."""
-        resolved: list[tuple[str, ResourceType, str]] = []
+        skip_missing: bool = False,
+    ) -> list[tuple[str, ResourceType, str, MemberType]]:
+        """Resolve ResourcePoolMemberIdentifiers to (internal_id, subject_type, role, member_type) tuples."""
+        resolved: list[tuple[str, ResourceType, str, MemberType]] = []
         for member in members:
             match member.member_type:
                 case MemberType.USER:
                     kc_user = await self.kc_user_repo.get_user(id=member.member_id)
                     if kc_user is None:
+                        if skip_missing:
+                            logger.warning(f"Skipping auto-grant for missing user {member.member_id}")
+                            continue
                         raise errors.MissingResourceError(message=f"User with ID {member.member_id} does not exist")
-                    resolved.append((kc_user.id, ResourceType.user, member.role))
+                    resolved.append((kc_user.id, ResourceType.user, member.role, member.member_type))
 
                 case MemberType.GROUP:
                     group_id = ULID.from_str(member.member_id)
                     group = await self.group_repo.get_group_by_id(api_user, group_id)
-                    if group is None:
-                        raise errors.MissingResourceError(message=f"Group with id {member.member_id!r} does not exist")
-                    resolved.append((str(group.id), ResourceType.group, member.role))
+                    resolved.append((str(group.id), ResourceType.group, member.role, member.member_type))
 
                 case MemberType.PROJECT:
                     project_id = ULID.from_str(member.member_id)
                     project = await self.project_repo.get_project(api_user, project_id)
-                    resolved.append((str(project.id), ResourceType.project, member.role))
+                    resolved.append((str(project.id), ResourceType.project, member.role, member.member_type))
 
         return resolved
 
@@ -1400,13 +1404,14 @@ class MemberRepository(_Base):
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
         session: AsyncSession | None = None,
+        skip_missing: bool = False,
     ) -> models.ResourcePoolMembershipChange | None:
-        specs = await self._resolve_members(api_user, members)
+        specs = await self._resolve_members(api_user, members, skip_missing=skip_missing)
         return self._build_pool_membership_changes(
             resource_pool_id,
             [
-                (member_id, subject_type, self._api_role_to_authz_role(role, member.member_type))
-                for (member_id, subject_type, role), member in zip(specs, members, strict=True)
+                (member_id, subject_type, self._api_role_to_authz_role(role, member_type))
+                for (member_id, subject_type, role, member_type) in specs
             ],
             Change.ADD,
         )
@@ -1419,13 +1424,14 @@ class MemberRepository(_Base):
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
         session: AsyncSession | None = None,
+        skip_missing: bool = False,
     ) -> models.ResourcePoolMembershipChange | None:
-        specs = await self._resolve_members(api_user, members)
+        specs = await self._resolve_members(api_user, members, skip_missing=skip_missing)
         return self._build_pool_membership_changes(
             resource_pool_id,
             [
-                (member_id, subject_type, self._api_role_to_authz_role(role, member.member_type))
-                for (member_id, subject_type, role), member in zip(specs, members, strict=True)
+                (member_id, subject_type, self._api_role_to_authz_role(role, member_type))
+                for (member_id, subject_type, role, member_type) in specs
             ],
             Change.REMOVE,
         )
@@ -1437,10 +1443,13 @@ class MemberRepository(_Base):
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
         append: bool = True,
+        skip_missing: bool = False,
     ) -> None:
         """Grant access to a resource pool for a collection of members (Users, Groups, Projects)."""
         async with self.session_maker() as session, session.begin():
-            await self._grant_resource_pool_members(api_user, resource_pool_id, members, session=session)
+            await self._grant_resource_pool_members(
+                api_user, resource_pool_id, members, session=session, skip_missing=skip_missing
+            )
 
     @_only_admins
     async def revoke_resource_pool_members(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -429,28 +429,50 @@ class ResourcePoolRepository(_Base):
         """Get the default resource class in the default resource pool."""
         return await self.__query_repository.get_default_resource_class()
 
-    async def filter_resource_pools(
-        self,
-        api_user: base_models.APIUser,
-        cpu: float = 0,
-        memory: int = 0,
-        max_storage: int = 0,
-        gpu: int = 0,
-    ) -> list[models.ResourcePool]:
-        """Get resource pools from database with indication of which resource class matches the specified criteria."""
-        return await self.__query_repository.filter_resource_pools(api_user, cpu, memory, max_storage, gpu)
+    async def _get_connected_user_ids(self, provider_id: str) -> list[str]:
+        """Query all users with a connected OAuth2 connection to the given provider."""
+        async with self.session_maker() as session:
+            result = await session.scalars(
+                select(OAuth2ConnectionORM.user_id)
+                .where(OAuth2ConnectionORM.client_id == provider_id)
+                .where(OAuth2ConnectionORM.status == ConnectionStatus.connected)
+            )
+            return list(result.all())
 
     @_only_admins
     async def insert_resource_pool(
         self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool
     ) -> models.ResourcePool:
         """Insert resource pool into database."""
+        provider_id = None
+        if new_resource_pool.remote and new_resource_pool.remote.provider_id:
+            provider_id = new_resource_pool.remote.provider_id
+            async with self.session_maker() as session:
+                from renku_data_services.connected_services.orm import OAuth2ClientORM
+
+                client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == provider_id))
+                if client is None:
+                    raise errors.MissingResourceError(message=f"OAuth2 Client with id '{provider_id}' does not exist.")
+
         async with self.session_maker() as session, session.begin():
-            return await self._insert_resource_pool(
+            result = await self._insert_resource_pool(
                 api_user=api_user,
                 new_resource_pool=new_resource_pool,
                 session=session,
             )
+
+        if provider_id and self.member_repo is not None:
+            user_ids = await self._get_connected_user_ids(provider_id)
+            if user_ids:
+                members = [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in user_ids]
+                try:
+                    await self.member_repo.grant_resource_pool_members(api_user, result.id, members)
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-grant members to resource pool {result.id} for provider {provider_id}: {e}"
+                    )
+
+        return result
 
     @with_db_transaction
     @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -564,6 +564,14 @@ class ResourcePoolRepository(_Base):
         self, api_user: base_models.APIUser, resource_pool_id: int, update: models.ResourcePoolPatch
     ) -> models.ResourcePool:
         """Update an existing resource pool in the database."""
+        old_provider_id: str | None = None
+        async with self.session_maker() as session:
+            rp_old = await session.scalar(
+                select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == resource_pool_id)
+            )
+            if rp_old is not None:
+                old_provider_id = rp_old.remote_provider_id
+
         async with self.session_maker() as session, session.begin():
             stmt = (
                 select(schemas.ResourcePoolORM)
@@ -672,12 +680,46 @@ class ResourcePoolRepository(_Base):
             await session.refresh(rp)
             result = rp.dump(quota=quota)
             if update_authz:
-                return await self._update_resource_pool(
+                result = await self._update_resource_pool(
                     api_user=api_user,
                     rp=result,
                     session=session,
                 )
-            return result
+            transaction_result = result
+
+        # After transaction, sync memberships
+        new_provider_id = transaction_result.remote.provider_id if transaction_result.remote else None
+        if old_provider_id != new_provider_id and self.member_repo is not None:
+            # Revoke old
+            if old_provider_id is not None:
+                old_user_ids = await self._get_connected_user_ids(old_provider_id)
+                if old_user_ids:
+                    old_members = [
+                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in old_user_ids
+                    ]
+                    try:
+                        await self.member_repo.revoke_resource_pool_members(api_user, resource_pool_id, old_members)
+                    except errors.BaseError as e:
+                        logger.warning(
+                            f"Failed to auto-revoke members from resource pool {resource_pool_id} "
+                            f"for provider {old_provider_id}: {e}"
+                        )
+            # Grant new
+            if new_provider_id is not None:
+                new_user_ids = await self._get_connected_user_ids(new_provider_id)
+                if new_user_ids:
+                    new_members = [
+                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in new_user_ids
+                    ]
+                    try:
+                        await self.member_repo.grant_resource_pool_members(api_user, resource_pool_id, new_members)
+                    except errors.BaseError as e:
+                        logger.warning(
+                            f"Failed to auto-grant members to resource pool {resource_pool_id} "
+                            f"for provider {new_provider_id}: {e}"
+                        )
+
+        return transaction_result
 
     @with_db_transaction
     @Authz.authz_change(op=AuthzOperation.update, resource=ResourceType.resource_pool)

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -480,7 +480,8 @@ class ResourcePoolRepository(_Base):
                     await self.member_repo.grant_resource_pool_members(api_user, result.id, [member])
                 except errors.BaseError as e:
                     logger.warning(
-                        f"Failed to auto-grant member {uid} to resource pool {result.id} for provider {provider_id}: {e}"
+                        f"Failed to auto-grant member {uid} to resource pool {result.id} "
+                        f"for provider {provider_id}: {e}"
                     )
 
         return result

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1139,73 +1139,115 @@ class MemberRepository(_Base):
                 output.append(rp.dump(quota))
             return output
 
+    async def _sync_user_resource_pool_membership(
+        self,
+        api_user: base_models.APIUser,
+        user: schemas.UserORM,
+        rps_to_add: Collection[schemas.ResourcePoolORM],
+        rps_to_remove: Collection[schemas.ResourcePoolORM],
+        session: AsyncSession,
+    ) -> None:
+        """Synchronize a user's resource pool memberships in SQL and Authz."""
+        member_identifier = ResourcePoolMemberIdentifier(member_id=user.keycloak_id, member_type=MemberType.USER)
+        for rp in rps_to_add:
+            if rp not in user.resource_pools:
+                user.resource_pools.append(rp)
+            await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
+            if rp.default or rp.public:
+                await self._unprohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+        for rp in rps_to_remove:
+            if rp in user.resource_pools:
+                user.resource_pools.remove(rp)
+            await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
+            if rp.default or rp.public:
+                await self._prohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+
+    @with_db_transaction
     @_only_admins
     async def update_user_resource_pools(
-        self, api_user: base_models.APIUser, keycloak_id: str, resource_pool_ids: list[int], append: bool = True
+        self,
+        api_user: base_models.APIUser,
+        keycloak_id: str,
+        resource_pool_ids: list[int],
+        append: bool = True,
+        session: AsyncSession | None = None,
     ) -> list[models.ResourcePool]:
         """Update the resource pools that a specific user has access to."""
-        async with self.session_maker() as session, session.begin():
-            kc_user = await self.kc_user_repo.get_user(keycloak_id)
-            if kc_user is None:
-                raise errors.MissingResourceError(message=f"The user with ID {keycloak_id} does not exist")
-            stmt = (
-                select(schemas.UserORM)
-                .where(schemas.UserORM.keycloak_id == keycloak_id)
-                .options(selectinload(schemas.UserORM.resource_pools))
-            )
-            res = await session.execute(stmt)
-            user = res.scalars().first()
-            if user is None:
-                user = schemas.UserORM(keycloak_id=keycloak_id)
-                session.add(user)
-            stmt_rp = (
-                select(schemas.ResourcePoolORM)
-                .where(schemas.ResourcePoolORM.id.in_(resource_pool_ids))
-                .options(selectinload(schemas.ResourcePoolORM.classes))
-            )
-            if user.no_default_access:
-                stmt_rp = stmt_rp.where(schemas.ResourcePoolORM.default == false())
-            res_rp = await session.execute(stmt_rp)
-            rps_to_add = res_rp.scalars().all()
-            if len(rps_to_add) != len(resource_pool_ids):
-                missing_rps = set(resource_pool_ids).difference(set([i.id for i in rps_to_add]))
-                raise errors.MissingResourceError(
-                    message=(
-                        f"The resource pools with ids: {missing_rps} do not exist or user doesn't have access to "
-                        "default resource pool."
-                    )
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        kc_user = await self.kc_user_repo.get_user(keycloak_id)
+        if kc_user is None:
+            raise errors.MissingResourceError(message=f"The user with ID {keycloak_id} does not exist")
+        stmt = (
+            select(schemas.UserORM)
+            .where(schemas.UserORM.keycloak_id == keycloak_id)
+            .options(selectinload(schemas.UserORM.resource_pools))
+        )
+        res = await session.execute(stmt)
+        user = res.scalars().first()
+        if user is None:
+            user = schemas.UserORM(keycloak_id=keycloak_id)
+            session.add(user)
+        stmt_rp = (
+            select(schemas.ResourcePoolORM)
+            .where(schemas.ResourcePoolORM.id.in_(resource_pool_ids))
+            .options(selectinload(schemas.ResourcePoolORM.classes))
+        )
+        if user.no_default_access:
+            stmt_rp = stmt_rp.where(schemas.ResourcePoolORM.default == false())
+        res_rp = await session.execute(stmt_rp)
+        rps_to_add = res_rp.scalars().all()
+        if len(rps_to_add) != len(resource_pool_ids):
+            missing_rps = set(resource_pool_ids).difference(set([i.id for i in rps_to_add]))
+            raise errors.MissingResourceError(
+                message=(
+                    f"The resource pools with ids: {missing_rps} do not exist or user doesn't have access to "
+                    "default resource pool."
                 )
-            if user.no_default_access:
-                default_rp = next((rp for rp in rps_to_add if rp.default), None)
-                if default_rp:
-                    raise errors.ForbiddenError(
-                        message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
-                    )
-            existing_rp_ids = {rp.id for rp in user.resource_pools}
-            new_rp_ids = {rp.id for rp in rps_to_add}
-            if append:
-                rps_to_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
-                user.resource_pools.extend(rps_to_add)
-                removed_rps: list[schemas.ResourcePoolORM] = []
-            else:
-                removed_rps = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
-                user.resource_pools = list(rps_to_add)
-            # TODO: the authz changes below are done in separate db transactions,
-            # TODO: use only one (collect everything into a single authz change)
-            member_identifier = ResourcePoolMemberIdentifier(member_id=keycloak_id, member_type=MemberType.USER)
-            for rp in rps_to_add:
-                await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
-                if rp.default or rp.public:
-                    await self._unprohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
-            for rp in removed_rps:
-                await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
-                if rp.default or rp.public:
-                    await self._prohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
-            output: list[models.ResourcePool] = []
-            for rp in rps_to_add:
-                quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
-                output.append(rp.dump(quota))
-            return output
+            )
+        if user.no_default_access:
+            default_rp = next((rp for rp in rps_to_add if rp.default), None)
+            if default_rp:
+                raise errors.ForbiddenError(
+                    message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
+                )
+        existing_rp_ids = {rp.id for rp in user.resource_pools}
+        new_rp_ids = {rp.id for rp in rps_to_add}
+        if append:
+            actual_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
+            actual_remove: list[schemas.ResourcePoolORM] = []
+        else:
+            actual_add = list(rps_to_add)
+            actual_remove = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
+        await self._sync_user_resource_pool_membership(api_user, user, actual_add, actual_remove, session)
+        output: list[models.ResourcePool] = []
+        for rp in actual_add:
+            quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
+            output.append(rp.dump(quota))
+        return output
+
+    @with_db_transaction
+    @_only_admins
+    async def remove_user_resource_pools(
+        self,
+        api_user: base_models.APIUser,
+        keycloak_id: str,
+        resource_pool_ids: list[int],
+        session: AsyncSession | None = None,
+    ) -> None:
+        """Remove a user from specific resource pools."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        stmt = (
+            select(schemas.UserORM)
+            .where(schemas.UserORM.keycloak_id == keycloak_id)
+            .options(selectinload(schemas.UserORM.resource_pools))
+        )
+        res = await session.execute(stmt)
+        user = res.scalars().first()
+        if user is not None:
+            actual_remove = [rp for rp in user.resource_pools if rp.id in resource_pool_ids]
+            await self._sync_user_resource_pool_membership(api_user, user, [], actual_remove, session)
 
     @_only_admins
     async def delete_resource_pool_user(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1415,7 +1415,7 @@ class MemberRepository(_Base):
         return resolved
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _unprohibit_resource_pool_users(
         self,
         api_user: base_models.APIUser,
@@ -1427,7 +1427,7 @@ class MemberRepository(_Base):
         return self._build_pool_membership_changes(resource_pool_id, specs, Change.REMOVE)
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _prohibit_resource_pool_users(
         self,
         api_user: base_models.APIUser,
@@ -1439,7 +1439,7 @@ class MemberRepository(_Base):
         return self._build_pool_membership_changes(resource_pool_id, specs, Change.ADD)
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _grant_resource_pool_members(
         self,
         api_user: base_models.APIUser,
@@ -1459,7 +1459,7 @@ class MemberRepository(_Base):
         )
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _revoke_resource_pool_members(
         self,
         api_user: base_models.APIUser,

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -474,15 +474,13 @@ class ResourcePoolRepository(_Base):
 
         if provider_id and self.member_repo is not None:
             user_ids = await self._get_connected_user_ids(provider_id)
-            for uid in user_ids:
-                member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid)
-                try:
-                    await self.member_repo.grant_resource_pool_members(api_user, result.id, [member])
-                except errors.BaseError as e:
-                    logger.warning(
-                        f"Failed to auto-grant member {uid} to resource pool {result.id} "
-                        f"for provider {provider_id}: {e}"
-                    )
+            members = [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in user_ids]
+            try:
+                await self.member_repo.grant_resource_pool_members(api_user, result.id, members)
+            except errors.BaseError as e:
+                logger.warning(
+                    f"Failed to auto-grant members  to resource pool {result.id} " f"for provider {provider_id}: {e}"
+                )
 
         return result
 
@@ -719,15 +717,16 @@ class ResourcePoolRepository(_Base):
             # Grant new
             if new_provider_id is not None:
                 new_user_ids = await self._get_connected_user_ids(new_provider_id)
-                for uid in new_user_ids:
-                    member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid)
-                    try:
-                        await self.member_repo.grant_resource_pool_members(api_user, resource_pool_id, [member])
-                    except errors.BaseError as e:
-                        logger.warning(
-                            f"Failed to auto-grant member {uid} to resource pool {resource_pool_id} "
-                            f"for provider {new_provider_id}: {e}"
-                        )
+                members = [
+                    ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in new_user_ids
+                ]
+                try:
+                    await self.member_repo.grant_resource_pool_members(api_user, resource_pool_id, members)
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-grant member {uid} to resource pool {resource_pool_id} "
+                        f"for provider {new_provider_id}: {e}"
+                    )
 
         return transaction_result
 

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from typing import cast
 
 import pytest
+from authzed.api.v1 import Relationship, RelationshipUpdate, SubjectReference, WriteRelationshipsRequest
 
+from renku_data_services.authz.authz import _AuthzConverter
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.connected_services.db import ConnectedServicesRepository, Image
 from renku_data_services.connected_services.models import (
@@ -14,10 +16,17 @@ from renku_data_services.connected_services.models import (
     UnsavedOAuth2Client,
 )
 from renku_data_services.connected_services.orm import OAuth2ConnectionORM
+from renku_data_services.crc import models as crc_models
+from renku_data_services.crc.models import (
+    MemberType,
+    RemoteConfigurationFirecrest,
+    RuntimePlatform,
+)
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.users.db import UserRepo
 from renku_data_services.users.models import UserInfo
+from test.utils import create_rp
 
 github_image = Image.from_path("ghcr.io/sdsc/test")
 gitlab_image = Image.from_path("registry.gitlab.com/sdsc/test")
@@ -82,6 +91,22 @@ async def setup_users(app_manager_instance: DependencyManager) -> SetupData:
     admin_info = cast(UserInfo, await user_repo.get_or_create_user(admin, str(admin.id)))
     user1_info = cast(UserInfo, await user_repo.get_or_create_user(user1, str(user1.id)))
     user2_info = cast(UserInfo, await user_repo.get_or_create_user(user2, str(user2.id)))
+
+    # Bootstrap the admin user as a platform admin in Authzed so that Authzed-based permission
+    # checks pass when the tests call get_resource_pool_members with the admin user.
+    authz = app_manager_instance.authz
+    rels = [
+        RelationshipUpdate(
+            operation=RelationshipUpdate.OPERATION_TOUCH,
+            relationship=Relationship(
+                resource=_AuthzConverter.platform(),
+                relation="admin",
+                subject=SubjectReference(object=_AuthzConverter.user(admin.id)),
+            ),
+        )
+    ]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=rels))
+
     return SetupData(admin, admin_info, user1, user1_info, user2, user2_info, app_manager_instance)
 
 
@@ -214,6 +239,314 @@ async def test_get_provider_for_image_unsupported_provider(app_manager_instance)
 
     p = await setup.connected_repo.get_provider_for_image(setup.user1, gitlab_image)
     assert p is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_connect_adds_user_to_rp(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-oauth-connect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-oauth-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection for user1
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # Call on_oauth2_connected directly
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # Assert user1 is a viewer member of the RP
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_disconnect_removes_user_from_rp(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-oauth-disconnect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-oauth-disconnect-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection and grant access
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # Verify user1 has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Disconnect user1
+    await app_manager_instance.connected_services_repo.on_oauth2_disconnected(setup.user1.id, client.id)
+
+    # Assert user1 is no longer a member
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_connect_with_no_matching_rp_does_nothing(
+    app_manager_instance: DependencyManager, admin_user: APIUser
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-no-match"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create a connection for user1 but no RP linked to this provider
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # This should not crash
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # No RPs exist anyway so nothing to assert, just no crash
+
+
+@pytest.mark.asyncio
+async def test_two_users_connect_same_integration_both_get_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-two-users"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-two-users-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create connections for both users
+    for user in [setup.user1, setup.user2]:
+        async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=user.id,
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+
+    # Connect both users
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user2.id, client.id)
+
+    # Both should have access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+    assert setup.user2.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_user_disconnect_only_affects_their_rp_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-isolated-disconnect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-isolated-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create connections for both users
+    for user in [setup.user1, setup.user2]:
+        async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=user.id,
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+
+    # Grant both users
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user2.id, client.id)
+
+    # Disconnect user1 only
+    await app_manager_instance.connected_services_repo.on_oauth2_disconnected(setup.user1.id, client.id)
+
+    # user1 revoked, user2 still has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+    assert setup.user2.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_delete_connection_revokes_rp_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-delete-revoke"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-delete-revoke-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection and grant access
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # Grant user1 access
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # Verify user1 has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Delete the connection (this should trigger on_oauth2_disconnected)
+    await app_manager_instance.connected_services_repo.delete_oauth2_connection(setup.user1, conn.id)
+
+    # Verify user1 no longer has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
 
 
 @pytest.mark.asyncio

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -321,9 +321,9 @@ async def test_resource_class_create(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert len(retrieved_rp.classes) >= 1
-        assert sum([i == inserted_class for i in retrieved_rp.classes]) == 1, (
-            f"class {inserted_class} should be in {retrieved_rp.classes}"
-        )
+        assert (
+            sum([i == inserted_class for i in retrieved_rp.classes]) == 1
+        ), f"class {inserted_class} should be in {retrieved_rp.classes}"
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -359,9 +359,9 @@ async def test_resource_class_delete(
         retrieved_rps = await pool_repo.get_resource_pools(id=inserted_rp.id, api_user=admin_user)
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
-        assert not any([i == removed_cls for i in retrieved_rp.classes]), (
-            f"class {removed_cls} should not be in {retrieved_rp.classes}"
-        )
+        assert not any(
+            [i == removed_cls for i in retrieved_rp.classes]
+        ), f"class {removed_cls} should not be in {retrieved_rp.classes}"
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -403,12 +403,12 @@ async def test_resource_class_update(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert updated_rc.id == rc_to_update.id
-        assert sum([i == updated_rc for i in retrieved_rp.classes]) == 1, (
-            f"class {updated_rc} should be in {retrieved_rp.classes}"
-        )
-        assert not any([i == rc_to_update for i in retrieved_rp.classes]), (
-            f"class {rc_to_update} should not be in {retrieved_rp.classes}"
-        )
+        assert (
+            sum([i == updated_rc for i in retrieved_rp.classes]) == 1
+        ), f"class {updated_rc} should be in {retrieved_rp.classes}"
+        assert not any(
+            [i == rc_to_update for i in retrieved_rp.classes]
+        ), f"class {rc_to_update} should not be in {retrieved_rp.classes}"
 
     except (ValidationError, errors.ValidationError):
         pass

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -321,9 +321,9 @@ async def test_resource_class_create(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert len(retrieved_rp.classes) >= 1
-        assert (
-            sum([i == inserted_class for i in retrieved_rp.classes]) == 1
-        ), f"class {inserted_class} should be in {retrieved_rp.classes}"
+        assert sum([i == inserted_class for i in retrieved_rp.classes]) == 1, (
+            f"class {inserted_class} should be in {retrieved_rp.classes}"
+        )
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -359,9 +359,9 @@ async def test_resource_class_delete(
         retrieved_rps = await pool_repo.get_resource_pools(id=inserted_rp.id, api_user=admin_user)
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
-        assert not any(
-            [i == removed_cls for i in retrieved_rp.classes]
-        ), f"class {removed_cls} should not be in {retrieved_rp.classes}"
+        assert not any([i == removed_cls for i in retrieved_rp.classes]), (
+            f"class {removed_cls} should not be in {retrieved_rp.classes}"
+        )
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -403,12 +403,12 @@ async def test_resource_class_update(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert updated_rc.id == rc_to_update.id
-        assert (
-            sum([i == updated_rc for i in retrieved_rp.classes]) == 1
-        ), f"class {updated_rc} should be in {retrieved_rp.classes}"
-        assert not any(
-            [i == rc_to_update for i in retrieved_rp.classes]
-        ), f"class {rc_to_update} should not be in {retrieved_rp.classes}"
+        assert sum([i == updated_rc for i in retrieved_rp.classes]) == 1, (
+            f"class {updated_rc} should be in {retrieved_rp.classes}"
+        )
+        assert not any([i == rc_to_update for i in retrieved_rp.classes]), (
+            f"class {rc_to_update} should not be in {retrieved_rp.classes}"
+        )
 
     except (ValidationError, errors.ValidationError):
         pass
@@ -1157,3 +1157,229 @@ async def test_get_connected_user_ids_returns_only_connected_users(
     connected_ids = await app_manager_instance.rp_repo._get_connected_user_ids(provider_id)
     assert str(user1.id) in connected_ids
     assert str(user2.id) not in connected_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_with_nonexistent_provider_id_fails(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    rp = models.UnsavedResourcePool(
+        name="test-update-nonexistent-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        with pytest.raises(errors.MissingResourceError):
+            await app_manager_instance.rp_repo.update_resource_pool(
+                api_user=admin_user,
+                resource_pool_id=inserted_rp.id,
+                update=models.ResourcePoolPatch(
+                    remote=RemoteConfigurationFirecrestPatch(
+                        provider_id="does-not-exist",
+                        api_url="https://example.org",
+                        system_name="test-system",
+                    ),
+                ),
+            )
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_insert_auto_grant_skips_missing_keycloak_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-missing", full_name="User One")
+    user2 = base_models.APIUser(id="user2-missing", full_name="User Two")
+    # Only add user1 to Keycloak, not user2
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-missing-insert"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-insert-missing-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_auto_grant_skips_missing_keycloak_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-update-missing", full_name="User One")
+    user2 = base_models.APIUser(id="user2-update-missing", full_name="User Two")
+    # Only add user1 to Keycloak, not user2
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-missing-update"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-update-missing-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+
+        # Verify no members initially
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert len(user_ids) == 0
+
+        # Update to add remote provider
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(
+                remote=RemoteConfigurationFirecrestPatch(
+                    provider_id=provider_id,
+                    api_url="https://example.org",
+                    system_name="test-system",
+                ),
+            ),
+        )
+
+        # Verify user1 gets access, user2 does not
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_remote_swap_skips_missing_keycloak_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-swap-missing", full_name="User One")
+    user2 = base_models.APIUser(id="user2-swap-missing", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id_1 = "test-provider-swap-1"
+    provider_id_2 = "test-provider-swap-2"
+
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id_1,
+        app_manager_instance.config.db.async_session_maker,
+    )
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id_2,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-swap-missing-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id_1,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+
+        # Update to provider 2
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(
+                remote=RemoteConfigurationFirecrestPatch(provider_id=provider_id_2),
+            ),
+        )
+
+        # Verify user1 still has access, user2 does not (because user2 missing from Keycloak)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -1139,6 +1139,9 @@ async def test_get_connected_user_ids_returns_only_connected_users(
             code_verifier=None,
             next_url=None,
         )
+        session.add(conn1)
+
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
         conn2 = OAuth2ConnectionORM(
             user_id=str(user2.id),
             client_id=client.id,
@@ -1148,7 +1151,6 @@ async def test_get_connected_user_ids_returns_only_connected_users(
             code_verifier=None,
             next_url=None,
         )
-        session.add(conn1)
         session.add(conn2)
 
     # Call the private helper

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -1109,7 +1109,7 @@ async def test_resource_pool_insert_with_nonexistent_provider_id_fails(
         ),
     )
 
-    with pytest.raises(errors.MissingResourceError):
+    with pytest.raises(errors.ValidationError):
         await app_manager_instance.rp_repo.insert_resource_pool(admin_user, rp)
 
 

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 from unittest.mock import AsyncMock
 
 import pytest
+from authzed.api.v1 import Relationship, RelationshipUpdate, SubjectReference, WriteRelationshipsRequest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
@@ -9,6 +10,7 @@ from ulid import ULID
 
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
+from renku_data_services.authz.authz import _AuthzConverter
 from renku_data_services.authz.models import Visibility
 from renku_data_services.base_models import RESET, APIUser
 from renku_data_services.connected_services.db import ConnectedServicesRepository
@@ -835,6 +837,18 @@ async def _insert_provider_and_connect(
     return client
 
 
+async def _bootstrap_admin(authz, admin_user: base_models.APIUser) -> None:
+    rels: list[RelationshipUpdate] = []
+    sub = SubjectReference(object=_AuthzConverter.user(str(admin_user.id)))
+    rels.append(
+        RelationshipUpdate(
+            operation=RelationshipUpdate.OPERATION_TOUCH,
+            relationship=Relationship(resource=_AuthzConverter.platform(), relation="admin", subject=sub),
+        )
+    )
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=rels))
+
+
 @pytest.mark.asyncio
 @pytest.mark.xdist_group("sessions")
 async def test_resource_pool_insert_with_remote_grants_connected_users(
@@ -844,6 +858,7 @@ async def test_resource_pool_insert_with_remote_grants_connected_users(
 ) -> None:
     run_migrations_for_app("common")
     await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
 
     user1 = base_models.APIUser(id="user1", full_name="User One")
     user2 = base_models.APIUser(id="user2", full_name="User Two")
@@ -894,6 +909,7 @@ async def test_resource_pool_update_remote_to_new_provider_swaps_access(
 ) -> None:
     run_migrations_for_app("common")
     await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
 
     user1 = base_models.APIUser(id="user1-update", full_name="User One")
     user2 = base_models.APIUser(id="user2-update", full_name="User Two")
@@ -969,6 +985,7 @@ async def test_resource_pool_update_remove_remote_revokes_access(
 ) -> None:
     run_migrations_for_app("common")
     await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
 
     user1 = base_models.APIUser(id="user1-remove", full_name="User One")
     await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
@@ -1030,6 +1047,7 @@ async def test_resource_pool_delete_cleans_authz(
 ) -> None:
     run_migrations_for_app("common")
     await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
 
     user1 = base_models.APIUser(id="user1-delete", full_name="User One")
     await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
@@ -1060,9 +1078,9 @@ async def test_resource_pool_delete_cleans_authz(
     inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
     await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
 
-    # After deletion, querying members should return empty
-    members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
-    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    # After deletion, querying members directly from Authz should return empty
+    members = await app_manager_instance.authz.get_resource_pool_members(admin_user, inserted_rp.id)
+    user_ids = {subject_id for _, subject_id, _ in members}
     assert str(user1.id) not in user_ids
     assert len(user_ids) == 0
 
@@ -1207,6 +1225,7 @@ async def test_resource_pool_insert_auto_grant_skips_missing_keycloak_users(
 ) -> None:
     run_migrations_for_app("common")
     await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
 
     user1 = base_models.APIUser(id="user1-missing", full_name="User One")
     user2 = base_models.APIUser(id="user2-missing", full_name="User Two")
@@ -1257,6 +1276,7 @@ async def test_resource_pool_update_auto_grant_skips_missing_keycloak_users(
 ) -> None:
     run_migrations_for_app("common")
     await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
 
     user1 = base_models.APIUser(id="user1-update-missing", full_name="User One")
     user2 = base_models.APIUser(id="user2-update-missing", full_name="User Two")
@@ -1322,6 +1342,7 @@ async def test_resource_pool_update_remote_swap_skips_missing_keycloak_users(
 ) -> None:
     run_migrations_for_app("common")
     await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
 
     user1 = base_models.APIUser(id="user1-swap-missing", full_name="User One")
     user2 = base_models.APIUser(id="user2-swap-missing", full_name="User Two")

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -10,7 +10,7 @@ from ulid import ULID
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
 from renku_data_services.authz.models import Visibility
-from renku_data_services.base_models import APIUser, RESET
+from renku_data_services.base_models import RESET, APIUser
 from renku_data_services.connected_services.db import ConnectedServicesRepository
 from renku_data_services.connected_services.models import ConnectionStatus, ProviderKind, UnsavedOAuth2Client
 from renku_data_services.connected_services.orm import OAuth2ConnectionORM
@@ -321,9 +321,9 @@ async def test_resource_class_create(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert len(retrieved_rp.classes) >= 1
-        assert sum([i == inserted_class for i in retrieved_rp.classes]) == 1, (
-            f"class {inserted_class} should be in {retrieved_rp.classes}"
-        )
+        assert (
+            sum([i == inserted_class for i in retrieved_rp.classes]) == 1
+        ), f"class {inserted_class} should be in {retrieved_rp.classes}"
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -359,9 +359,9 @@ async def test_resource_class_delete(
         retrieved_rps = await pool_repo.get_resource_pools(id=inserted_rp.id, api_user=admin_user)
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
-        assert not any([i == removed_cls for i in retrieved_rp.classes]), (
-            f"class {removed_cls} should not be in {retrieved_rp.classes}"
-        )
+        assert not any(
+            [i == removed_cls for i in retrieved_rp.classes]
+        ), f"class {removed_cls} should not be in {retrieved_rp.classes}"
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -403,12 +403,12 @@ async def test_resource_class_update(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert updated_rc.id == rc_to_update.id
-        assert sum([i == updated_rc for i in retrieved_rp.classes]) == 1, (
-            f"class {updated_rc} should be in {retrieved_rp.classes}"
-        )
-        assert not any([i == rc_to_update for i in retrieved_rp.classes]), (
-            f"class {rc_to_update} should not be in {retrieved_rp.classes}"
-        )
+        assert (
+            sum([i == updated_rc for i in retrieved_rp.classes]) == 1
+        ), f"class {updated_rc} should be in {retrieved_rp.classes}"
+        assert not any(
+            [i == rc_to_update for i in retrieved_rp.classes]
+        ), f"class {rc_to_update} should not be in {retrieved_rp.classes}"
 
     except (ValidationError, errors.ValidationError):
         pass

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -10,9 +10,17 @@ from ulid import ULID
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
 from renku_data_services.authz.models import Visibility
-from renku_data_services.base_models import APIUser
+from renku_data_services.base_models import APIUser, RESET
+from renku_data_services.connected_services.db import ConnectedServicesRepository
+from renku_data_services.connected_services.models import ConnectionStatus, ProviderKind, UnsavedOAuth2Client
+from renku_data_services.connected_services.orm import OAuth2ConnectionORM
 from renku_data_services.crc import models
-from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
+from renku_data_services.crc.models import (
+    MemberType,
+    RemoteConfigurationFirecrest,
+    RemoteConfigurationFirecrestPatch,
+    ResourcePoolMemberIdentifier,
+)
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.namespace import models as namespace_models
@@ -116,6 +124,9 @@ async def test_resource_pool_update_quota(
         assert retrieved_rps[0] == updated_rp
     except (ValidationError, errors.ValidationError):
         pass
+    finally:
+        if inserted_rp is not None:
+            await pool_repo.delete_resource_pool(admin_user, inserted_rp.id)
 
 
 @given(rp=rp_strat(), data=st.data())
@@ -310,9 +321,9 @@ async def test_resource_class_create(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert len(retrieved_rp.classes) >= 1
-        assert (
-            sum([i == inserted_class for i in retrieved_rp.classes]) == 1
-        ), f"class {inserted_class} should be in {retrieved_rp.classes}"
+        assert sum([i == inserted_class for i in retrieved_rp.classes]) == 1, (
+            f"class {inserted_class} should be in {retrieved_rp.classes}"
+        )
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -348,9 +359,9 @@ async def test_resource_class_delete(
         retrieved_rps = await pool_repo.get_resource_pools(id=inserted_rp.id, api_user=admin_user)
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
-        assert not any(
-            [i == removed_cls for i in retrieved_rp.classes]
-        ), f"class {removed_cls} should not be in {retrieved_rp.classes}"
+        assert not any([i == removed_cls for i in retrieved_rp.classes]), (
+            f"class {removed_cls} should not be in {retrieved_rp.classes}"
+        )
     except (ValidationError, errors.ValidationError):
         pass
     finally:
@@ -392,12 +403,12 @@ async def test_resource_class_update(
         assert len(retrieved_rps) == 1
         retrieved_rp = retrieved_rps[0]
         assert updated_rc.id == rc_to_update.id
-        assert (
-            sum([i == updated_rc for i in retrieved_rp.classes]) == 1
-        ), f"class {updated_rc} should be in {retrieved_rp.classes}"
-        assert not any(
-            [i == rc_to_update for i in retrieved_rp.classes]
-        ), f"class {rc_to_update} should not be in {retrieved_rp.classes}"
+        assert sum([i == updated_rc for i in retrieved_rp.classes]) == 1, (
+            f"class {updated_rc} should be in {retrieved_rp.classes}"
+        )
+        assert not any([i == rc_to_update for i in retrieved_rp.classes]), (
+            f"class {rc_to_update} should not be in {retrieved_rp.classes}"
+        )
 
     except (ValidationError, errors.ValidationError):
         pass
@@ -785,3 +796,362 @@ async def test_member_repository_rejects_bad_project_id(
             inserted_rp.id,
             [ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id="not-a-ulid")],
         )
+
+
+async def _insert_provider_and_connect(
+    connected_repo: ConnectedServicesRepository,
+    admin_user: base_models.APIUser,
+    user_api_users: list[base_models.APIUser],
+    provider_id: str,
+    session_maker: any,
+) -> any:
+    """Insert an OAuth2 provider and create connections for users."""
+    client = await connected_repo.insert_oauth2_client(
+        admin_user,
+        UnsavedOAuth2Client(
+            id=provider_id,
+            app_slug=f"{provider_id}-slug",
+            url="https://example.org",
+            kind=ProviderKind.gitlab,
+            client_id="cid",
+            client_secret="secret",
+            display_name="Test Provider",
+            scope="api",
+            use_pkce=False,
+        ),
+    )
+    for user in user_api_users:
+        async with session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=str(user.id),
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+    return client
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_insert_with_remote_grants_connected_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1", full_name="User One")
+    user2 = base_models.APIUser(id="user2", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+    await app_manager_instance.kc_user_repo.get_or_create_user(user2, str(user2.id))
+
+    provider_id = "test-provider-insert"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-insert-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_remote_to_new_provider_swaps_access(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-update", full_name="User One")
+    user2 = base_models.APIUser(id="user2-update", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+    await app_manager_instance.kc_user_repo.get_or_create_user(user2, str(user2.id))
+
+    provider_id_1 = "test-provider-update-1"
+    provider_id_2 = "test-provider-update-2"
+
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id_1,
+        app_manager_instance.config.db.async_session_maker,
+    )
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user2],
+        provider_id_2,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-update-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id_1,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+
+        # Verify user1 has access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+
+        # Update to provider 2
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(
+                remote=RemoteConfigurationFirecrestPatch(provider_id=provider_id_2),
+            ),
+        )
+
+        # Verify user1 lost access and user2 gained access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) not in user_ids
+        assert str(user2.id) in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_remove_remote_revokes_access(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-remove", full_name="User One")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-remove"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-remove-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+
+        # Verify user1 has access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+
+        # Remove remote provider
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(remote=RESET),
+        )
+
+        # Verify user1 lost access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_delete_cleans_authz(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-delete", full_name="User One")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-delete"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-delete-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+    await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+    # After deletion, querying members should return empty
+    members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert str(user1.id) not in user_ids
+    assert len(user_ids) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_insert_with_nonexistent_provider_id_fails(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    rp = models.UnsavedResourcePool(
+        name="test-nonexistent-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id="does-not-exist",
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    with pytest.raises(errors.MissingResourceError):
+        await app_manager_instance.rp_repo.insert_resource_pool(admin_user, rp)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_get_connected_user_ids_returns_only_connected_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-conn", full_name="User One")
+    user2 = base_models.APIUser(id="user2-conn", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+    await app_manager_instance.kc_user_repo.get_or_create_user(user2, str(user2.id))
+
+    provider_id = "test-provider-conn"
+
+    # Insert provider
+    client = await app_manager_instance.connected_services_repo.insert_oauth2_client(
+        admin_user,
+        UnsavedOAuth2Client(
+            id=provider_id,
+            app_slug=f"{provider_id}-slug",
+            url="https://example.org",
+            kind=ProviderKind.gitlab,
+            client_id="cid",
+            client_secret="secret",
+            display_name="Test Provider",
+            scope="api",
+            use_pkce=False,
+        ),
+    )
+
+    # Connect user1 as connected, user2 as pending
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn1 = OAuth2ConnectionORM(
+            user_id=str(user1.id),
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        conn2 = OAuth2ConnectionORM(
+            user_id=str(user2.id),
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.pending,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn1)
+        session.add(conn2)
+
+    # Call the private helper
+    connected_ids = await app_manager_instance.rp_repo._get_connected_user_ids(provider_id)
+    assert str(user1.id) in connected_ids
+    assert str(user2.id) not in connected_ids

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -920,7 +920,7 @@ async def test_resource_pool_update_remote_to_new_provider_swaps_access(
 
     rp = models.UnsavedResourcePool(
         name="test-update-rp",
-        classes=[],
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
         quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
         public=False,
         default=False,
@@ -984,7 +984,7 @@ async def test_resource_pool_update_remove_remote_revokes_access(
 
     rp = models.UnsavedResourcePool(
         name="test-remove-rp",
-        classes=[],
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
         quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
         public=False,
         default=False,

--- a/test/utils.py
+++ b/test/utils.py
@@ -365,6 +365,7 @@ class TestDependencyManager(DependencyManager):
             resource_usage_service=resource_usage_service,
             authz=authz,
             resource_requests_repo=resource_requests_repo,
+            member_repo=member_repo,
         )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,

--- a/test/utils.py
+++ b/test/utils.py
@@ -423,6 +423,7 @@ class TestDependencyManager(DependencyManager):
             session_maker=config.db.async_session_maker,
             encryption_key=config.secrets.encryption_key,
             oauth_client_factory=oauth_client_factory,
+            member_repo=member_repo,
         )
         platform_repo = PlatformRepository(
             session_maker=config.db.async_session_maker,


### PR DESCRIPTION
## Summary

This PR implements automatic authorization for individual users on resource pools by linking them to OAuth2 providers. When an admin creates or updates a resource pool with a `remote.provider_id`, all users who currently have an active (`connected`) OAuth2 connection to that provider are automatically granted `viewer` access. When the provider is changed or removed, access is revoked from the previously connected users and granted to the new ones.

## Motivation & Context

Resource pools already support polymorphic members (users, groups, projects) via Authzed/SpiceDB, and connected-services already supports HPC integrations (FirecREST, Run:AI) through OAuth2. However, granting access to a resource pool tied to an OAuth provider previously required manual admin intervention.

The goal is to make the OAuth2 connection the **source of truth** for resource pool access: if a user is connected to a provider, they should automatically see the resource pools linked to that provider.

## Design Decisions & Rationale

### 1. No Database Migrations
We rely entirely on existing schema:
- `ResourcePoolORM.remote_provider_id` already links a resource pool to an OAuth2 client.
- `OAuth2ConnectionORM` already tracks `user_id`, `client_id`, and `status` (`connected` | `pending`).
- The Authz/SpiceDB schema (v10) already defines `relation viewer: user` on `resource_pool`.

This keeps the change minimal and non-invasive.

### 2. Direct User Authorization (No Hidden Groups)
Rather than creating synthetic/hidden groups to bridge OAuth connections and resource pools, we authorize users **directly** via the `viewer` relation in SpiceDB. This is simpler, more transparent, and avoids the complexity of managing hidden group lifecycle.

A known consequence is that manual admin `viewer` grants and auto-grants are indistinguishable in SpiceDB. Disconnecting a provider unconditionally revokes `viewer` for all its connected users, which is accepted because the OAuth connection is the source of truth.

### 3. Validation Before Mutation
Before inserting or updating a resource pool with a `provider_id`, we validate that the referenced OAuth2 client actually exists:
```python
client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == provider_id))
if client is None:
    raise errors.MissingResourceError(...)
```
This prevents creating dangling links to non-existent providers.

### 4. Best-Effort Membership Sync with Soft Failure
The membership sync (grant/revoke) happens **outside** the main DB transaction. This is intentional because `MemberRepository` operations open their own session and write to SpiceDB via the `@Authz.authz_change` decorator. If a bulk grant fails (e.g., a connected user is missing from Keycloak), the resource pool DB row has already been committed.

We handle this by granting/revoking users **individually** in a loop with `try/except`, logging warnings on failure:
```python
for uid in user_ids:
    member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid)
    try:
        await self.member_repo.grant_resource_pool_members(api_user, result.id, [member])
    except errors.BaseError as e:
        logger.warning(f"Failed to auto-grant member {uid} ...")
```
This ensures one bad user record does not block access for everyone else.

### 5. Update Sync: Capture Old Provider Before Transaction
For updates, we capture `old_provider_id` **before** the transaction begins, then compare it to the `new_provider_id` after the ORM update commits. If they differ:
1. Revoke all connected users of the old provider.
2. Grant all connected users of the new provider.

This cleanly handles:
- Provider swap (A → B)
- Provider removal (A → `None` / `RESET`)
- Provider addition (`None` → B)

## Changes

- **`components/renku_data_services/crc/db.py`**
  - `ResourcePoolRepository.__init__` now accepts an optional `member_repo: MemberRepository`.
  - Added `_get_connected_user_ids(provider_id)` to query `OAuth2ConnectionORM` for users with `status == connected`.
  - `insert_resource_pool`: validates provider existence, then auto-grants connected users after successful insert.
  - `update_resource_pool`: captures old provider, validates new provider, then syncs memberships (revoke old → grant new) after the transaction.
  - `delete_resource_pool`: no changes needed — Authz cascade already cleans up all relations.

- **`bases/renku_data_services/data_api/dependencies.py`** & **`test/utils.py`**
  - Wired `member_repo` into `ResourcePoolRepository` construction.

- **`test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py`**
  - Added comprehensive integration tests:
    - `test_resource_pool_insert_with_remote_grants_connected_users`
    - `test_resource_pool_update_remote_to_new_provider_swaps_access`
    - `test_resource_pool_update_remove_remote_revokes_access`
    - `test_resource_pool_delete_cleans_authz`
    - `test_resource_pool_insert_with_nonexistent_provider_id_fails`
    - `test_get_connected_user_ids_returns_only_connected_users`
    - `test_resource_pool_update_with_nonexistent_provider_id_fails`
    - `test_resource_pool_insert_auto_grant_skips_missing_keycloak_users`
    - `test_resource_pool_update_auto_grant_skips_missing_keycloak_users`
    - `test_resource_pool_update_remote_swap_skips_missing_keycloak_users`

## Behavioral Change (Notable)

### Stricter validation of `remote.provider_id`

`insert_resource_pool` and `update_resource_pool` now validate that the referenced `provider_id` actually exists in `oauth2_clients` **before** persisting the resource pool. If it doesn't exist, they raise `MissingResourceError`.

**Previously:** You could create or update a resource pool with any arbitrary `provider_id` (valid or not), and it would be stored as-is.  
**Now:** The request will fail with a 404-style error.

This is a contract change for the `POST /api/data/resource_pools` and `PATCH /api/data/resource_pools/{id}` endpoints (and their repository equivalents). Any client or script that was previously sending non-existent provider IDs will now get an error instead of silent acceptance.

Everything else is backward-compatible:
- `ResourcePoolRepository.__init__` adds `member_repo: MemberRepository | None = None` — optional, defaults to `None`.
- The auto-grant/revoke logic only runs when `member_repo` is provided.
- No database migrations, no Authz schema changes, no API response format changes.

---

## PR Stack

* base: #1315
  * [this](#1314)
  * #1317
  * #1327