### PR TITLE
feat: automatic resource pool viewer access via OAuth2 provider linkage

### DIFF
--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -362,6 +362,7 @@ class DependencyManager:
             authz=authz,
             resource_usage_service=resource_usage_service,
             resource_requests_repo=resource_requests_repo,
+            member_repo=member_repo,
         )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -244,11 +244,31 @@ class DependencyManager:
             config.secrets.encryption_key, config.db.async_session_maker
         )
 
-        connected_services_repo = ConnectedServicesRepository(
+        metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
+        metrics = StagingMetricsService(enabled=config.posthog.enabled, metrics_repo=metrics_repo)
+        search_updates_repo = SearchUpdatesRepo(session_maker=config.db.async_session_maker)
+        authz = Authz(config.authz_config)
+        group_repo = GroupRepository(
             session_maker=config.db.async_session_maker,
-            encryption_key=config.secrets.encryption_key,
-            oauth_client_factory=oauth_http_client_factory,
+            group_authz=authz,
+            search_updates_repo=search_updates_repo,
         )
+        kc_user_repo = KcUserRepo(
+            session_maker=config.db.async_session_maker,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+            encryption_key=config.secrets.encryption_key,
+            metrics=metrics,
+            authz=authz,
+        )
+
+        project_repo = ProjectRepository(
+            session_maker=config.db.async_session_maker,
+            authz=authz,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+        )
+
         k8s_db_cache = K8sDbCache(config.db.async_session_maker)
         default_kubeconfig = KubeConfigEnv()
         client = K8sClusterClientsPool(
@@ -260,7 +280,22 @@ class DependencyManager:
                 kinds_to_cache=[AMALTHEA_SESSION_GVK, JUPYTER_SESSION_GVK, BUILD_RUN_GVK, TASK_RUN_GVK],
             ),
         )
+
         quota_repo = QuotaRepository(K8sResourceQuotaClient(client), K8sPriorityClassClient(client))
+        member_repo = MemberRepository(
+            session_maker=config.db.async_session_maker,
+            quotas_repo=quota_repo,
+            user_repo=kc_user_repo,
+            group_repo=group_repo,
+            project_repo=project_repo,
+            authz=authz,
+        )
+        connected_services_repo = ConnectedServicesRepository(
+            session_maker=config.db.async_session_maker,
+            encryption_key=config.secrets.encryption_key,
+            oauth_client_factory=oauth_http_client_factory,
+            member_repo=member_repo,
+        )
         job_client = DepositUploadJobClient(client)
         secret_client = K8sSecretClient(client)
 
@@ -310,45 +345,12 @@ class DependencyManager:
                     namespace=config.k8s_namespace,
                 )
 
-        authz = Authz(config.authz_config)
         internal_authenticator = RenkuSelfAuthenticator.from_config(config=config.internal_authn_config)
         internal_token_mint = RenkuSelfTokenMint.from_config(config=config.internal_authn_config)
         internal_scope_verifier = ScopeVerifier(
             deposit_config=config.deposit_config,
             notebook_k8s_client=config.nb_config.k8s_v2_client,
             job_client=job_client,
-        )
-        search_updates_repo = SearchUpdatesRepo(session_maker=config.db.async_session_maker)
-        metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
-        metrics = StagingMetricsService(enabled=config.posthog.enabled, metrics_repo=metrics_repo)
-        group_repo = GroupRepository(
-            session_maker=config.db.async_session_maker,
-            group_authz=authz,
-            search_updates_repo=search_updates_repo,
-        )
-        kc_user_repo = KcUserRepo(
-            session_maker=config.db.async_session_maker,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-            encryption_key=config.secrets.encryption_key,
-            metrics=metrics,
-            authz=authz,
-        )
-
-        project_repo = ProjectRepository(
-            session_maker=config.db.async_session_maker,
-            authz=authz,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-        )
-
-        member_repo = MemberRepository(
-            session_maker=config.db.async_session_maker,
-            quotas_repo=quota_repo,
-            user_repo=kc_user_repo,
-            group_repo=group_repo,
-            project_repo=project_repo,
-            authz=authz,
         )
         resource_requests_repo = ResourceRequestsRepo(
             session_maker=config.db.async_session_maker,

--- a/components/renku_data_services/authz/authz.py
+++ b/components/renku_data_services/authz/authz.py
@@ -191,6 +191,7 @@ class AuthzOperation(StrEnum):
     insert_many = "insert_many"
     create_link = "create_link"
     delete_link = "delete_link"
+    update_membership = "update_membership"
 
 
 class _AuthzConverter:
@@ -960,10 +961,9 @@ class Authz:
                     case AuthzOperation.delete, ResourceType.resource_pool if isinstance(result, DeletedResourcePool):
                         user = _extract_user_from_args(*func_args, **func_kwargs)
                         authz_change = await db_repo.authz._remove_resource_pool(user, result)
-                    case (
-                        (AuthzOperation.create | AuthzOperation.delete),
-                        ResourceType.resource_pool,
-                    ) if isinstance(result, ResourcePoolMembershipChange):
+                    case AuthzOperation.update_membership, ResourceType.resource_pool if isinstance(
+                        result, ResourcePoolMembershipChange
+                    ):
                         authz_change = db_repo.authz._resource_pool_membership_changes_to_authz_change(
                             result, operation
                         )
@@ -1696,7 +1696,7 @@ class Authz:
 
             rel = Relationship(resource=resource, relation=relation, subject=subject)
 
-            if operation == AuthzOperation.create:
+            if mc.change == Change.ADD:
                 apply_updates.append(RelationshipUpdate(operation=RelationshipUpdate.OPERATION_TOUCH, relationship=rel))
                 undo_updates.append(RelationshipUpdate(operation=RelationshipUpdate.OPERATION_DELETE, relationship=rel))
             else:

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -154,6 +154,16 @@ class OAuth2ClientsBP(CustomBlueprint):
                     # TODO: redirect to a error page (that needs to be created)
                     raise errors.ForbiddenError(message="You do not have the required permissions for this operation.")
                 case _:
+                    user_id = client.connection.user_id
+                    provider_id = client.connection.client_id
+                    if user_id is not None and provider_id is not None:
+                        try:
+                            await self.connected_services_repo.on_oauth2_connected(user_id, provider_id)
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to sync resource pool memberships after OAuth2 connection for user "
+                                f"{user_id} and provider {provider_id}: {e}"
+                            )
                     next_url = client.connection.next_url
                     return redirect(to=next_url) if next_url else json({"status": "OK"})
 

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -1,6 +1,9 @@
 """Adapters for connected services database classes."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from sqlalchemy import and_, select
@@ -11,15 +14,21 @@ from ulid import ULID
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
 from renku_data_services.app_config import logging
+from renku_data_services.base_models.core import InternalServiceAdmin
 from renku_data_services.connected_services import models
 from renku_data_services.connected_services import orm as schemas
 from renku_data_services.connected_services.oauth_http import (
     OAuthHttpClientFactory,
     OAuthHttpFactoryError,
 )
+from renku_data_services.crc import orm as crc_schemas
 from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDockerAPI
 from renku_data_services.users.db import APIUser
+from renku_data_services.utils.core import with_db_transaction
 from renku_data_services.utils.cryptography import encrypt_string
+
+if TYPE_CHECKING:
+    from renku_data_services.crc.db import MemberRepository
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +41,50 @@ class ConnectedServicesRepository:
         session_maker: Callable[..., AsyncSession],
         oauth_client_factory: OAuthHttpClientFactory,
         encryption_key: bytes,
+        member_repo: MemberRepository,
     ):
         self.session_maker = session_maker
         self.encryption_key = encryption_key
         self.oauth_client_factory = oauth_client_factory
         self.supported_image_registry_providers = {models.ProviderKind.gitlab, models.ProviderKind.github}
+        self.member_repo = member_repo
+
+    async def _get_rp_ids_for_provider(self, client_id: str, session: AsyncSession) -> list[int]:
+        """Get all resource pool IDs linked to a given OAuth2 provider."""
+        rps = await session.scalars(
+            select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
+        )
+        return [rp.id for rp in rps]
+
+    @with_db_transaction
+    async def on_oauth2_connected(self, user_id: str, client_id: str, session: AsyncSession | None = None) -> None:
+        """Grant user viewer access to all RPs linked to the provider."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        admin = InternalServiceAdmin()
+        rp_ids = await self._get_rp_ids_for_provider(client_id, session)
+        if rp_ids:
+            try:
+                await self.member_repo.update_user_resource_pools(admin, user_id, rp_ids, append=True, session=session)
+            except errors.BaseError as e:
+                logger.warning(
+                    f"Failed to auto-grant member {user_id} to resource pools {rp_ids} for provider {client_id}: {e}"
+                )
+
+    @with_db_transaction
+    async def on_oauth2_disconnected(self, user_id: str, client_id: str, session: AsyncSession | None = None) -> None:
+        """Revoke user viewer access from all RPs linked to the provider."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        admin = InternalServiceAdmin()
+        rp_ids = await self._get_rp_ids_for_provider(client_id, session)
+        if rp_ids:
+            try:
+                await self.member_repo.remove_user_resource_pools(admin, user_id, rp_ids, session=session)
+            except errors.BaseError as e:
+                logger.warning(
+                    f"Failed to auto-revoke member {user_id} from resource pools {rp_ids} for provider {client_id}: {e}"
+                )
 
     async def get_oauth2_clients(
         self,
@@ -190,6 +238,16 @@ class ConnectedServicesRepository:
                 return False
 
             await session.delete(conn)
+            await session.flush()
+
+            try:
+                await self.on_oauth2_disconnected(conn.user_id, conn.client_id, session=session)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to sync resource pool memberships after OAuth2 disconnection for user "
+                    f"{conn.user_id} and provider {conn.client_id}: {e}"
+                )
+
             return True
 
     async def get_oauth2_connections(

--- a/components/renku_data_services/connected_services/models.py
+++ b/components/renku_data_services/connected_services/models.py
@@ -85,6 +85,8 @@ class OAuth2Connection:
     provider_id: str
     status: ConnectionStatus
     next_url: str | None
+    user_id: str | None = None
+    client_id: str | None = None
 
     def is_connected(self) -> bool:
         """Returns whether this connection is in status 'connected'."""

--- a/components/renku_data_services/connected_services/orm.py
+++ b/components/renku_data_services/connected_services/orm.py
@@ -110,5 +110,10 @@ class OAuth2ConnectionORM(BaseORM):
     def dump(self) -> models.OAuth2Connection:
         """Create an OAuth2 connection model from the OAuth2ConnectionORM."""
         return models.OAuth2Connection(
-            id=self.id, provider_id=self.client_id, status=self.status, next_url=self.next_url
+            id=self.id,
+            provider_id=self.client_id,
+            status=self.status,
+            next_url=self.next_url,
+            user_id=self.user_id,
+            client_id=self.client_id,
         )

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1065,73 +1065,115 @@ class MemberRepository(_Base):
                 output.append(rp.dump(quota))
             return output
 
+    async def _sync_user_resource_pool_membership(
+        self,
+        api_user: base_models.APIUser,
+        user: schemas.UserORM,
+        rps_to_add: Collection[schemas.ResourcePoolORM],
+        rps_to_remove: Collection[schemas.ResourcePoolORM],
+        session: AsyncSession,
+    ) -> None:
+        """Synchronize a user's resource pool memberships in SQL and Authz."""
+        member_identifier = ResourcePoolMemberIdentifier(member_id=user.keycloak_id, member_type=MemberType.USER)
+        for rp in rps_to_add:
+            if rp not in user.resource_pools:
+                user.resource_pools.append(rp)
+            await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
+            if rp.default or rp.public:
+                await self._unprohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+        for rp in rps_to_remove:
+            if rp in user.resource_pools:
+                user.resource_pools.remove(rp)
+            await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
+            if rp.default or rp.public:
+                await self._prohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+
+    @with_db_transaction
     @_only_admins
     async def update_user_resource_pools(
-        self, api_user: base_models.APIUser, keycloak_id: str, resource_pool_ids: list[int], append: bool = True
+        self,
+        api_user: base_models.APIUser,
+        keycloak_id: str,
+        resource_pool_ids: list[int],
+        append: bool = True,
+        session: AsyncSession | None = None,
     ) -> list[models.ResourcePool]:
         """Update the resource pools that a specific user has access to."""
