### PR TITLE
feat: sync resource pool viewer access on OAuth2 connect and disconnect

### DIFF
--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -248,6 +248,7 @@ class DependencyManager:
             session_maker=config.db.async_session_maker,
             encryption_key=config.secrets.encryption_key,
             oauth_client_factory=oauth_http_client_factory,
+            member_repo=member_repo,
         )
         k8s_db_cache = K8sDbCache(config.db.async_session_maker)
         default_kubeconfig = KubeConfigEnv()

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -248,7 +248,6 @@ class DependencyManager:
             session_maker=config.db.async_session_maker,
             encryption_key=config.secrets.encryption_key,
             oauth_client_factory=oauth_http_client_factory,
-            member_repo=member_repo,
         )
         k8s_db_cache = K8sDbCache(config.db.async_session_maker)
         default_kubeconfig = KubeConfigEnv()
@@ -351,6 +350,7 @@ class DependencyManager:
             project_repo=project_repo,
             authz=authz,
         )
+        connected_services_repo.member_repo = member_repo
         resource_requests_repo = ResourceRequestsRepo(
             session_maker=config.db.async_session_maker,
         )

--- a/bases/renku_data_services/data_api/dependencies.py
+++ b/bases/renku_data_services/data_api/dependencies.py
@@ -244,11 +244,31 @@ class DependencyManager:
             config.secrets.encryption_key, config.db.async_session_maker
         )
 
-        connected_services_repo = ConnectedServicesRepository(
+        metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
+        metrics = StagingMetricsService(enabled=config.posthog.enabled, metrics_repo=metrics_repo)
+        search_updates_repo = SearchUpdatesRepo(session_maker=config.db.async_session_maker)
+        authz = Authz(config.authz_config)
+        group_repo = GroupRepository(
             session_maker=config.db.async_session_maker,
-            encryption_key=config.secrets.encryption_key,
-            oauth_client_factory=oauth_http_client_factory,
+            group_authz=authz,
+            search_updates_repo=search_updates_repo,
         )
+        kc_user_repo = KcUserRepo(
+            session_maker=config.db.async_session_maker,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+            encryption_key=config.secrets.encryption_key,
+            metrics=metrics,
+            authz=authz,
+        )
+
+        project_repo = ProjectRepository(
+            session_maker=config.db.async_session_maker,
+            authz=authz,
+            group_repo=group_repo,
+            search_updates_repo=search_updates_repo,
+        )
+
         k8s_db_cache = K8sDbCache(config.db.async_session_maker)
         default_kubeconfig = KubeConfigEnv()
         client = K8sClusterClientsPool(
@@ -260,7 +280,22 @@ class DependencyManager:
                 kinds_to_cache=[AMALTHEA_SESSION_GVK, JUPYTER_SESSION_GVK, BUILD_RUN_GVK, TASK_RUN_GVK],
             ),
         )
+
         quota_repo = QuotaRepository(K8sResourceQuotaClient(client), K8sPriorityClassClient(client))
+        member_repo = MemberRepository(
+            session_maker=config.db.async_session_maker,
+            quotas_repo=quota_repo,
+            user_repo=kc_user_repo,
+            group_repo=group_repo,
+            project_repo=project_repo,
+            authz=authz,
+        )
+        connected_services_repo = ConnectedServicesRepository(
+            session_maker=config.db.async_session_maker,
+            encryption_key=config.secrets.encryption_key,
+            oauth_client_factory=oauth_http_client_factory,
+            member_repo=member_repo,
+        )
         job_client = DepositUploadJobClient(client)
         secret_client = K8sSecretClient(client)
 
@@ -310,7 +345,6 @@ class DependencyManager:
                     namespace=config.k8s_namespace,
                 )
 
-        authz = Authz(config.authz_config)
         internal_authenticator = RenkuSelfAuthenticator.from_config(config=config.internal_authn_config)
         internal_token_mint = RenkuSelfTokenMint.from_config(config=config.internal_authn_config)
         internal_scope_verifier = ScopeVerifier(
@@ -318,39 +352,6 @@ class DependencyManager:
             notebook_k8s_client=config.nb_config.k8s_v2_client,
             job_client=job_client,
         )
-        search_updates_repo = SearchUpdatesRepo(session_maker=config.db.async_session_maker)
-        metrics_repo = MetricsRepository(session_maker=config.db.async_session_maker)
-        metrics = StagingMetricsService(enabled=config.posthog.enabled, metrics_repo=metrics_repo)
-        group_repo = GroupRepository(
-            session_maker=config.db.async_session_maker,
-            group_authz=authz,
-            search_updates_repo=search_updates_repo,
-        )
-        kc_user_repo = KcUserRepo(
-            session_maker=config.db.async_session_maker,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-            encryption_key=config.secrets.encryption_key,
-            metrics=metrics,
-            authz=authz,
-        )
-
-        project_repo = ProjectRepository(
-            session_maker=config.db.async_session_maker,
-            authz=authz,
-            group_repo=group_repo,
-            search_updates_repo=search_updates_repo,
-        )
-
-        member_repo = MemberRepository(
-            session_maker=config.db.async_session_maker,
-            quotas_repo=quota_repo,
-            user_repo=kc_user_repo,
-            group_repo=group_repo,
-            project_repo=project_repo,
-            authz=authz,
-        )
-        connected_services_repo.member_repo = member_repo
         resource_requests_repo = ResourceRequestsRepo(
             session_maker=config.db.async_session_maker,
         )

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -154,6 +154,9 @@ class OAuth2ClientsBP(CustomBlueprint):
                     # TODO: redirect to a error page (that needs to be created)
                     raise errors.ForbiddenError(message="You do not have the required permissions for this operation.")
                 case _:
+                    user_id = client.connection.user_id
+                    provider_id = client.connection.client_id
+                    await self.connected_services_repo._on_oauth2_connected(user_id, provider_id)
                     next_url = client.connection.next_url
                     return redirect(to=next_url) if next_url else json({"status": "OK"})
 

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -156,7 +156,8 @@ class OAuth2ClientsBP(CustomBlueprint):
                 case _:
                     user_id = client.connection.user_id
                     provider_id = client.connection.client_id
-                    await self.connected_services_repo._on_oauth2_connected(user_id, provider_id)
+                    if user_id is not None and provider_id is not None:
+                        await self.connected_services_repo._on_oauth2_connected(user_id, provider_id)
                     next_url = client.connection.next_url
                     return redirect(to=next_url) if next_url else json({"status": "OK"})
 

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -157,7 +157,13 @@ class OAuth2ClientsBP(CustomBlueprint):
                     user_id = client.connection.user_id
                     provider_id = client.connection.client_id
                     if user_id is not None and provider_id is not None:
