### PR TITLE
fix: update session labels upon patch

### DIFF
--- a/components/renku_data_services/notebooks/api/classes/k8s_client.py
+++ b/components/renku_data_services/notebooks/api/classes/k8s_client.py
@@ -188,11 +188,12 @@ class NotebookK8sClient(SecretClient):
     ) -> list[AmaltheaSessionV1Alpha1]:
         """Get a list of sessions that belong to a user."""
         session_filter = {self.__username_label: safe_username}
+        # NOTE: "interactive" sessions may exist without the "renku.io/session-type" label.
         match session_type:
-            case SessionType.non_interactive:
-                session_filter.update({"renku.io/session-type": SessionType.non_interactive.value})
-            case _:
+            case SessionType.interactive | None:
                 pass
+            case _:
+                session_filter.update({"renku.io/session-type": session_type.value})
         sessions = [
             self.__session_type.model_validate(s.manifest)
             async for s in self.__client.list(
@@ -203,13 +204,16 @@ class NotebookK8sClient(SecretClient):
                 )
             )
         ]
-        if session_type:
-
-            def _filter_by_label(s: AmaltheaSessionV1Alpha1) -> bool:
-                session_type_label: str | None = s.metadata.labels.get("renku.io/session-type")
-                return not session_type_label or session_type_label.lower() == session_type.value.lower()
-
-            sessions = list(filter(_filter_by_label, sessions))
+        # NOTE: because "interactive" sessions may exist without the "renku.io/session-type" label,
+        # we need to filter results in this case.
+        if session_type == SessionType.interactive:
+            sessions = list(
+                filter(
+                    lambda s: s.metadata.labels.get("renku.io/session-type", SessionType.interactive.value).lower()
+                    == SessionType.interactive.value.lower(),
+                    sessions,
+                )
+            )
         return sorted(sessions, key=lambda sess: sess.metadata.name)
 
     async def get_session(self, name: str, safe_username: str) -> AmaltheaSessionV1Alpha1 | None:

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1241,6 +1241,28 @@ async def patch_session(
         annotations["renku.io/resource_class_id"] = str(rc.id)
         annotations["renku.io/resource_pool_id"] = str(rp.id)
         patch.spec.template = TemplatePatch(metadata=TemplateMetadataPatch(annotations=annotations))
+        assert isinstance(
+            patch.spec.template.metadata, TemplateMetadataPatch
+        )  # We just assigned with TemplateMetadataPatch
+        # Patch the labels
+        labels: dict[str, str | ResetType] = dict()
+        labels.update(session.metadata.labels)
+        labels["renku.io/safe-username"] = user.id
+        if user.is_anonymous:
+            labels["renku.io/anonymous-session"] = "true"
+        if not labels.get("renku.io/session-type"):
+            labels["renku.io/session-type"] = SessionType.interactive.value
+        patch.metadata.labels = labels
+        # Patch the template labels
+        labels: dict[str, str | ResetType] = dict()
+        if session.spec.template and session.spec.template.metadata and session.spec.template.metadata.labels:
+            labels.update(session.spec.template.metadata.labels)
+        labels["renku.io/safe-username"] = user.id
+        if user.is_anonymous:
+            labels["renku.io/anonymous-session"] = "true"
+        if not labels.get("renku.io/session-type"):
+            labels["renku.io/session-type"] = SessionType.interactive.value
+        patch.spec.template.metadata.labels = labels
         if not patch.spec.session:
             patch.spec.session = AmaltheaSessionV1Alpha1SpecSessionPatch()
         patch.spec.session.resources = resources_patch_from_resource_class(rc)

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1241,28 +1241,6 @@ async def patch_session(
         annotations["renku.io/resource_class_id"] = str(rc.id)
         annotations["renku.io/resource_pool_id"] = str(rp.id)
         patch.spec.template = TemplatePatch(metadata=TemplateMetadataPatch(annotations=annotations))
-        assert isinstance(
-            patch.spec.template.metadata, TemplateMetadataPatch
-        )  # We just assigned with TemplateMetadataPatch
-        # Patch the labels
-        labels: dict[str, str | ResetType] = dict()
-        labels.update(session.metadata.labels)
-        labels["renku.io/safe-username"] = user.id
-        if user.is_anonymous:
-            labels["renku.io/anonymous-session"] = "true"
-        if not labels.get("renku.io/session-type"):
-            labels["renku.io/session-type"] = SessionType.interactive.value
-        patch.metadata.labels = labels
-        # Patch the template labels
-        labels: dict[str, str | ResetType] = dict()
-        if session.spec.template and session.spec.template.metadata and session.spec.template.metadata.labels:
-            labels.update(session.spec.template.metadata.labels)
-        labels["renku.io/safe-username"] = user.id
-        if user.is_anonymous:
-            labels["renku.io/anonymous-session"] = "true"
-        if not labels.get("renku.io/session-type"):
-            labels["renku.io/session-type"] = SessionType.interactive.value
-        patch.spec.template.metadata.labels = labels
         if not patch.spec.session:
             patch.spec.session = AmaltheaSessionV1Alpha1SpecSessionPatch()
         patch.spec.session.resources = resources_patch_from_resource_class(rc)
@@ -1277,6 +1255,32 @@ async def patch_session(
             patch.spec.service_account_name = (
                 rp.cluster.service_account_name if rp.cluster.service_account_name is not None else RESET
             )
+
+    # Patch the labels
+    labels: dict[str, str | ResetType] = dict()
+    labels.update(session.metadata.labels)
+    labels["renku.io/safe-username"] = user.id
+    if user.is_anonymous:
+        labels["renku.io/anonymous-session"] = "true"
+    if not labels.get("renku.io/session-type"):
+        labels["renku.io/session-type"] = SessionType.interactive.value
+    if not patch.metadata:
+        patch.metadata = AmaltheaSessionV1Alpha1MetadataPatch()
+    patch.metadata.labels = labels
+    # Patch the template labels
+    labels: dict[str, str | ResetType] = dict()
+    if session.spec.template and session.spec.template.metadata and session.spec.template.metadata.labels:
+        labels.update(session.spec.template.metadata.labels)
+    labels["renku.io/safe-username"] = user.id
+    if user.is_anonymous:
+        labels["renku.io/anonymous-session"] = "true"
+    if not labels.get("renku.io/session-type"):
+        labels["renku.io/session-type"] = SessionType.interactive.value
+    if not isinstance(patch.spec.template, TemplatePatch):
+        patch.spec.template = TemplatePatch(metadata=TemplateMetadataPatch())
+    if not isinstance(patch.spec.template.metadata, TemplateMetadataPatch):
+        patch.spec.template.metadata = TemplateMetadataPatch()
+    patch.spec.template.metadata.labels = labels
 
     patch.spec.culling = get_culling_patch(
         user, rp, nb_config, body.lastInteraction, SessionType.from_amalthea(session.spec.sessionType)

--- a/components/renku_data_services/notebooks/crs.py
+++ b/components/renku_data_services/notebooks/crs.py
@@ -406,6 +406,7 @@ class AmaltheaSessionV1Alpha1MetadataPatch(BaseCRD):
     """Patch for the metadata of an amalthea session."""
 
     annotations: dict[str, str | ResetType] | ResetType | None = None
+    labels: dict[str, str | ResetType] | ResetType | None = None
 
 
 class NodeAffinityPatch(BaseCRD):


### PR DESCRIPTION
Tested in the deployment: the session type label is added with `interactive` if not present.

/deploy