-        async with self.session_maker() as session, session.begin():
-            kc_user = await self.kc_user_repo.get_user(keycloak_id)
-            if kc_user is None:
-                raise errors.MissingResourceError(message=f"The user with ID {keycloak_id} does not exist")
-            stmt = (
-                select(schemas.UserORM)
-                .where(schemas.UserORM.keycloak_id == keycloak_id)
-                .options(selectinload(schemas.UserORM.resource_pools))
-            )
-            res = await session.execute(stmt)
-            user = res.scalars().first()
-            if user is None:
-                user = schemas.UserORM(keycloak_id=keycloak_id)
-                session.add(user)
-            stmt_rp = (
-                select(schemas.ResourcePoolORM)
-                .where(schemas.ResourcePoolORM.id.in_(resource_pool_ids))
-                .options(selectinload(schemas.ResourcePoolORM.classes))
-            )
-            if user.no_default_access:
-                stmt_rp = stmt_rp.where(schemas.ResourcePoolORM.default == false())
-            res_rp = await session.execute(stmt_rp)
-            rps_to_add = res_rp.scalars().all()
-            if len(rps_to_add) != len(resource_pool_ids):
-                missing_rps = set(resource_pool_ids).difference(set([i.id for i in rps_to_add]))
-                raise errors.MissingResourceError(
-                    message=(
-                        f"The resource pools with ids: {missing_rps} do not exist or user doesn't have access to "
-                        "default resource pool."
-                    )
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        kc_user = await self.kc_user_repo.get_user(keycloak_id)
+        if kc_user is None:
+            raise errors.MissingResourceError(message=f"The user with ID {keycloak_id} does not exist")
+        stmt = (
+            select(schemas.UserORM)
+            .where(schemas.UserORM.keycloak_id == keycloak_id)
+            .options(selectinload(schemas.UserORM.resource_pools))
+        )
+        res = await session.execute(stmt)
+        user = res.scalars().first()
+        if user is None:
+            user = schemas.UserORM(keycloak_id=keycloak_id)
+            session.add(user)
+        stmt_rp = (
+            select(schemas.ResourcePoolORM)
+            .where(schemas.ResourcePoolORM.id.in_(resource_pool_ids))
+            .options(selectinload(schemas.ResourcePoolORM.classes))
+        )
+        if user.no_default_access:
+            stmt_rp = stmt_rp.where(schemas.ResourcePoolORM.default == false())
+        res_rp = await session.execute(stmt_rp)
+        rps_to_add = res_rp.scalars().all()
+        if len(rps_to_add) != len(resource_pool_ids):
+            missing_rps = set(resource_pool_ids).difference(set([i.id for i in rps_to_add]))
+            raise errors.MissingResourceError(
+                message=(
+                    f"The resource pools with ids: {missing_rps} do not exist or user doesn't have access to "
+                    "default resource pool."
                 )
-            if user.no_default_access:
-                default_rp = next((rp for rp in rps_to_add if rp.default), None)
-                if default_rp:
-                    raise errors.ForbiddenError(
-                        message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
-                    )
-            existing_rp_ids = {rp.id for rp in user.resource_pools}
-            new_rp_ids = {rp.id for rp in rps_to_add}
-            if append:
-                rps_to_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
-                user.resource_pools.extend(rps_to_add)
-                removed_rps: list[schemas.ResourcePoolORM] = []
-            else:
-                removed_rps = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
-                user.resource_pools = list(rps_to_add)
-            # TODO: the authz changes below are done in separate db transactions,
-            # TODO: use only one (collect everything into a single authz change)
-            member_identifier = ResourcePoolMemberIdentifier(member_id=keycloak_id, member_type=MemberType.USER)
-            for rp in rps_to_add:
-                await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
-                if rp.default or rp.public:
-                    await self._unprohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
-            for rp in removed_rps:
-                await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
-                if rp.default or rp.public:
-                    await self._prohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
-            output: list[models.ResourcePool] = []
-            for rp in rps_to_add:
-                quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
-                output.append(rp.dump(quota))
-            return output
+            )
+        if user.no_default_access:
+            default_rp = next((rp for rp in rps_to_add if rp.default), None)
+            if default_rp:
+                raise errors.ForbiddenError(
+                    message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
+                )
+        existing_rp_ids = {rp.id for rp in user.resource_pools}
+        new_rp_ids = {rp.id for rp in rps_to_add}
+        if append:
+            actual_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
+            actual_remove: list[schemas.ResourcePoolORM] = []
+        else:
+            actual_add = list(rps_to_add)
+            actual_remove = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
+        await self._sync_user_resource_pool_membership(api_user, user, actual_add, actual_remove, session)
+        output: list[models.ResourcePool] = []
+        for rp in actual_add:
+            quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
+            output.append(rp.dump(quota))
+        return output
+
+    @with_db_transaction
+    @_only_admins
+    async def remove_user_resource_pools(
+        self,
+        api_user: base_models.APIUser,
+        keycloak_id: str,
+        resource_pool_ids: list[int],
+        session: AsyncSession | None = None,
+    ) -> None:
+        """Remove a user from specific resource pools."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        stmt = (
+            select(schemas.UserORM)
+            .where(schemas.UserORM.keycloak_id == keycloak_id)
+            .options(selectinload(schemas.UserORM.resource_pools))
+        )
+        res = await session.execute(stmt)
+        user = res.scalars().first()
+        if user is not None:
+            actual_remove = [rp for rp in user.resource_pools if rp.id in resource_pool_ids]
+            await self._sync_user_resource_pool_membership(api_user, user, [], actual_remove, session)
 
     @_only_admins
     async def delete_resource_pool_user(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -28,6 +28,8 @@ from renku_data_services.authz.authz import Authz, AuthzOperation
 from renku_data_services.authz.models import Change, Member, MembershipChange, Role, Scope
 from renku_data_services.base_models import RESET
 from renku_data_services.base_models.core import ResetType, ResourceType
+from renku_data_services.connected_services.models import ConnectionStatus
+from renku_data_services.connected_services.orm import OAuth2ClientORM, OAuth2ConnectionORM
 from renku_data_services.crc import models
 from renku_data_services.crc import orm as schemas
 from renku_data_services.crc.core import (
@@ -52,11 +54,11 @@ from renku_data_services.resource_usage.db import ResourceRequestsRepo
 from renku_data_services.users.db import UserRepo
 from renku_data_services.utils.core import with_db_transaction
 
-logger = logging.getLogger(__name__)
-
 if TYPE_CHECKING:
     from renku_data_services.namespace.db import GroupRepository
     from renku_data_services.project.db import ProjectRepository
+
+logger = logging.getLogger(__name__)
 
 
 class _Base:
@@ -358,6 +360,7 @@ class ResourcePoolRepository(_Base):
         authz: Authz,
         resource_usage_service: ResourceUsageService | None = None,
         resource_requests_repo: ResourceRequestsRepo | None = None,
+        member_repo: MemberRepository | None = None,
     ):
         super().__init__(session_maker, quotas_repo, authz)
         self.__query_repository = ResourcePoolQueryRepository(
@@ -368,6 +371,7 @@ class ResourcePoolRepository(_Base):
             resource_requests_repo=resource_requests_repo,
         )
         self.__cluster_repo = ClusterRepository(session_maker=self.session_maker)
+        self.member_repo = member_repo
 
     async def initialize(self, async_connection_url: str, rp: models.UnsavedResourcePool) -> None:
         """Add the default resource pool if it does not already exist."""
@@ -436,17 +440,53 @@ class ResourcePoolRepository(_Base):
         """Get resource pools from database with indication of which resource class matches the specified criteria."""
         return await self.__query_repository.filter_resource_pools(api_user, cpu, memory, max_storage, gpu)
 
+    @with_db_transaction
+    async def _get_connected_user_ids(self, provider_id: str, session: AsyncSession | None = None) -> list[str]:
+        """Query all users with a connected OAuth2 connection to the given provider."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        result = await session.scalars(
+            select(OAuth2ConnectionORM.user_id)
+            .where(OAuth2ConnectionORM.client_id == provider_id)
+            .where(OAuth2ConnectionORM.status == ConnectionStatus.connected)
+        )
+        return list(result.all())
+
     @_only_admins
     async def insert_resource_pool(
         self, api_user: base_models.APIUser, new_resource_pool: models.UnsavedResourcePool
     ) -> models.ResourcePool:
         """Insert resource pool into database."""
         async with self.session_maker() as session, session.begin():