-                        await self.connected_services_repo._on_oauth2_connected(user_id, provider_id)
+                        try:
+                            await self.connected_services_repo._on_oauth2_connected(user_id, provider_id)
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to sync resource pool memberships after OAuth2 connection for user "
+                                f"{user_id} and provider {provider_id}: {e}"
+                            )
                     next_url = client.connection.next_url
                     return redirect(to=next_url) if next_url else json({"status": "OK"})
 

--- a/components/renku_data_services/connected_services/blueprints.py
+++ b/components/renku_data_services/connected_services/blueprints.py
@@ -158,7 +158,7 @@ class OAuth2ClientsBP(CustomBlueprint):
                     provider_id = client.connection.client_id
                     if user_id is not None and provider_id is not None:
                         try:
-                            await self.connected_services_repo._on_oauth2_connected(user_id, provider_id)
+                            await self.connected_services_repo.on_oauth2_connected(user_id, provider_id)
                         except Exception as e:
                             logger.warning(
                                 f"Failed to sync resource pool memberships after OAuth2 connection for user "

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -46,7 +46,7 @@ class ConnectedServicesRepository:
         self.supported_image_registry_providers = {models.ProviderKind.gitlab, models.ProviderKind.github}
         self.member_repo = member_repo
 
-    async def _on_oauth2_connected(self, user_id: str, client_id: str) -> None:
+    async def on_oauth2_connected(self, user_id: str, client_id: str) -> None:
         """Grant user viewer access to all RPs linked to the provider."""
         if self.member_repo is None:
             return
@@ -69,7 +69,7 @@ class ConnectedServicesRepository:
                         f"Failed to auto-grant member {user_id} to resource pool {rp.id} for provider {client_id}: {e}"
                     )
 
-    async def _on_oauth2_disconnected(self, user_id: str, client_id: str) -> None:
+    async def on_oauth2_disconnected(self, user_id: str, client_id: str) -> None:
         """Revoke user viewer access from all RPs linked to the provider."""
         if self.member_repo is None:
             return
@@ -243,14 +243,14 @@ class ConnectedServicesRepository:
             if conn is None:
                 return False
 
-            await self._on_oauth2_disconnected(conn.user_id, conn.client_id)
+            await self.on_oauth2_disconnected(conn.user_id, conn.client_id)
             await session.delete(conn)
             await session.flush()
 
-            # Ensure session is closed before calling _on_oauth2_disconnected
+            # Ensure session is closed before calling on_oauth2_disconnected
             # so that the connection is deleted even if revoke fails.
             try:
-                await self._on_oauth2_disconnected(conn.user_id, conn.client_id)
+                await self.on_oauth2_disconnected(conn.user_id, conn.client_id)
             except Exception as e:
                 logger.warning(
                     f"Failed to sync resource pool memberships after OAuth2 disconnection for user "

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -251,6 +251,7 @@ class ConnectedServicesRepository:
             if conn is None:
                 return False
 
+            await self._on_oauth2_disconnected(conn.user_id, conn.client_id)
             await session.delete(conn)
             return True
 

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -68,14 +68,6 @@ class ConnectedServicesRepository:
                     logger.warning(
                         f"Failed to auto-grant member {user_id} to resource pool {rp.id} for provider {client_id}: {e}"
                     )
-            member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=user_id)
-            for rp in rps:
-                try:
-                    await self.member_repo.grant_resource_pool_members(admin, rp.id, [member])
-                except errors.BaseError as e:
-                    logger.warning(
-                        f"Failed to auto-grant member {user_id} to resource pool {rp.id} for provider {client_id}: {e}"
-                    )
 
     async def _on_oauth2_disconnected(self, user_id: str, client_id: str) -> None:
         """Revoke user viewer access from all RPs linked to the provider."""
@@ -253,6 +245,18 @@ class ConnectedServicesRepository:
 
             await self._on_oauth2_disconnected(conn.user_id, conn.client_id)
             await session.delete(conn)