-            return await self._insert_resource_pool(
+            provider_id = None
+            if new_resource_pool.remote and new_resource_pool.remote.provider_id:
+                provider_id = new_resource_pool.remote.provider_id
+                client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == provider_id))
+                if client is None:
+                    raise errors.ValidationError(message=f"Provider ID's value is incorrect: '{provider_id}'")
+
+            members = None
+            if provider_id:
+                user_ids = await self._get_connected_user_ids(provider_id, session=session)
+                members = [ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in user_ids]
+
+            result = await self._insert_resource_pool(
                 api_user=api_user,
                 new_resource_pool=new_resource_pool,
                 session=session,
             )
+
+            # TODO figure out how to ensure we can commit AUTHZ changes in the same DB session
+
+            if members is not None and self.member_repo is not None:
+                try:
+                    await self.member_repo.grant_resource_pool_members(api_user, result.id, members, skip_missing=True)
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-grant members to resource pool {result.id} for provider {provider_id}: {e}"
+                    )
+
+        return result
 
     @with_db_transaction
     @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
@@ -548,6 +588,7 @@ class ResourcePoolRepository(_Base):
             rp = res.one_or_none()
             if rp is None:
                 raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} cannot be found")
+            old_provider_id = rp.remote_provider_id
             quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
 
             validate_resource_pool_update(existing=rp.dump(quota=quota), update=update)
@@ -633,9 +674,16 @@ class ResourcePoolRepository(_Base):
                 rp.remote_provider_id = None
                 rp.remote_json = None
             elif update.remote is not None:
-                rp.remote_provider_id = (
+                new_provider_id = (
                     update.remote.provider_id if update.remote.provider_id is not None else rp.remote_provider_id
                 )
+                if new_provider_id is not None and new_provider_id != rp.remote_provider_id:
+                    client = await session.scalar(select(OAuth2ClientORM).where(OAuth2ClientORM.id == new_provider_id))
+                    if client is None:
+                        raise errors.MissingResourceError(
+                            message=f"OAuth2 Client with id '{new_provider_id}' does not exist."
+                        )
+                rp.remote_provider_id = new_provider_id
                 remote_json = rp.remote_json if rp.remote_json is not None else dict()
                 remote_json.update(update.remote.to_dict())
                 del remote_json["provider_id"]
@@ -644,14 +692,56 @@ class ResourcePoolRepository(_Base):
             await gather(*new_classes_coroutines)
             await session.flush()
             await session.refresh(rp)
-            result = rp.dump(quota=quota)
+            transaction_result = rp.dump(quota=quota)
+            new_provider_id = transaction_result.remote.provider_id if transaction_result.remote else None
+            old_members, new_members = None, None
+            if old_provider_id != new_provider_id:
+                # Get old
+                if old_provider_id is not None:
+                    old_user_ids = await self._get_connected_user_ids(old_provider_id, session=session)
+                    old_members = [
+                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in old_user_ids
+                    ]
+                # Get new
+                if new_provider_id is not None:
+                    new_user_ids = await self._get_connected_user_ids(new_provider_id, session=session)
+                    new_members = [
+                        ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=uid) for uid in new_user_ids
+                    ]
             if update_authz:
-                return await self._update_resource_pool(
+                transaction_result = await self._update_resource_pool(
                     api_user=api_user,
-                    rp=result,
+                    rp=transaction_result,
                     session=session,
                 )
-            return result
+
+        # After transaction, sync memberships
+        if self.member_repo is not None:
+            # Revoke old
+            if old_members is not None:
+                try:
+                    await self.member_repo.revoke_resource_pool_members(
+                        api_user, resource_pool_id, old_members, skip_missing=True
+                    )
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-revoke members from resource pool {resource_pool_id} "
+                        f"for provider {old_provider_id}: {e}"
+                    )
+
+            # Grant new
+            if new_members is not None:
+                try:
+                    await self.member_repo.grant_resource_pool_members(
+                        api_user, resource_pool_id, new_members, skip_missing=True
+                    )
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-grant members to resource pool {resource_pool_id} "
+                        f"for provider {new_provider_id}: {e}"
+                    )
+
+        return transaction_result
 
     @with_db_transaction
     @Authz.authz_change(op=AuthzOperation.update, resource=ResourceType.resource_pool)
@@ -1313,33 +1403,35 @@ class MemberRepository(_Base):
         self,
         api_user: base_models.APIUser,
         members: Collection[ResourcePoolMemberIdentifier],
-    ) -> list[tuple[str, ResourceType, str]]:
-        """Resolve ResourcePoolMemberIdentifiers to (internal_id, subject_type, role) tuples."""
-        resolved: list[tuple[str, ResourceType, str]] = []
+        skip_missing: bool = False,
+    ) -> list[tuple[str, ResourceType, str, MemberType]]:
+        """Resolve ResourcePoolMemberIdentifiers to (internal_id, subject_type, role, member_type) tuples."""
+        resolved: list[tuple[str, ResourceType, str, MemberType]] = []
         for member in members:
             match member.member_type:
                 case MemberType.USER:
                     kc_user = await self.kc_user_repo.get_user(id=member.member_id)
                     if kc_user is None:
+                        if skip_missing:
+                            logger.warning(f"Skipping auto-grant for missing user {member.member_id}")
+                            continue
                         raise errors.MissingResourceError(message=f"User with ID {member.member_id} does not exist")
-                    resolved.append((kc_user.id, ResourceType.user, member.role))
+                    resolved.append((kc_user.id, ResourceType.user, member.role, member.member_type))
 
                 case MemberType.GROUP:
                     group_id = ULID.from_str(member.member_id)
                     group = await self.group_repo.get_group_by_id(api_user, group_id)
-                    if group is None:
-                        raise errors.MissingResourceError(message=f"Group with id {member.member_id!r} does not exist")
-                    resolved.append((str(group.id), ResourceType.group, member.role))
+                    resolved.append((str(group.id), ResourceType.group, member.role, member.member_type))
 
                 case MemberType.PROJECT:
                     project_id = ULID.from_str(member.member_id)
                     project = await self.project_repo.get_project(api_user, project_id)