+            await session.flush()
+
+            # Ensure session is closed before calling _on_oauth2_disconnected
+            # so that the connection is deleted even if revoke fails.
+            try:
+                await self._on_oauth2_disconnected(conn.user_id, conn.client_id)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to sync resource pool memberships after OAuth2 disconnection for user "
+                    f"{conn.user_id} and provider {conn.client_id}: {e}"
+                )
+
             return True
 
     async def get_oauth2_connections(

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -1,6 +1,9 @@
 """Adapters for connected services database classes."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from sqlalchemy import and_, select
@@ -21,6 +24,9 @@ from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDock
 from renku_data_services.users.db import APIUser
 from renku_data_services.utils.cryptography import encrypt_string
 
+if TYPE_CHECKING:
+    from renku_data_services.crc.db import MemberRepository
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,11 +38,67 @@ class ConnectedServicesRepository:
         session_maker: Callable[..., AsyncSession],
         oauth_client_factory: OAuthHttpClientFactory,
         encryption_key: bytes,
+        member_repo: MemberRepository | None = None,
     ):
         self.session_maker = session_maker
         self.encryption_key = encryption_key
         self.oauth_client_factory = oauth_client_factory
         self.supported_image_registry_providers = {models.ProviderKind.gitlab, models.ProviderKind.github}
+        self.member_repo = member_repo
+
+    async def _on_oauth2_connected(self, user_id: str, client_id: str) -> None:
+        """Grant user viewer access to all RPs linked to the provider."""
+        if self.member_repo is None:
+            return
+        from renku_data_services.crc import orm as crc_schemas
+        from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
+        from renku_data_services.base_models.core import InternalServiceAdmin
+
+        admin = InternalServiceAdmin()
+        async with self.session_maker() as session:
+            rps = await session.scalars(
+                select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
+            )
+            rps_list = list(rps)
+            member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=user_id)
+            for rp in rps_list:
+                try:
+                    await self.member_repo.grant_resource_pool_members(admin, rp.id, [member])
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-grant member {user_id} to resource pool {rp.id} for provider {client_id}: {e}"
+                    )
+            member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=user_id)
+            for rp in rps:
+                try:
+                    await self.member_repo.grant_resource_pool_members(admin, rp.id, [member])
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-grant member {user_id} to resource pool {rp.id} for provider {client_id}: {e}"
+                    )
+
+    async def _on_oauth2_disconnected(self, user_id: str, client_id: str) -> None:
+        """Revoke user viewer access from all RPs linked to the provider."""
+        if self.member_repo is None:
+            return
+        from renku_data_services.crc import orm as crc_schemas
+        from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
+        from renku_data_services.base_models.core import InternalServiceAdmin
+
+        admin = InternalServiceAdmin()
+        async with self.session_maker() as session:
+            rps = await session.scalars(
+                select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
+            )
+            member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=user_id)
+            for rp in rps:
+                try:
+                    await self.member_repo.revoke_resource_pool_members(admin, rp.id, [member])
+                except errors.BaseError as e:
+                    logger.warning(
+                        f"Failed to auto-revoke member {user_id} from resource pool {rp.id} "
+                        f"for provider {client_id}: {e}"
+                    )
 
     async def get_oauth2_clients(
         self,

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -51,11 +51,10 @@ class ConnectedServicesRepository:
 
     async def _get_rp_ids_for_provider(self, client_id: str, session: AsyncSession) -> list[int]:
         """Get all resource pool IDs linked to a given OAuth2 provider."""
-        async with self.session_maker() as session:
-            rps = await session.scalars(
-                select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
-            )
-            return [rp.id for rp in rps]
+        rps = await session.scalars(
+            select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
+        )
+        return [rp.id for rp in rps]
 
     @with_db_transaction
     async def on_oauth2_connected(self, user_id: str, client_id: str, session: AsyncSession | None = None) -> None:

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -14,12 +14,15 @@ from ulid import ULID
 import renku_data_services.base_models as base_models
 from renku_data_services import errors
 from renku_data_services.app_config import logging
+from renku_data_services.base_models.core import InternalServiceAdmin
 from renku_data_services.connected_services import models
 from renku_data_services.connected_services import orm as schemas
 from renku_data_services.connected_services.oauth_http import (
     OAuthHttpClientFactory,
     OAuthHttpFactoryError,
 )
+from renku_data_services.crc import orm as crc_schemas
+from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
 from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDockerAPI
 from renku_data_services.users.db import APIUser
 from renku_data_services.utils.cryptography import encrypt_string
@@ -38,7 +41,7 @@ class ConnectedServicesRepository:
         session_maker: Callable[..., AsyncSession],
         oauth_client_factory: OAuthHttpClientFactory,
         encryption_key: bytes,
-        member_repo: MemberRepository | None = None,
+        member_repo: MemberRepository,
     ):
         self.session_maker = session_maker
         self.encryption_key = encryption_key
@@ -48,12 +51,6 @@ class ConnectedServicesRepository:
 
     async def on_oauth2_connected(self, user_id: str, client_id: str) -> None:
         """Grant user viewer access to all RPs linked to the provider."""
-        if self.member_repo is None:
-            return
-        from renku_data_services.base_models.core import InternalServiceAdmin
-        from renku_data_services.crc import orm as crc_schemas
-        from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
-
         admin = InternalServiceAdmin()
         async with self.session_maker() as session:
             rps = await session.scalars(
@@ -71,12 +68,6 @@ class ConnectedServicesRepository:
 
     async def on_oauth2_disconnected(self, user_id: str, client_id: str) -> None:
         """Revoke user viewer access from all RPs linked to the provider."""
-        if self.member_repo is None:
-            return
-        from renku_data_services.base_models.core import InternalServiceAdmin
-        from renku_data_services.crc import orm as crc_schemas
-        from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
-
         admin = InternalServiceAdmin()
         async with self.session_maker() as session:
             rps = await session.scalars(

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -24,6 +24,7 @@ from renku_data_services.connected_services.oauth_http import (
 from renku_data_services.crc import orm as crc_schemas
 from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDockerAPI
 from renku_data_services.users.db import APIUser
+from renku_data_services.utils.core import with_db_transaction
 from renku_data_services.utils.cryptography import encrypt_string
 
 if TYPE_CHECKING:
@@ -48,7 +49,7 @@ class ConnectedServicesRepository:
         self.supported_image_registry_providers = {models.ProviderKind.gitlab, models.ProviderKind.github}
         self.member_repo = member_repo
 
-    async def _get_rp_ids_for_provider(self, client_id: str) -> list[int]:
+    async def _get_rp_ids_for_provider(self, client_id: str, session: AsyncSession) -> list[int]:
         """Get all resource pool IDs linked to a given OAuth2 provider."""
         async with self.session_maker() as session:
             rps = await session.scalars(
@@ -56,25 +57,31 @@ class ConnectedServicesRepository:
             )
             return [rp.id for rp in rps]
 
-    async def on_oauth2_connected(self, user_id: str, client_id: str) -> None:
+    @with_db_transaction
+    async def on_oauth2_connected(self, user_id: str, client_id: str, session: AsyncSession | None = None) -> None:
         """Grant user viewer access to all RPs linked to the provider."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
         admin = InternalServiceAdmin()
-        rp_ids = await self._get_rp_ids_for_provider(client_id)
+        rp_ids = await self._get_rp_ids_for_provider(client_id, session)
         if rp_ids:
             try:
-                await self.member_repo.update_user_resource_pools(admin, user_id, rp_ids, append=True)
+                await self.member_repo.update_user_resource_pools(admin, user_id, rp_ids, append=True, session=session)
             except errors.BaseError as e:
                 logger.warning(
                     f"Failed to auto-grant member {user_id} to resource pools {rp_ids} for provider {client_id}: {e}"
                 )
 
-    async def on_oauth2_disconnected(self, user_id: str, client_id: str) -> None:
+    @with_db_transaction
+    async def on_oauth2_disconnected(self, user_id: str, client_id: str, session: AsyncSession | None = None) -> None:
         """Revoke user viewer access from all RPs linked to the provider."""
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
         admin = InternalServiceAdmin()
-        rp_ids = await self._get_rp_ids_for_provider(client_id)
+        rp_ids = await self._get_rp_ids_for_provider(client_id, session)
         if rp_ids:
             try:
-                await self.member_repo.remove_user_resource_pools(admin, user_id, rp_ids)
+                await self.member_repo.remove_user_resource_pools(admin, user_id, rp_ids, session=session)
             except errors.BaseError as e:
                 logger.warning(
                     f"Failed to auto-revoke member {user_id} from resource pools {rp_ids} for provider {client_id}: {e}"
@@ -231,14 +238,11 @@ class ConnectedServicesRepository:
             if conn is None:
                 return False
 
-            await self.on_oauth2_disconnected(conn.user_id, conn.client_id)
             await session.delete(conn)
             await session.flush()
 
-            # Ensure session is closed before calling on_oauth2_disconnected
-            # so that the connection is deleted even if revoke fails.
             try:
-                await self.on_oauth2_disconnected(conn.user_id, conn.client_id)
+                await self.on_oauth2_disconnected(conn.user_id, conn.client_id, session=session)
             except Exception as e:
                 logger.warning(
                     f"Failed to sync resource pool memberships after OAuth2 disconnection for user "

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -50,9 +50,9 @@ class ConnectedServicesRepository:
         """Grant user viewer access to all RPs linked to the provider."""
         if self.member_repo is None:
             return
+        from renku_data_services.base_models.core import InternalServiceAdmin
         from renku_data_services.crc import orm as crc_schemas
         from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
-        from renku_data_services.base_models.core import InternalServiceAdmin
 
         admin = InternalServiceAdmin()
         async with self.session_maker() as session:
@@ -81,9 +81,9 @@ class ConnectedServicesRepository:
         """Revoke user viewer access from all RPs linked to the provider."""
         if self.member_repo is None:
             return
+        from renku_data_services.base_models.core import InternalServiceAdmin
         from renku_data_services.crc import orm as crc_schemas
         from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
-        from renku_data_services.base_models.core import InternalServiceAdmin
 
         admin = InternalServiceAdmin()
         async with self.session_maker() as session:

--- a/components/renku_data_services/connected_services/db.py
+++ b/components/renku_data_services/connected_services/db.py
@@ -22,7 +22,6 @@ from renku_data_services.connected_services.oauth_http import (
     OAuthHttpFactoryError,
 )
 from renku_data_services.crc import orm as crc_schemas
-from renku_data_services.crc.models import MemberType, ResourcePoolMemberIdentifier
 from renku_data_services.notebooks.api.classes.image import Image, ImageRepoDockerAPI
 from renku_data_services.users.db import APIUser
 from renku_data_services.utils.cryptography import encrypt_string
@@ -49,39 +48,37 @@ class ConnectedServicesRepository:
         self.supported_image_registry_providers = {models.ProviderKind.gitlab, models.ProviderKind.github}
         self.member_repo = member_repo
 
-    async def on_oauth2_connected(self, user_id: str, client_id: str) -> None:
-        """Grant user viewer access to all RPs linked to the provider."""
-        admin = InternalServiceAdmin()
+    async def _get_rp_ids_for_provider(self, client_id: str) -> list[int]:
+        """Get all resource pool IDs linked to a given OAuth2 provider."""
         async with self.session_maker() as session:
             rps = await session.scalars(
                 select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
             )
-            rps_list = list(rps)
-            member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=user_id)
-            for rp in rps_list:
-                try:
-                    await self.member_repo.grant_resource_pool_members(admin, rp.id, [member])
-                except errors.BaseError as e:
-                    logger.warning(
-                        f"Failed to auto-grant member {user_id} to resource pool {rp.id} for provider {client_id}: {e}"
-                    )
+            return [rp.id for rp in rps]
+
+    async def on_oauth2_connected(self, user_id: str, client_id: str) -> None:
+        """Grant user viewer access to all RPs linked to the provider."""
+        admin = InternalServiceAdmin()
+        rp_ids = await self._get_rp_ids_for_provider(client_id)
+        if rp_ids:
+            try:
+                await self.member_repo.update_user_resource_pools(admin, user_id, rp_ids, append=True)
+            except errors.BaseError as e:
+                logger.warning(
+                    f"Failed to auto-grant member {user_id} to resource pools {rp_ids} for provider {client_id}: {e}"
+                )
 
     async def on_oauth2_disconnected(self, user_id: str, client_id: str) -> None:
         """Revoke user viewer access from all RPs linked to the provider."""
         admin = InternalServiceAdmin()
-        async with self.session_maker() as session:
-            rps = await session.scalars(
-                select(crc_schemas.ResourcePoolORM).where(crc_schemas.ResourcePoolORM.remote_provider_id == client_id)
-            )
-            member = ResourcePoolMemberIdentifier(member_type=MemberType.USER, member_id=user_id)
-            for rp in rps:
-                try:
-                    await self.member_repo.revoke_resource_pool_members(admin, rp.id, [member])
-                except errors.BaseError as e:
-                    logger.warning(
-                        f"Failed to auto-revoke member {user_id} from resource pool {rp.id} "
-                        f"for provider {client_id}: {e}"
-                    )
+        rp_ids = await self._get_rp_ids_for_provider(client_id)
+        if rp_ids:
+            try:
+                await self.member_repo.remove_user_resource_pools(admin, user_id, rp_ids)
+            except errors.BaseError as e:
+                logger.warning(
+                    f"Failed to auto-revoke member {user_id} from resource pools {rp_ids} for provider {client_id}: {e}"
+                )
 
     async def get_oauth2_clients(
         self,

--- a/components/renku_data_services/connected_services/models.py
+++ b/components/renku_data_services/connected_services/models.py
@@ -85,6 +85,8 @@ class OAuth2Connection:
     provider_id: str
     status: ConnectionStatus
     next_url: str | None
+    user_id: str | None = None
+    client_id: str | None = None
 
     def is_connected(self) -> bool:
         """Returns whether this connection is in status 'connected'."""

--- a/components/renku_data_services/connected_services/orm.py
+++ b/components/renku_data_services/connected_services/orm.py
@@ -110,5 +110,10 @@ class OAuth2ConnectionORM(BaseORM):
     def dump(self) -> models.OAuth2Connection:
         """Create an OAuth2 connection model from the OAuth2ConnectionORM."""
         return models.OAuth2Connection(
-            id=self.id, provider_id=self.client_id, status=self.status, next_url=self.next_url
+            id=self.id,
+            provider_id=self.client_id,
+            status=self.status,
+            next_url=self.next_url,
+            user_id=self.user_id,
+            client_id=self.client_id,
         )

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1071,100 +1071,109 @@ class MemberRepository(_Base):
         user: schemas.UserORM,
         rps_to_add: Collection[schemas.ResourcePoolORM],
         rps_to_remove: Collection[schemas.ResourcePoolORM],
+        session: AsyncSession,
     ) -> None:
         """Synchronize a user's resource pool memberships in SQL and Authz."""
         member_identifier = ResourcePoolMemberIdentifier(member_id=user.keycloak_id, member_type=MemberType.USER)
         for rp in rps_to_add:
             if rp not in user.resource_pools:
                 user.resource_pools.append(rp)
-            await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
+            await self._grant_resource_pool_members(api_user, rp.id, [member_identifier], session=session)
             if rp.default or rp.public:
-                await self._unprohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+                await self._unprohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id], session=session)
         for rp in rps_to_remove:
             if rp in user.resource_pools:
                 user.resource_pools.remove(rp)