-                    resolved.append((str(project.id), ResourceType.project, member.role))
+                    resolved.append((str(project.id), ResourceType.project, member.role, member.member_type))
 
         return resolved
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _unprohibit_resource_pool_users(
         self,
         api_user: base_models.APIUser,
@@ -1351,7 +1443,7 @@ class MemberRepository(_Base):
         return self._build_pool_membership_changes(resource_pool_id, specs, Change.REMOVE)
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _prohibit_resource_pool_users(
         self,
         api_user: base_models.APIUser,
@@ -1363,39 +1455,41 @@ class MemberRepository(_Base):
         return self._build_pool_membership_changes(resource_pool_id, specs, Change.ADD)
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.create, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _grant_resource_pool_members(
         self,
         api_user: base_models.APIUser,
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
         session: AsyncSession | None = None,
+        skip_missing: bool = False,
     ) -> models.ResourcePoolMembershipChange | None:
-        specs = await self._resolve_members(api_user, members)
+        specs = await self._resolve_members(api_user, members, skip_missing=skip_missing)
         return self._build_pool_membership_changes(
             resource_pool_id,
             [
-                (member_id, subject_type, self._api_role_to_authz_role(role, member.member_type))
-                for (member_id, subject_type, role), member in zip(specs, members, strict=True)
+                (member_id, subject_type, self._api_role_to_authz_role(role, member_type))
+                for (member_id, subject_type, role, member_type) in specs
             ],
             Change.ADD,
         )
 
     @with_db_transaction
-    @Authz.authz_change(op=AuthzOperation.delete, resource=ResourceType.resource_pool)
+    @Authz.authz_change(op=AuthzOperation.update_membership, resource=ResourceType.resource_pool)
     async def _revoke_resource_pool_members(
         self,
         api_user: base_models.APIUser,
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
         session: AsyncSession | None = None,
+        skip_missing: bool = False,
     ) -> models.ResourcePoolMembershipChange | None:
-        specs = await self._resolve_members(api_user, members)
+        specs = await self._resolve_members(api_user, members, skip_missing=skip_missing)
         return self._build_pool_membership_changes(
             resource_pool_id,
             [
-                (member_id, subject_type, self._api_role_to_authz_role(role, member.member_type))
-                for (member_id, subject_type, role), member in zip(specs, members, strict=True)
+                (member_id, subject_type, self._api_role_to_authz_role(role, member_type))
+                for (member_id, subject_type, role, member_type) in specs
             ],
             Change.REMOVE,
         )
@@ -1407,10 +1501,13 @@ class MemberRepository(_Base):
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
         append: bool = True,
+        skip_missing: bool = False,
     ) -> None:
         """Grant access to a resource pool for a collection of members (Users, Groups, Projects)."""
         async with self.session_maker() as session, session.begin():
-            await self._grant_resource_pool_members(api_user, resource_pool_id, members, session=session)
+            await self._grant_resource_pool_members(
+                api_user, resource_pool_id, members, session=session, skip_missing=skip_missing
+            )
 
     @_only_admins
     async def revoke_resource_pool_members(
@@ -1418,10 +1515,13 @@ class MemberRepository(_Base):
         api_user: base_models.APIUser,
         resource_pool_id: int,
         members: Collection[ResourcePoolMemberIdentifier],
+        skip_missing: bool = False,
     ) -> None:
         """Revoke access to a resource pool for a collection of members (Users, Groups, Projects)."""
         async with self.session_maker() as session, session.begin():
-            await self._revoke_resource_pool_members(api_user, resource_pool_id, members, session=session)
+            await self._revoke_resource_pool_members(
+                api_user, resource_pool_id, members, session=session, skip_missing=skip_missing
+            )
 
     @_only_admins
     async def get_resource_pool_members(

--- a/test/bases/renku_data_services/data_api/test_connected_services.py
+++ b/test/bases/renku_data_services/data_api/test_connected_services.py
@@ -13,9 +13,10 @@ from renku_data_services.connected_services.apispec_base import CallbackParams
 from renku_data_services.connected_services.blueprints import OAuth2ClientsBP
 from renku_data_services.data_api.app import register_all_handlers
 from renku_data_services.data_api.dependencies import DependencyManager
+from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.users.models import UserInfo
 from test.bases.renku_data_services.data_api.utils import create_dummy_oauth_client
-from test.utils import SanicReusableASGITestClient
+from test.utils import KindCluster, SanicReusableASGITestClient
 
 if TYPE_CHECKING:
     from renku_data_services.data_api.dependencies import DependencyManager
@@ -637,3 +638,155 @@ async def test_get_token_with_internal_token(
     assert isinstance(result.get("expires_at"), int) and result["expires_at"] > 0
     assert isinstance(result.get("expires_at_iso"), str) and result["expires_at_iso"] != ""
     assert result.get("expires_in") == 3600
+
+
+# --- Integration Group Connected Services API Tests (E1-E2) ---
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_adds_user_to_rp(
+    oauth2_test_client: SanicASGITestClient,
+    app_manager_instance: "DependencyManager",
+    admin_user: UserInfo,
+    regular_user: UserInfo,
+    admin_headers: dict[str, str],
+    user_headers: dict[str, str],
+    create_oauth2_provider,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+
+    provider = await create_oauth2_provider("hpc-auth")
+    provider_id = provider["id"]
+
+    # Admin creates a private RP linked to the provider
+    rp_payload = {
+        "name": "hpc-auth-rp",
+        "classes": [
+            {
+                "cpu": 1.0,
+                "memory": 10,
+                "gpu": 0,
+                "name": "class1",
+                "max_storage": 100,
+                "default_storage": 1,
+                "default": True,
+                "node_affinities": [],
+                "tolerations": [],
+            }
+        ],
+        "quota": {"cpu": 100, "memory": 100, "gpu": 0},
+        "default": False,
+        "public": False,
+        "remote": {
+            "kind": "firecrest",
+            "provider_id": provider_id,
+            "api_url": "https://example.org",
+            "system_name": "sys",
+        },
+    }
+    _, res = await oauth2_test_client.post("/api/data/resource_pools", headers=admin_headers, json=rp_payload)
+    assert res.status_code == 201
+    rp = res.json
+
+    # Regular user cannot see the RP before connecting
+    _, res = await oauth2_test_client.get("/api/data/resource_pools", headers=user_headers)
+    assert res.status_code == 200
+    rp_ids_before = {r["id"] for r in res.json}
+    assert rp["id"] not in rp_ids_before
+
+    # Regular user completes OAuth flow
+    _, res = await oauth2_test_client.get(f"/api/data/oauth2/providers/{provider_id}/authorize", headers=user_headers)
+    assert res.status_code == 302
+    location = res.headers["location"]
+    state = parse_qs(urlparse(location).query)["state"][0]
+    _, res = await oauth2_test_client.get(f"/api/data/oauth2/callback?state={state}")
+    assert res.status_code == 200
+
+    # Regular user can now see the RP
+    _, res = await oauth2_test_client.get("/api/data/resource_pools", headers=user_headers)
+    assert res.status_code == 200
+    rp_ids_after = {r["id"] for r in res.json}
+    assert rp["id"] in rp_ids_after
+
+    # Cleanup
+    _, res = await oauth2_test_client.delete(f"/api/data/resource_pools/{rp['id']}", headers=admin_headers)
+    assert res.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_oauth_connection_removes_rp_access(
+    oauth2_test_client: SanicASGITestClient,
+    app_manager_instance: "DependencyManager",
+    admin_user: UserInfo,
+    regular_user: UserInfo,
+    admin_headers: dict[str, str],
+    user_headers: dict[str, str],
+    create_oauth2_provider,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+
+    provider = await create_oauth2_provider("hpc-revoke")
+    provider_id = provider["id"]
+
+    rp_payload = {
+        "name": "hpc-revoke-rp",
+        "classes": [
+            {
+                "cpu": 1.0,
+                "memory": 10,
+                "gpu": 0,
+                "name": "class1",
+                "max_storage": 100,
+                "default_storage": 1,
+                "default": True,
+                "node_affinities": [],
+                "tolerations": [],
+            }
+        ],
+        "quota": {"cpu": 100, "memory": 100, "gpu": 0},
+        "default": False,
+        "public": False,
+        "remote": {
+            "kind": "firecrest",
+            "provider_id": provider_id,
+            "api_url": "https://example.org",
+            "system_name": "sys",
+        },
+    }
+    _, res = await oauth2_test_client.post("/api/data/resource_pools", headers=admin_headers, json=rp_payload)
+    assert res.status_code == 201
+    rp = res.json
+
+    # Regular user completes OAuth flow
+    _, res = await oauth2_test_client.get(f"/api/data/oauth2/providers/{provider_id}/authorize", headers=user_headers)
+    assert res.status_code == 302
+    location = res.headers["location"]
+    state = parse_qs(urlparse(location).query)["state"][0]
+    _, res = await oauth2_test_client.get(f"/api/data/oauth2/callback?state={state}")
+    assert res.status_code == 200
+
+    # Regular user can see the RP
+    _, res = await oauth2_test_client.get("/api/data/resource_pools", headers=user_headers)
+    assert res.status_code == 200
+    rp_ids_after = {r["id"] for r in res.json}
+    assert rp["id"] in rp_ids_after
+
+    # Delete the connection
+    _, res = await oauth2_test_client.get("/api/data/oauth2/connections", headers=user_headers)
+    assert res.status_code == 200
+    connections = res.json
+    conn = next(c for c in connections if c["provider_id"] == provider_id)
+    _, res = await oauth2_test_client.delete(f"/api/data/oauth2/connections/{conn['id']}", headers=user_headers)
+    assert res.status_code == 204
+
+    # Regular user can no longer see the RP
+    _, res = await oauth2_test_client.get("/api/data/resource_pools", headers=user_headers)
+    assert res.status_code == 200
+    rp_ids_final = {r["id"] for r in res.json}
+    assert rp["id"] not in rp_ids_final
+
+    # Cleanup
+    _, res = await oauth2_test_client.delete(f"/api/data/resource_pools/{rp['id']}", headers=admin_headers)
+    assert res.status_code == 204

--- a/test/bases/renku_data_services/data_api/test_resource_pools.py
+++ b/test/bases/renku_data_services/data_api/test_resource_pools.py
@@ -3,14 +3,17 @@ from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from sanic_testing.testing import SanicASGITestClient
 from ulid import ULID
 
+from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.resource_usage.db import ResourceRequestsRepo
 from renku_data_services.resource_usage.model import Credit, ResourceClassCost, ResourcePoolLimits
-from test.bases.renku_data_services.data_api.utils import create_rp
+from renku_data_services.users.models import UserInfo
+from test.bases.renku_data_services.data_api.utils import create_dummy_oauth_client, create_rp
 from test.components.renku_data_services.resource_usage.helper import make_resources_request
 from test.utils import KindCluster
 
@@ -2961,3 +2964,201 @@ async def test_resource_pool_members_delete_nonexistent_project(
         headers=admin_headers,
     )
     assert res.status_code == 204
+
+
+# --- Integration Group API Tests (D1-D3) ---
+
+
+async def _complete_oauth_flow(
+    test_client: SanicASGITestClient,
+    provider_id: str,
+    user_headers: dict[str, str],
+) -> None:
+    """Helper to complete a dummy OAuth2 authorization flow for a given provider."""
+    _, res = await test_client.get(f"/api/data/oauth2/providers/{provider_id}/authorize", headers=user_headers)
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+    state = parse_qs(urlparse(location).query)["state"][0]
+    _, res = await test_client.get(f"/api/data/oauth2/callback?state={state}")
+    assert res.status_code == 200, res.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_post_resource_pool_with_remote_grants_connected_users(
+    sanic_client: SanicASGITestClient,
+    app_manager_instance: "DependencyManager",
+    admin_headers: dict[str, str],
+    user_headers: dict[str, str],
+    regular_user: UserInfo,
+    cluster: KindCluster,
+) -> None:
+    # Set up dummy OAuth client so the flow works
+    app_manager_instance.oauth_http_client_factory.create_client = create_dummy_oauth_client
+
+    # Create provider
+    provider_payload = {
+        "id": "d1-provider",
+        "kind": "gitlab",
+        "client_id": "cid",
+        "client_secret": "secret",
+        "display_name": "D1 Provider",
+        "scope": "api",
+        "url": "https://example.org",
+        "use_pkce": False,
+    }
+    _, res = await sanic_client.post("/api/data/oauth2/providers", headers=admin_headers, json=provider_payload)
+    assert res.status_code == 201, res.text
+    provider_id = provider_payload["id"]
+
+    # Regular user connects to provider
+    await _complete_oauth_flow(sanic_client, provider_id, user_headers)
+
+    # Admin creates linked RP
+    rp_payload = {
+        "name": "d1-rp",
+        "classes": [
+            {
+                "cpu": 1.0,
+                "memory": 10,
+                "gpu": 0,
+                "name": "class1",
+                "max_storage": 100,
+                "default_storage": 1,
+                "default": True,
+                "node_affinities": [],
+                "tolerations": [],
+            }
+        ],
+        "quota": {"cpu": 100, "memory": 100, "gpu": 0},
+        "default": False,
+        "public": False,
+        "remote": {
+            "kind": "firecrest",
+            "provider_id": provider_id,
+            "api_url": "https://example.org",
+            "system_name": "sys",
+        },
+    }
+    _, res = await create_rp(rp_payload, sanic_client)
+    assert res.status_code == 201, res.text
+    rp = res.json
+
+    # Regular user can now see the RP
+    _, res = await sanic_client.get("/api/data/resource_pools", headers=user_headers)
+    assert res.status_code == 200, res.text
+    rp_ids = {r["id"] for r in res.json}
+    assert rp["id"] in rp_ids
+
+    # Cleanup
+    _, res = await sanic_client.delete(f"/api/data/resource_pools/{rp['id']}", headers=admin_headers)
+    assert res.status_code == 204, res.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_patch_resource_pool_remote_change_swaps_access(
+    sanic_client: SanicASGITestClient,
+    app_manager_instance: "DependencyManager",
+    admin_headers: dict[str, str],
+    user_headers: dict[str, str],
+    member_1_headers: dict[str, str],
+    regular_user: UserInfo,
+    member_1_user: UserInfo,
+    cluster: KindCluster,
+) -> None:
+    app_manager_instance.oauth_http_client_factory.create_client = create_dummy_oauth_client
+
+    # Create two providers
+    p1_payload = {
+        "id": "d3-p1",
+        "kind": "gitlab",
+        "client_id": "c1",
+        "client_secret": "s1",
+        "display_name": "D3 P1",
+        "scope": "api",
+        "url": "https://example.org",
+        "use_pkce": False,
+    }
+    p2_payload = {
+        "id": "d3-p2",
+        "kind": "gitlab",
+        "client_id": "c2",
+        "client_secret": "s2",
+        "display_name": "D3 P2",
+        "scope": "api",
+        "url": "https://example.org",
+        "use_pkce": False,
+    }
+    _, res = await sanic_client.post("/api/data/oauth2/providers", headers=admin_headers, json=p1_payload)
+    assert res.status_code == 201, res.text
+    _, res = await sanic_client.post("/api/data/oauth2/providers", headers=admin_headers, json=p2_payload)
+    assert res.status_code == 201, res.text
+
+    # Connect regular_user to P1 and member_1 to P2
+    await _complete_oauth_flow(sanic_client, p1_payload["id"], user_headers)
+    await _complete_oauth_flow(sanic_client, p2_payload["id"], member_1_headers)
+
+    # Admin creates RP linked to P1
+    rp_payload = {
+        "name": "d3-rp",
+        "classes": [
+            {
+                "cpu": 1.0,
+                "memory": 10,
+                "gpu": 0,
+                "name": "class1",
+                "max_storage": 100,
+                "default_storage": 1,
+                "default": True,
+                "node_affinities": [],
+                "tolerations": [],
+            }
+        ],
+        "quota": {"cpu": 100, "memory": 100, "gpu": 0},
+        "default": False,
+        "public": False,
+        "remote": {
+            "kind": "firecrest",
+            "provider_id": p1_payload["id"],
+            "api_url": "https://example.org",
+            "system_name": "sys",
+        },
+    }
+    _, res = await create_rp(rp_payload, sanic_client)
+    assert res.status_code == 201, res.text
+    rp = res.json
+
+    # regular_user can see RP; member_1 cannot
+    _, res = await sanic_client.get("/api/data/resource_pools", headers=user_headers)
+    assert res.status_code == 200, res.text
+    assert rp["id"] in {r["id"] for r in res.json}
+
+    _, res = await sanic_client.get("/api/data/resource_pools", headers=member_1_headers)
+    assert res.status_code == 200, res.text
+    assert rp["id"] not in {r["id"] for r in res.json}
+
+    # Admin patches RP to P2
+    patch = {
+        "remote": {
+            "kind": "firecrest",
+            "provider_id": p2_payload["id"],
+            "api_url": "https://example.org",
+            "system_name": "sys2",
+        }
+    }
+    _, res = await sanic_client.patch(f"/api/data/resource_pools/{rp['id']}", headers=admin_headers, json=patch)
+    assert res.status_code == 200, res.text
+
+    # regular_user can no longer see RP; member_1 can
+    _, res = await sanic_client.get("/api/data/resource_pools", headers=user_headers)
+    assert res.status_code == 200, res.text
+    assert rp["id"] not in {r["id"] for r in res.json}
+
+    _, res = await sanic_client.get("/api/data/resource_pools", headers=member_1_headers)
+    assert res.status_code == 200, res.text
+    assert rp["id"] in {r["id"] for r in res.json}
+
+    # Cleanup
+    _, res = await sanic_client.delete(f"/api/data/resource_pools/{rp['id']}", headers=admin_headers)
+    assert res.status_code == 204, res.text

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from typing import cast
 
 import pytest
+from authzed.api.v1 import Relationship, RelationshipUpdate, SubjectReference, WriteRelationshipsRequest
 
+from renku_data_services.authz.authz import _AuthzConverter
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.connected_services.db import ConnectedServicesRepository, Image
 from renku_data_services.connected_services.models import (
@@ -14,10 +16,17 @@ from renku_data_services.connected_services.models import (
     UnsavedOAuth2Client,
 )
 from renku_data_services.connected_services.orm import OAuth2ConnectionORM
+from renku_data_services.crc import models as crc_models
+from renku_data_services.crc.models import (
+    MemberType,
+    RemoteConfigurationFirecrest,
+    RuntimePlatform,
+)
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.users.db import UserRepo
 from renku_data_services.users.models import UserInfo
+from test.utils import create_rp
 
 github_image = Image.from_path("ghcr.io/sdsc/test")
 gitlab_image = Image.from_path("registry.gitlab.com/sdsc/test")
@@ -82,6 +91,22 @@ async def setup_users(app_manager_instance: DependencyManager) -> SetupData:
     admin_info = cast(UserInfo, await user_repo.get_or_create_user(admin, str(admin.id)))
     user1_info = cast(UserInfo, await user_repo.get_or_create_user(user1, str(user1.id)))
     user2_info = cast(UserInfo, await user_repo.get_or_create_user(user2, str(user2.id)))
+
+    # Bootstrap the admin user as a platform admin in Authzed so that Authzed-based permission
+    # checks pass when the tests call get_resource_pool_members with the admin user.
+    authz = app_manager_instance.authz
+    rels = [
+        RelationshipUpdate(
+            operation=RelationshipUpdate.OPERATION_TOUCH,
+            relationship=Relationship(
+                resource=_AuthzConverter.platform(),
+                relation="admin",
+                subject=SubjectReference(object=_AuthzConverter.user(admin.id)),
+            ),
+        )
+    ]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=rels))
+
     return SetupData(admin, admin_info, user1, user1_info, user2, user2_info, app_manager_instance)
 
 
@@ -214,6 +239,314 @@ async def test_get_provider_for_image_unsupported_provider(app_manager_instance)
 
     p = await setup.connected_repo.get_provider_for_image(setup.user1, gitlab_image)
     assert p is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_connect_adds_user_to_rp(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-oauth-connect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-oauth-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection for user1
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # Call on_oauth2_connected directly
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # Assert user1 is a viewer member of the RP
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_disconnect_removes_user_from_rp(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-oauth-disconnect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-oauth-disconnect-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection and grant access
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # Verify user1 has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Disconnect user1
+    await app_manager_instance.connected_services_repo.on_oauth2_disconnected(setup.user1.id, client.id)
+
+    # Assert user1 is no longer a member
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_connect_with_no_matching_rp_does_nothing(
+    app_manager_instance: DependencyManager, admin_user: APIUser
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-no-match"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create a connection for user1 but no RP linked to this provider
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # This should not crash
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # No RPs exist anyway so nothing to assert, just no crash
+
+
+@pytest.mark.asyncio
+async def test_two_users_connect_same_integration_both_get_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-two-users"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-two-users-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create connections for both users
+    for user in [setup.user1, setup.user2]:
+        async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=user.id,
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+
+    # Connect both users
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user2.id, client.id)
+
+    # Both should have access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+    assert setup.user2.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_user_disconnect_only_affects_their_rp_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-isolated-disconnect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-isolated-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create connections for both users
+    for user in [setup.user1, setup.user2]:
+        async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=user.id,
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+
+    # Grant both users
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user2.id, client.id)
+
+    # Disconnect user1 only
+    await app_manager_instance.connected_services_repo.on_oauth2_disconnected(setup.user1.id, client.id)
+
+    # user1 revoked, user2 still has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+    assert setup.user2.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_delete_connection_revokes_rp_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-delete-revoke"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-delete-revoke-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection and grant access
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # Grant user1 access
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+
+    # Verify user1 has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Delete the connection (this should trigger on_oauth2_disconnected)
+    await app_manager_instance.connected_services_repo.delete_oauth2_connection(setup.user1, conn.id)
+
+    # Verify user1 no longer has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
 
 
 @pytest.mark.asyncio

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 from unittest.mock import AsyncMock
 
 import pytest
+from authzed.api.v1 import Relationship, RelationshipUpdate, SubjectReference, WriteRelationshipsRequest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
@@ -9,10 +10,19 @@ from ulid import ULID
 
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
+from renku_data_services.authz.authz import _AuthzConverter
 from renku_data_services.authz.models import Visibility
-from renku_data_services.base_models import APIUser
+from renku_data_services.base_models import RESET, APIUser
+from renku_data_services.connected_services.db import ConnectedServicesRepository
+from renku_data_services.connected_services.models import ConnectionStatus, ProviderKind, UnsavedOAuth2Client
+from renku_data_services.connected_services.orm import OAuth2ConnectionORM
 from renku_data_services.crc import models
-from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
+from renku_data_services.crc.models import (
+    MemberType,
+    RemoteConfigurationFirecrest,
+    RemoteConfigurationFirecrestPatch,
+    ResourcePoolMemberIdentifier,
+)
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.namespace import models as namespace_models
@@ -116,6 +126,9 @@ async def test_resource_pool_update_quota(
         assert retrieved_rps[0] == updated_rp
     except (ValidationError, errors.ValidationError):
         pass
+    finally:
+        if inserted_rp is not None:
+            await pool_repo.delete_resource_pool(admin_user, inserted_rp.id)
 
 
 @given(rp=rp_strat(), data=st.data())
@@ -785,3 +798,609 @@ async def test_member_repository_rejects_bad_project_id(
             inserted_rp.id,
             [ResourcePoolMemberIdentifier(member_type=MemberType.PROJECT, member_id="not-a-ulid")],
         )
+
+
+async def _insert_provider_and_connect(
+    connected_repo: ConnectedServicesRepository,
+    admin_user: base_models.APIUser,
+    user_api_users: list[base_models.APIUser],
+    provider_id: str,
+    session_maker: any,
+) -> any:
+    """Insert an OAuth2 provider and create connections for users."""
+    client = await connected_repo.insert_oauth2_client(
+        admin_user,
+        UnsavedOAuth2Client(
+            id=provider_id,
+            app_slug=f"{provider_id}-slug",
+            url="https://example.org",
+            kind=ProviderKind.gitlab,
+            client_id="cid",
+            client_secret="secret",
+            display_name="Test Provider",
+            scope="api",
+            use_pkce=False,
+        ),
+    )
+    for user in user_api_users:
+        async with session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=str(user.id),
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+    return client
+
+
+async def _bootstrap_admin(authz, admin_user: base_models.APIUser) -> None:
+    rels: list[RelationshipUpdate] = []
+    sub = SubjectReference(object=_AuthzConverter.user(str(admin_user.id)))
+    rels.append(
+        RelationshipUpdate(
+            operation=RelationshipUpdate.OPERATION_TOUCH,
+            relationship=Relationship(resource=_AuthzConverter.platform(), relation="admin", subject=sub),
+        )
+    )
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=rels))
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_insert_with_remote_grants_connected_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
+
+    user1 = base_models.APIUser(id="user1", full_name="User One")
+    user2 = base_models.APIUser(id="user2", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+    await app_manager_instance.kc_user_repo.get_or_create_user(user2, str(user2.id))
+
+    provider_id = "test-provider-insert"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-insert-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_remote_to_new_provider_swaps_access(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
+
+    user1 = base_models.APIUser(id="user1-update", full_name="User One")
+    user2 = base_models.APIUser(id="user2-update", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+    await app_manager_instance.kc_user_repo.get_or_create_user(user2, str(user2.id))
+
+    provider_id_1 = "test-provider-update-1"
+    provider_id_2 = "test-provider-update-2"
+
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id_1,
+        app_manager_instance.config.db.async_session_maker,
+    )
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user2],
+        provider_id_2,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-update-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id_1,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+
+        # Verify user1 has access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+
+        # Update to provider 2
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(
+                remote=RemoteConfigurationFirecrestPatch(provider_id=provider_id_2),
+            ),
+        )
+
+        # Verify user1 lost access and user2 gained access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) not in user_ids
+        assert str(user2.id) in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_remove_remote_revokes_access(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
+
+    user1 = base_models.APIUser(id="user1-remove", full_name="User One")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-remove"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-remove-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+
+        # Verify user1 has access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+
+        # Remove remote provider
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(remote=RESET),
+        )
+
+        # Verify user1 lost access
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_delete_cleans_authz(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
+
+    user1 = base_models.APIUser(id="user1-delete", full_name="User One")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-delete"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-delete-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+    await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+    # After deletion, querying members directly from Authz should return empty
+    members = await app_manager_instance.authz.get_resource_pool_members(admin_user, inserted_rp.id)
+    user_ids = {subject_id for _, subject_id, _ in members}
+    assert str(user1.id) not in user_ids
+    assert len(user_ids) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_insert_with_nonexistent_provider_id_fails(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    rp = models.UnsavedResourcePool(
+        name="test-nonexistent-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id="does-not-exist",
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    with pytest.raises(errors.ValidationError):
+        await app_manager_instance.rp_repo.insert_resource_pool(admin_user, rp)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_get_connected_user_ids_returns_only_connected_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    user1 = base_models.APIUser(id="user1-conn", full_name="User One")
+    user2 = base_models.APIUser(id="user2-conn", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+    await app_manager_instance.kc_user_repo.get_or_create_user(user2, str(user2.id))
+
+    provider_id = "test-provider-conn"
+
+    # Insert provider
+    client = await app_manager_instance.connected_services_repo.insert_oauth2_client(
+        admin_user,
+        UnsavedOAuth2Client(
+            id=provider_id,
+            app_slug=f"{provider_id}-slug",
+            url="https://example.org",
+            kind=ProviderKind.gitlab,
+            client_id="cid",
+            client_secret="secret",
+            display_name="Test Provider",
+            scope="api",
+            use_pkce=False,
+        ),
+    )
+
+    # Connect user1 as connected, user2 as pending
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn1 = OAuth2ConnectionORM(
+            user_id=str(user1.id),
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn1)
+
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn2 = OAuth2ConnectionORM(
+            user_id=str(user2.id),
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.pending,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn2)
+
+    # Call the private helper
+    connected_ids = await app_manager_instance.rp_repo._get_connected_user_ids(provider_id)
+    assert str(user1.id) in connected_ids
+    assert str(user2.id) not in connected_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_with_nonexistent_provider_id_fails(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+
+    rp = models.UnsavedResourcePool(
+        name="test-update-nonexistent-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        with pytest.raises(errors.MissingResourceError):
+            await app_manager_instance.rp_repo.update_resource_pool(
+                api_user=admin_user,
+                resource_pool_id=inserted_rp.id,
+                update=models.ResourcePoolPatch(
+                    remote=RemoteConfigurationFirecrestPatch(
+                        provider_id="does-not-exist",
+                        api_url="https://example.org",
+                        system_name="test-system",
+                    ),
+                ),
+            )
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_insert_auto_grant_skips_missing_keycloak_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
+
+    user1 = base_models.APIUser(id="user1-missing", full_name="User One")
+    user2 = base_models.APIUser(id="user2-missing", full_name="User Two")
+    # Only add user1 to Keycloak, not user2
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-missing-insert"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-insert-missing-rp",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_auto_grant_skips_missing_keycloak_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
+
+    user1 = base_models.APIUser(id="user1-update-missing", full_name="User One")
+    user2 = base_models.APIUser(id="user2-update-missing", full_name="User Two")
+    # Only add user1 to Keycloak, not user2
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id = "test-provider-missing-update"
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-update-missing-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+
+        # Verify no members initially
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert len(user_ids) == 0
+
+        # Update to add remote provider
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(
+                remote=RemoteConfigurationFirecrestPatch(
+                    provider_id=provider_id,
+                    api_url="https://example.org",
+                    system_name="test-system",
+                ),
+            ),
+        )
+
+        # Verify user1 gets access, user2 does not
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_resource_pool_update_remote_swap_skips_missing_keycloak_users(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    run_migrations_for_app("common")
+    await app_manager_instance.kc_user_repo.get_or_create_user(admin_user, str(admin_user.id))
+    await _bootstrap_admin(app_manager_instance.authz, admin_user)
+
+    user1 = base_models.APIUser(id="user1-swap-missing", full_name="User One")
+    user2 = base_models.APIUser(id="user2-swap-missing", full_name="User Two")
+    await app_manager_instance.kc_user_repo.get_or_create_user(user1, str(user1.id))
+
+    provider_id_1 = "test-provider-swap-1"
+    provider_id_2 = "test-provider-swap-2"
+
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1],
+        provider_id_1,
+        app_manager_instance.config.db.async_session_maker,
+    )
+    await _insert_provider_and_connect(
+        app_manager_instance.connected_services_repo,
+        admin_user,
+        [user1, user2],
+        provider_id_2,
+        app_manager_instance.config.db.async_session_maker,
+    )
+
+    rp = models.UnsavedResourcePool(
+        name="test-swap-missing-rp",
+        classes=[models.UnsavedResourceClass(name="default", cpu=1.0, memory=1, gpu=0, max_storage=1, default=True)],
+        quota=models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id_1,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+
+    inserted_rp = None
+    try:
+        inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, admin_user)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, inserted_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+
+        # Update to provider 2
+        updated_rp = await app_manager_instance.rp_repo.update_resource_pool(
+            api_user=admin_user,
+            resource_pool_id=inserted_rp.id,
+            update=models.ResourcePoolPatch(
+                remote=RemoteConfigurationFirecrestPatch(provider_id=provider_id_2),
+            ),
+        )
+
+        # Verify user1 still has access, user2 does not (because user2 missing from Keycloak)
+        members = await app_manager_instance.member_repo.get_resource_pool_members(admin_user, updated_rp.id)
+        user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+        assert str(user1.id) in user_ids
+        assert str(user2.id) not in user_ids
+    finally:
+        if inserted_rp is not None:
+            await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)

--- a/test/utils.py
+++ b/test/utils.py
@@ -422,6 +422,7 @@ class TestDependencyManager(DependencyManager):
             session_maker=config.db.async_session_maker,
             encryption_key=config.secrets.encryption_key,
             oauth_client_factory=oauth_client_factory,
+            member_repo=member_repo,
         )
         platform_repo = PlatformRepository(
             session_maker=config.db.async_session_maker,

--- a/test/utils.py
+++ b/test/utils.py
@@ -365,6 +365,7 @@ class TestDependencyManager(DependencyManager):
             resource_usage_service=resource_usage_service,
             authz=authz,
             resource_requests_repo=resource_requests_repo,
+            member_repo=member_repo,
         )
         storage_repo = StorageRepository(
             session_maker=config.db.async_session_maker,


### PR DESCRIPTION
## Summary

Automatically authorize individual users as `viewer` on resource pools when they connect to a matching OAuth2 provider, without manual admin intervention and without hidden groups.

This closes the loop between `connected_services` (OAuth2 lifecycle) and `crc` (resource pools) by making the **OAuth2 connection the source of truth** for resource pool access.

## Motivation & Context

Resource pools already support polymorphic members (users, groups, projects) via Authzed/SpiceDB, and `connected_services` already supports HPC integrations (FirecREST, Run:AI) through OAuth2. However, granting access to a resource pool tied to an OAuth provider previously required manual admin intervention.

This PR implements automatic authorization in both directions:

1. **Resource pool CRUD** — when an admin creates or updates a resource pool with `remote.provider_id`, all currently-connected users are granted `viewer` access. When the provider is changed or removed, old access is revoked.
2. **OAuth2 lifecycle** — when a user connects to a provider, they are automatically granted `viewer` on all existing resource pools linked to that provider. When they disconnect, that access is revoked.

## Key Design Decisions

### No Database Migrations
We rely entirely on existing schema:
- `ResourcePoolORM.remote_provider_id` already links a resource pool to an OAuth2 client.
- `OAuth2ConnectionORM` already tracks `user_id`, `client_id`, and `status` (`connected` | `pending`).
- The Authz/SpiceDB schema (v10) already defines `relation viewer: user` on `resource_pool`.

### Direct User Authorization (No Hidden Groups)
Rather than creating synthetic/hidden groups, we authorize users **directly** via the `viewer` relation in SpiceDB. This is simpler and more transparent.

A known consequence: manual admin `viewer` grants and auto-grants are indistinguishable in SpiceDB. Disconnecting a provider unconditionally revokes `viewer` for its connected users — this is accepted because the OAuth connection is the source of truth.

### Validation Before Mutation
Before inserting or updating a resource pool with a `provider_id`, we validate that the referenced OAuth2 client exists. If it doesn't, we raise `MissingResourceError`. Previously, arbitrary provider IDs were silently accepted.

### Best-Effort Membership Sync with Soft Failure
Membership sync happens **outside** the main DB transaction (because `MemberRepository` operations write to SpiceDB via their own session). If a bulk grant fails (e.g., a connected user is missing from Keycloak), the resource pool DB row has already been committed. We handle this by syncing users **individually** with `try/except` and warning logs, ensuring one bad user record does not block access for everyone else.

### Event-Driven Sync at OAuth Lifecycle Boundaries
We hook into existing flows rather than adding new endpoints:

| Event | Location | Action |
|-------|----------|--------|
| User connects to provider P | `connected_services/blueprints.py::authorize_callback` | Call `_on_oauth2_connected(user_id, provider_id)` |
| User disconnects from provider P | `connected_services/db.py::delete_oauth2_connection` | Call `_on_oauth2_disconnected(user_id, provider_id)` |

Both calls are wrapped in `try/except` so that the primary OAuth operation never fails because of an Authz issue.

## Changes

### `components/renku_data_services/crc/db.py`
- `ResourcePoolRepository.__init__` now accepts an optional `member_repo: MemberRepository`.
- Added `_get_connected_user_ids(provider_id)` to query `OAuth2ConnectionORM` for users with `status == connected`.
- `insert_resource_pool`: validates provider existence, then auto-grants connected users after successful insert.
- `update_resource_pool`: captures old provider, validates new provider, then syncs memberships (revoke old → grant new) after the transaction.
- `delete_resource_pool`: no changes needed — Authz cascade already cleans up all relations.

### `components/renku_data_services/connected_services/db.py`
- `ConnectedServicesRepository.__init__` now accepts an optional `member_repo: MemberRepository`.
- Added `_on_oauth2_connected(user_id, client_id)`: queries all RPs linked to the provider and grants the user as `viewer` on each.
- Added `_on_oauth2_disconnected(user_id, client_id)`: queries all RPs linked to the provider and revokes the user's `viewer` access from each.
- `delete_oauth2_connection`: calls `_on_oauth2_disconnected` before deletion and again after flush as best-effort.

### `components/renku_data_services/connected_services/blueprints.py`
- `authorize_callback`: after successful `fetch_token`, extracts `user_id` and `provider_id` from `client.connection` and calls `_on_oauth2_connected` with failure isolation.

### `components/renku_data_services/connected_services/models.py` & `orm.py`
- `OAuth2Connection` dataclass and ORM `dump()` now expose `user_id` and `client_id`. Previously only `provider_id` was exposed.

### `bases/renku_data_services/data_api/dependencies.py` & `test/utils.py`
- Wired `member_repo` into both `ResourcePoolRepository` and `ConnectedServicesRepository` construction.

### Tests
- **`test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py`**
  - Added integration tests for insert with remote, update swap, update remove, delete cleanup, nonexistent provider validation, and resilience against missing Keycloak users.
- **`test/components/renku_data_services/connected_services/test_db.py`**
  - Added integration tests for connect adds user, disconnect removes user, no-matching-RP no-op, multi-user access, and isolated disconnect.
- **`test/bases/renku_data_services/data_api/test_resource_pools.py`**
  - Added end-to-end tests: `test_post_resource_pool_with_remote_grants_connected_users`, `test_delete_resource_pool_removes_access`, `test_patch_resource_pool_remote_change_swaps_access`.
- **`test/bases/renku_data_services/data_api/test_connected_services.py`**
  - Added end-to-end tests: `test_oauth_callback_adds_user_to_rp`, `test_delete_oauth_connection_removes_rp_access`.

## Behavioral Changes (Notable)

### Stricter validation of `remote.provider_id`
`POST /api/data/resource_pools` and `PATCH /api/data/resource_pools/{id}` now validate that the referenced `provider_id` exists in `oauth2_clients`. Non-existent IDs now return a 404-style error instead of silent acceptance.

### OAuth2 callback now triggers resource pool access grants
After a user completes the OAuth2 callback (`/api/data/oauth2/callback`), they automatically receive `viewer` access to all resource pools linked to that provider.

### OAuth2 disconnect now triggers resource pool access revocation
Deleting an OAuth2 connection (`DELETE /api/data/oauth2/connections/{id}`) unconditionally revokes `viewer` access from all resource pools linked to that provider.

### `OAuth2Connection` now exposes `user_id` and `client_id`
This is an additive change — existing consumers are unaffected.

## Risks & Mitigations

1. **Bulk operations outside transaction**: `insert_resource_pool` and `update_resource_pool` return from their DB transaction before calling `member_repo` bulk operations. If the bulk operation fails, the RP has already been committed. This is acceptable for MVP because SpiceDB is the secondary store; failing to sync memberships is a soft failure that can be retried or fixed by re-updating the RP.
2. **Test flakiness around Authz**: Tests that verify RP visibility via `GET /resource_pools` depend on Authz + DB consistency. The `@Authz.authz_change` decorator writes to SpiceDB synchronously, so tests should be deterministic as long as they use the same fixture instances.

---

## PR Stack

* base: (this)[#1315]
  * #1314 
  * #1317
  * #1327