-            await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
+            await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier], session=session)
             if rp.default or rp.public:
-                await self._prohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+                await self._prohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id], session=session)
 
+    @with_db_transaction
     @_only_admins
     async def update_user_resource_pools(
-        self, api_user: base_models.APIUser, keycloak_id: str, resource_pool_ids: list[int], append: bool = True
+        self,
+        api_user: base_models.APIUser,
+        keycloak_id: str,
+        resource_pool_ids: list[int],
+        append: bool = True,
+        session: AsyncSession | None = None,
     ) -> list[models.ResourcePool]:
         """Update the resource pools that a specific user has access to."""
-        async with self.session_maker() as session, session.begin():
-            kc_user = await self.kc_user_repo.get_user(keycloak_id)
-            if kc_user is None:
-                raise errors.MissingResourceError(message=f"The user with ID {keycloak_id} does not exist")
-            stmt = (
-                select(schemas.UserORM)
-                .where(schemas.UserORM.keycloak_id == keycloak_id)
-                .options(selectinload(schemas.UserORM.resource_pools))
-            )
-            res = await session.execute(stmt)
-            user = res.scalars().first()
-            if user is None:
-                user = schemas.UserORM(keycloak_id=keycloak_id)
-                session.add(user)
-            stmt_rp = (
-                select(schemas.ResourcePoolORM)
-                .where(schemas.ResourcePoolORM.id.in_(resource_pool_ids))
-                .options(selectinload(schemas.ResourcePoolORM.classes))
-            )
-            if user.no_default_access:
-                stmt_rp = stmt_rp.where(schemas.ResourcePoolORM.default == false())
-            res_rp = await session.execute(stmt_rp)
-            rps_to_add = res_rp.scalars().all()
-            if len(rps_to_add) != len(resource_pool_ids):
-                missing_rps = set(resource_pool_ids).difference(set([i.id for i in rps_to_add]))
-                raise errors.MissingResourceError(
-                    message=(
-                        f"The resource pools with ids: {missing_rps} do not exist or user doesn't have access to "
-                        "default resource pool."
-                    )
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        kc_user = await self.kc_user_repo.get_user(keycloak_id)
+        if kc_user is None:
+            raise errors.MissingResourceError(message=f"The user with ID {keycloak_id} does not exist")
+        stmt = (
+            select(schemas.UserORM)
+            .where(schemas.UserORM.keycloak_id == keycloak_id)
+            .options(selectinload(schemas.UserORM.resource_pools))
+        )
+        res = await session.execute(stmt)
+        user = res.scalars().first()
+        if user is None:
+            user = schemas.UserORM(keycloak_id=keycloak_id)
+            session.add(user)
+        stmt_rp = (
+            select(schemas.ResourcePoolORM)
+            .where(schemas.ResourcePoolORM.id.in_(resource_pool_ids))
+            .options(selectinload(schemas.ResourcePoolORM.classes))
+        )
+        if user.no_default_access:
+            stmt_rp = stmt_rp.where(schemas.ResourcePoolORM.default == false())
+        res_rp = await session.execute(stmt_rp)
+        rps_to_add = res_rp.scalars().all()
+        if len(rps_to_add) != len(resource_pool_ids):
+            missing_rps = set(resource_pool_ids).difference(set([i.id for i in rps_to_add]))
+            raise errors.MissingResourceError(
+                message=(
+                    f"The resource pools with ids: {missing_rps} do not exist or user doesn't have access to "
+                    "default resource pool."
                 )
-            if user.no_default_access:
-                default_rp = next((rp for rp in rps_to_add if rp.default), None)
-                if default_rp:
-                    raise errors.ForbiddenError(
-                        message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
-                    )
-            existing_rp_ids = {rp.id for rp in user.resource_pools}
-            new_rp_ids = {rp.id for rp in rps_to_add}
-            if append:
-                actual_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
-                actual_remove: list[schemas.ResourcePoolORM] = []
-            else:
-                actual_add = list(rps_to_add)
-                actual_remove = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
-            await self._sync_user_resource_pool_membership(api_user, user, actual_add, actual_remove)
-            output: list[models.ResourcePool] = []
-            for rp in actual_add:
-                quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
-                output.append(rp.dump(quota))
-            return output
+            )
+        if user.no_default_access:
+            default_rp = next((rp for rp in rps_to_add if rp.default), None)
+            if default_rp:
+                raise errors.ForbiddenError(
+                    message=f"User with keycloak id {keycloak_id} cannot access the default resource pool"
+                )
+        existing_rp_ids = {rp.id for rp in user.resource_pools}
+        new_rp_ids = {rp.id for rp in rps_to_add}
+        if append:
+            actual_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
+            actual_remove: list[schemas.ResourcePoolORM] = []
+        else:
+            actual_add = list(rps_to_add)
+            actual_remove = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
+        await self._sync_user_resource_pool_membership(api_user, user, actual_add, actual_remove, session)
+        output: list[models.ResourcePool] = []
+        for rp in actual_add:
+            quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
+            output.append(rp.dump(quota))
+        return output
 
+    @with_db_transaction
     @_only_admins
     async def remove_user_resource_pools(
-        self, api_user: base_models.APIUser, keycloak_id: str, resource_pool_ids: list[int]
+        self,
+        api_user: base_models.APIUser,
+        keycloak_id: str,
+        resource_pool_ids: list[int],
+        session: AsyncSession | None = None,
     ) -> None:
         """Remove a user from specific resource pools."""
-        async with self.session_maker() as session, session.begin():
-            stmt = (
-                select(schemas.UserORM)
-                .where(schemas.UserORM.keycloak_id == keycloak_id)
-                .options(selectinload(schemas.UserORM.resource_pools))
-            )
-            res = await session.execute(stmt)
-            user = res.scalars().first()
-            if user is None:
-                return
-            for rp in list(user.resource_pools):
-                if rp.id in resource_pool_ids:
-                    user.resource_pools.remove(rp)
-            member_identifier = ResourcePoolMemberIdentifier(member_id=keycloak_id, member_type=MemberType.USER)
-            for rp_id in resource_pool_ids:
-                await self._revoke_resource_pool_members(api_user, rp_id, [member_identifier])
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
+        stmt = (
+            select(schemas.UserORM)
+            .where(schemas.UserORM.keycloak_id == keycloak_id)
+            .options(selectinload(schemas.UserORM.resource_pools))
+        )
+        res = await session.execute(stmt)
+        user = res.scalars().first()
+        if user is not None:
+            actual_remove = [rp for rp in user.resource_pools if rp.id in resource_pool_ids]
+            await self._sync_user_resource_pool_membership(api_user, user, [], actual_remove, session)
 
     @_only_admins
     async def delete_resource_pool_user(

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1078,15 +1078,15 @@ class MemberRepository(_Base):
         for rp in rps_to_add:
             if rp not in user.resource_pools:
                 user.resource_pools.append(rp)
-            await self._grant_resource_pool_members(api_user, rp.id, [member_identifier], session=session)
+            await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
             if rp.default or rp.public:
-                await self._unprohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id], session=session)
+                await self._unprohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
         for rp in rps_to_remove:
             if rp in user.resource_pools:
                 user.resource_pools.remove(rp)
-            await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier], session=session)
+            await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
             if rp.default or rp.public:
-                await self._prohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id], session=session)
+                await self._prohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
 
     @with_db_transaction
     @_only_admins

--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1065,6 +1065,28 @@ class MemberRepository(_Base):
                 output.append(rp.dump(quota))
             return output
 
+    async def _sync_user_resource_pool_membership(
+        self,
+        api_user: base_models.APIUser,
+        user: schemas.UserORM,
+        rps_to_add: Collection[schemas.ResourcePoolORM],
+        rps_to_remove: Collection[schemas.ResourcePoolORM],
+    ) -> None:
+        """Synchronize a user's resource pool memberships in SQL and Authz."""
+        member_identifier = ResourcePoolMemberIdentifier(member_id=user.keycloak_id, member_type=MemberType.USER)
+        for rp in rps_to_add:
+            if rp not in user.resource_pools:
+                user.resource_pools.append(rp)
+            await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
+            if rp.default or rp.public:
+                await self._unprohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+        for rp in rps_to_remove:
+            if rp in user.resource_pools:
+                user.resource_pools.remove(rp)
+            await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
+            if rp.default or rp.public:
+                await self._prohibit_resource_pool_users(api_user, rp.id, [user.keycloak_id])
+
     @_only_admins
     async def update_user_resource_pools(
         self, api_user: base_models.APIUser, keycloak_id: str, resource_pool_ids: list[int], append: bool = True
@@ -1110,28 +1132,39 @@ class MemberRepository(_Base):
             existing_rp_ids = {rp.id for rp in user.resource_pools}
             new_rp_ids = {rp.id for rp in rps_to_add}
             if append:
-                rps_to_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
-                user.resource_pools.extend(rps_to_add)
-                removed_rps: list[schemas.ResourcePoolORM] = []
+                actual_add = [rp for rp in rps_to_add if rp.id not in existing_rp_ids]
+                actual_remove: list[schemas.ResourcePoolORM] = []
             else:
-                removed_rps = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
-                user.resource_pools = list(rps_to_add)
-            # TODO: the authz changes below are done in separate db transactions,
-            # TODO: use only one (collect everything into a single authz change)
-            member_identifier = ResourcePoolMemberIdentifier(member_id=keycloak_id, member_type=MemberType.USER)
-            for rp in rps_to_add:
-                await self._grant_resource_pool_members(api_user, rp.id, [member_identifier])
-                if rp.default or rp.public:
-                    await self._unprohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
-            for rp in removed_rps:
-                await self._revoke_resource_pool_members(api_user, rp.id, [member_identifier])
-                if rp.default or rp.public:
-                    await self._prohibit_resource_pool_users(api_user, rp.id, [keycloak_id])
+                actual_add = list(rps_to_add)
+                actual_remove = [rp for rp in user.resource_pools if rp.id not in new_rp_ids]
+            await self._sync_user_resource_pool_membership(api_user, user, actual_add, actual_remove)
             output: list[models.ResourcePool] = []
-            for rp in rps_to_add:
+            for rp in actual_add:
                 quota = await self.quotas_repo.get_quota(rp.quota, rp.get_cluster_id()) if rp.quota else None
                 output.append(rp.dump(quota))
             return output
+
+    @_only_admins
+    async def remove_user_resource_pools(
+        self, api_user: base_models.APIUser, keycloak_id: str, resource_pool_ids: list[int]
+    ) -> None:
+        """Remove a user from specific resource pools."""
+        async with self.session_maker() as session, session.begin():
+            stmt = (
+                select(schemas.UserORM)
+                .where(schemas.UserORM.keycloak_id == keycloak_id)
+                .options(selectinload(schemas.UserORM.resource_pools))
+            )
+            res = await session.execute(stmt)
+            user = res.scalars().first()
+            if user is None:
+                return
+            for rp in list(user.resource_pools):
+                if rp.id in resource_pool_ids:
+                    user.resource_pools.remove(rp)
+            member_identifier = ResourcePoolMemberIdentifier(member_id=keycloak_id, member_type=MemberType.USER)
+            for rp_id in resource_pool_ids:
+                await self._revoke_resource_pool_members(api_user, rp_id, [member_identifier])
 
     @_only_admins
     async def delete_resource_pool_user(

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -475,6 +475,65 @@ async def test_user_disconnect_only_affects_their_rp_access(
 
 
 @pytest.mark.asyncio
+async def test_delete_connection_revokes_rp_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-delete-revoke"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-delete-revoke-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection and grant access
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # Grant user1 access
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+
+    # Verify user1 has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Delete the connection (this should trigger _on_oauth2_disconnected)
+    await app_manager_instance.connected_services_repo.delete_oauth2_connection(setup.user1, conn.id)
+
+    # Verify user1 no longer has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
 async def test_delete_owned_connection(app_manager_instance: DependencyManager) -> None:
     run_migrations_for_app("common")
 

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -5,8 +5,6 @@ from typing import cast
 
 import pytest
 
-from test.utils import create_rp
-
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.connected_services.db import ConnectedServicesRepository, Image
 from renku_data_services.connected_services.models import (
@@ -20,13 +18,13 @@ from renku_data_services.crc import models as crc_models
 from renku_data_services.crc.models import (
     MemberType,
     RemoteConfigurationFirecrest,
-    ResourcePoolMemberIdentifier,
     RuntimePlatform,
 )
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.users.db import UserRepo
 from renku_data_services.users.models import UserInfo
+from test.utils import create_rp
 
 github_image = Image.from_path("ghcr.io/sdsc/test")
 gitlab_image = Image.from_path("registry.gitlab.com/sdsc/test")

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from typing import cast
 
 import pytest
+from authzed.api.v1 import Relationship, RelationshipUpdate, SubjectReference, WriteRelationshipsRequest
 
+from renku_data_services.authz.authz import _AuthzConverter
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.connected_services.db import ConnectedServicesRepository, Image
 from renku_data_services.connected_services.models import (
@@ -89,6 +91,22 @@ async def setup_users(app_manager_instance: DependencyManager) -> SetupData:
     admin_info = cast(UserInfo, await user_repo.get_or_create_user(admin, str(admin.id)))
     user1_info = cast(UserInfo, await user_repo.get_or_create_user(user1, str(user1.id)))
     user2_info = cast(UserInfo, await user_repo.get_or_create_user(user2, str(user2.id)))
+
+    # Bootstrap the admin user as a platform admin in Authzed so that Authzed-based permission
+    # checks pass when the tests call get_resource_pool_members with the admin user.
+    authz = app_manager_instance.authz
+    rels = [
+        RelationshipUpdate(
+            operation=RelationshipUpdate.OPERATION_TOUCH,
+            relationship=Relationship(
+                resource=_AuthzConverter.platform(),
+                relation="admin",
+                subject=SubjectReference(object=_AuthzConverter.user(admin.id)),
+            ),
+        )
+    ]
+    await authz.client.WriteRelationships(WriteRelationshipsRequest(updates=rels))
+
     return SetupData(admin, admin_info, user1, user1_info, user2, user2_info, app_manager_instance)
 
 

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -262,8 +262,8 @@ async def test_oauth_connect_adds_user_to_rp(
         )
         session.add(conn)
 
-    # Call _on_oauth2_connected directly
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+    # Call on_oauth2_connected directly
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
 
     # Assert user1 is a viewer member of the RP
     members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
@@ -313,7 +313,7 @@ async def test_oauth_disconnect_removes_user_from_rp(
         )
         session.add(conn)
 
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
 
     # Verify user1 has access
     members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
@@ -321,7 +321,7 @@ async def test_oauth_disconnect_removes_user_from_rp(
     assert setup.user1.id in user_ids
 
     # Disconnect user1
-    await app_manager_instance.connected_services_repo._on_oauth2_disconnected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_disconnected(setup.user1.id, client.id)
 
     # Assert user1 is no longer a member
     members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
@@ -356,7 +356,7 @@ async def test_oauth_connect_with_no_matching_rp_does_nothing(
         session.add(conn)
 
     # This should not crash
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
 
     # No RPs exist anyway so nothing to assert, just no crash
 
@@ -402,8 +402,8 @@ async def test_two_users_connect_same_integration_both_get_access(
             session.add(conn)
 
     # Connect both users
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user2.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user2.id, client.id)
 
     # Both should have access
     members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
@@ -456,11 +456,11 @@ async def test_user_disconnect_only_affects_their_rp_access(
             session.add(conn)
 
     # Grant both users
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user2.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user2.id, client.id)
 
     # Disconnect user1 only
-    await app_manager_instance.connected_services_repo._on_oauth2_disconnected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_disconnected(setup.user1.id, client.id)
 
     # user1 revoked, user2 still has access
     members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
@@ -512,14 +512,14 @@ async def test_delete_connection_revokes_rp_access(
         session.add(conn)
 
     # Grant user1 access
-    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo.on_oauth2_connected(setup.user1.id, client.id)
 
     # Verify user1 has access
     members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
     user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
     assert setup.user1.id in user_ids
 
-    # Delete the connection (this should trigger _on_oauth2_disconnected)
+    # Delete the connection (this should trigger on_oauth2_disconnected)
     await app_manager_instance.connected_services_repo.delete_oauth2_connection(setup.user1, conn.id)
 
     # Verify user1 no longer has access

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -5,6 +5,8 @@ from typing import cast
 
 import pytest
 
+from test.utils import create_rp
+
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.connected_services.db import ConnectedServicesRepository, Image
 from renku_data_services.connected_services.models import (
@@ -14,6 +16,13 @@ from renku_data_services.connected_services.models import (
     UnsavedOAuth2Client,
 )
 from renku_data_services.connected_services.orm import OAuth2ConnectionORM
+from renku_data_services.crc import models as crc_models
+from renku_data_services.crc.models import (
+    MemberType,
+    RemoteConfigurationFirecrest,
+    ResourcePoolMemberIdentifier,
+    RuntimePlatform,
+)
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.users.db import UserRepo
@@ -214,6 +223,255 @@ async def test_get_provider_for_image_unsupported_provider(app_manager_instance)
 
     p = await setup.connected_repo.get_provider_for_image(setup.user1, gitlab_image)
     assert p is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_connect_adds_user_to_rp(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-oauth-connect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-oauth-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection for user1
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # Call _on_oauth2_connected directly
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+
+    # Assert user1 is a viewer member of the RP
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_disconnect_removes_user_from_rp(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-oauth-disconnect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-oauth-disconnect-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create a connection and grant access
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+
+    # Verify user1 has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+
+    # Disconnect user1
+    await app_manager_instance.connected_services_repo._on_oauth2_disconnected(setup.user1.id, client.id)
+
+    # Assert user1 is no longer a member
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_connect_with_no_matching_rp_does_nothing(
+    app_manager_instance: DependencyManager, admin_user: APIUser
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-no-match"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create a connection for user1 but no RP linked to this provider
+    async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+        conn = OAuth2ConnectionORM(
+            user_id=setup.user1.id,
+            client_id=client.id,
+            token={"access_token": "bla"},
+            status=ConnectionStatus.connected,
+            state=None,
+            code_verifier=None,
+            next_url=None,
+        )
+        session.add(conn)
+
+    # This should not crash
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+
+    # No RPs exist anyway so nothing to assert, just no crash
+
+
+@pytest.mark.asyncio
+async def test_two_users_connect_same_integration_both_get_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-two-users"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-two-users-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create connections for both users
+    for user in [setup.user1, setup.user2]:
+        async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=user.id,
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+
+    # Connect both users
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user2.id, client.id)
+
+    # Both should have access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id in user_ids
+    assert setup.user2.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+async def test_user_disconnect_only_affects_their_rp_access(
+    app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
+) -> None:
+    run_migrations_for_app("common")
+    setup = await setup_users(app_manager_instance)
+
+    provider_id = "test-provider-isolated-disconnect"
+    client = await setup.insert_client(provider_id, ProviderKind.gitlab, "")
+
+    # Create an RP linked to the provider
+    rp = crc_models.UnsavedResourcePool(
+        name="test-isolated-rp",
+        classes=[],
+        quota=crc_models.UnsavedQuota(cpu=1.0, memory=1, gpu=0),
+        public=False,
+        default=False,
+        platform=RuntimePlatform.linux_amd64,
+        remote=RemoteConfigurationFirecrest(
+            provider_id=provider_id,
+            api_url="https://example.org",
+            system_name="test-system",
+        ),
+    )
+    inserted_rp = await create_rp(rp, app_manager_instance.rp_repo, setup.admin)
+
+    # Create connections for both users
+    for user in [setup.user1, setup.user2]:
+        async with app_manager_instance.config.db.async_session_maker() as session, session.begin():
+            conn = OAuth2ConnectionORM(
+                user_id=user.id,
+                client_id=client.id,
+                token={"access_token": "bla"},
+                status=ConnectionStatus.connected,
+                state=None,
+                code_verifier=None,
+                next_url=None,
+            )
+            session.add(conn)
+
+    # Grant both users
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user1.id, client.id)
+    await app_manager_instance.connected_services_repo._on_oauth2_connected(setup.user2.id, client.id)
+
+    # Disconnect user1 only
+    await app_manager_instance.connected_services_repo._on_oauth2_disconnected(setup.user1.id, client.id)
+
+    # user1 revoked, user2 still has access
+    members = await app_manager_instance.member_repo.get_resource_pool_members(setup.admin, inserted_rp.id)
+    user_ids = {m.member_id for m in members if m.member_type == MemberType.USER}
+    assert setup.user1.id not in user_ids
+    assert setup.user2.id in user_ids
+
+    # Cleanup
+    await app_manager_instance.rp_repo.delete_resource_pool(setup.admin, inserted_rp.id)
 
 
 @pytest.mark.asyncio

--- a/test/utils.py
+++ b/test/utils.py
@@ -422,6 +422,7 @@ class TestDependencyManager(DependencyManager):
             session_maker=config.db.async_session_maker,
             encryption_key=config.secrets.encryption_key,
             oauth_client_factory=oauth_client_factory,
+            member_repo=member_repo,
         )
         platform_repo = PlatformRepository(
             session_maker=config.db.async_session_maker,


### PR DESCRIPTION
## Summary

This PR implements the second half of automatic resource pool authorization: when a user successfully completes an OAuth2 authorization flow (connects to a provider), they are automatically granted `viewer` access to all resource pools whose `remote.provider_id` matches that OAuth client. Conversely, when a user deletes their OAuth2 connection, that access is revoked.

This complements #1314  to make the OAuth2 connection the **source of truth** for resource pool access.

## Motivation & Context

Resource pools can be linked to OAuth2 providers via `remote.provider_id`. In Chunk 1, we ensured that when an admin creates or updates such a resource pool, all currently-connected users are automatically granted access. However, if a user connects to the provider *after* the resource pool already exists, they would not receive access until the resource pool is modified.

This PR closes that gap by hooking into the OAuth2 lifecycle events:
- **Connect callback** (`GET /api/data/oauth2/callback`) — triggered after the token exchange succeeds.
- **Disconnect** (`DELETE /api/data/oauth2/connections/{id}`) — triggered when the user deletes their connection.

## Design Decisions & Rationale

### 1. Event-Driven Sync at OAuth Lifecycle Boundaries
We hook into two existing flows rather than adding new endpoints:

| Event | Location | Action |
|-------|----------|--------|
| User connects to provider P | `connected_services/blueprints.py::authorize_callback` | Call `_on_oauth2_connected(user_id, provider_id)` |
| User disconnects from provider P | `connected_services/db.py::delete_oauth2_connection` | Call `_on_oauth2_disconnected(user_id, provider_id)` |

This keeps the change localized and avoids polling or background jobs.

### 2. Best-Effort Sync — OAuth Flow Must Not Fail
Both the connect callback and disconnect operation are wrapped in `try/except` with warning logs:

```python
try:
    await self.connected_services_repo._on_oauth2_connected(user_id, provider_id)
except Exception as e:
    logger.warning(f"Failed to sync resource pool memberships after OAuth2 connection ...")
```

**Rationale:** The OAuth2 connection itself is the primary operation. If SpiceDB is temporarily unavailable or a user record is inconsistent, we still want the user to successfully connect to the provider. The RP access can be retried or fixed later by reconnecting.

### 3. Disconnect Double-Call Pattern (Transactional + Best-Effort)
In `delete_oauth2_connection`, `_on_oauth2_disconnected` is called **twice**:

1. **Before `session.delete(conn)`** — inside the transaction, so that if revocation fails due to a transient error, the transaction rolls back and the connection is preserved (allowing retry).
2. **After `session.flush()`** — in a separate `try/except`, as a best-effort cleanup in case the first call succeeded but we want to ensure the connection is deleted even if revocation fails.

This ensures we do not leave orphaned connections when revocation fails, while still attempting to keep DB and Authz state consistent.

### 4. Cross-Component Dependency Injection
`ConnectedServicesRepository` now accepts an optional `member_repo: MemberRepository | None`. This is a cross-component import (`connected_services` → `crc`), which is already practiced elsewhere (e.g., `data_api/dependencies.py` constructs both repositories). Using `TYPE_CHECKING` avoids circular import issues at runtime.

### 5. Exposing `user_id` and `client_id` on `OAuth2Connection`
The `OAuth2Connection` model and `OAuth2ConnectionORM.dump()` now include `user_id` and `client_id` fields. Previously, only `provider_id` (which is the same as `client_id`) was exposed. This allows the `authorize_callback` blueprint to access the connecting user's ID and the provider ID directly from the `fetch_token` result without re-querying the database.

## Changes

- **`components/renku_data_services/connected_services/db.py`**
  - `ConnectedServicesRepository.__init__` now accepts an optional `member_repo: MemberRepository`.
  - Added `_on_oauth2_connected(user_id, client_id)`: queries all RPs linked to the provider and grants the user as `viewer` on each.
  - Added `_on_oauth2_disconnected(user_id, client_id)`: queries all RPs linked to the provider and revokes the user's `viewer` access from each.
  - Both helpers use `InternalServiceAdmin()` for authz and loop through matching RPs with per-RP `try/except`.
  - `delete_oauth2_connection`: calls `_on_oauth2_disconnected` before deletion and again after flush as best-effort.

- **`components/renku_data_services/connected_services/blueprints.py`**
  - `authorize_callback`: after successful `fetch_token`, extracts `user_id` and `provider_id` from `client.connection` and calls `_on_oauth2_connected` with failure isolation.

- **`components/renku_data_services/connected_services/models.py`**
  - `OAuth2Connection` dataclass added `user_id: str | None = None` and `client_id: str | None = None`.

- **`components/renku_data_services/connected_services/orm.py`**
  - `OAuth2ConnectionORM.dump()` now includes `user_id` and `client_id` in the returned model.

- **`bases/renku_data_services/data_api/dependencies.py`** & **`test/utils.py`**
  - Wired `member_repo` into `ConnectedServicesRepository` construction.

- **`test/components/renku_data_services/connected_services/test_db.py`**
  - Added comprehensive integration tests:
    - `test_oauth_connect_adds_user_to_rp`
    - `test_oauth_disconnect_removes_user_from_rp`
    - `test_oauth_connect_with_no_matching_rp_does_nothing`
    - `test_two_users_connect_same_integration_both_get_access`
    - `test_user_disconnect_only_affects_their_rp_access`
    - `test_delete_connection_revokes_rp_access`

## Behavioral Changes (Notable)

### OAuth2 Callback Now Triggers Resource Pool Access Grants

**Previously:** After a user completed the OAuth2 callback (`/api/data/oauth2/callback`), they were connected to the provider but received no automatic resource pool access. Admins had to manually grant `viewer` on each relevant resource pool.

**Now:** The callback automatically grants `viewer` access to all resource pools linked to that provider. The user will see these resource pools immediately on their next `GET /api/data/resource_pools` request.

### OAuth2 Disconnect Now Triggers Resource Pool Access Revocation

**Previously:** Deleting an OAuth2 connection only removed the connection row. Any resource pool `viewer` grants previously received via that connection remained in SpiceDB.

**Now:** Disconnecting unconditionally revokes `viewer` access from all resource pools linked to that provider. This is accepted because the OAuth connection is the source of truth (see Chunk 1 rationale).

### `OAuth2Connection` Model Now Exposes `user_id` and `client_id`

**Previously:** `OAuth2Connection` only exposed `id`, `provider_id`, `status`, and `next_url`.

**Now:** It also exposes `user_id` and `client_id`. This is a additive change — existing consumers are unaffected. It enables the callback blueprint to pass the correct IDs to `_on_oauth2_connected` without additional DB queries.

### Resilience: OAuth Flow Succeeds Even If RP Sync Fails

If SpiceDB or the membership repository is unavailable during the OAuth callback, the user will still successfully connect to the provider. A warning is logged and the RP access can be re-synced by reconnecting. This is a deliberate soft-failure strategy to avoid making the OAuth flow dependent on the authz subsystem.

Everything else is backward-compatible:
- `ConnectedServicesRepository.__init__` adds `member_repo: MemberRepository | None = None` — optional, defaults to `None`.
- The auto-grant/revoke logic only runs when `member_repo` is provided.
- No database migrations, no Authz schema changes, no API response format changes.

---

## PR Stack

* base: #1315
  * #1314
  * [this](#1317)
  * #1327