### PR TITLE
fix: do not fail builds when refreshing them from another user

### DIFF
--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -907,7 +907,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
                 raise errors.MissingResourceError(message=not_found_message)
 
             authorized = await self._get_environment_authorization(
-                session=session, user=user, environment=environment, scope=Scope.READ
+                session=session, user=user, environment=environment, scope=Scope.WRITE
             )
             if not authorized:
                 raise errors.MissingResourceError(message=not_found_message)
@@ -1025,29 +1025,15 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             result = await session.scalars(stmt)
             build = result.one_or_none()
 
+            not_found_message = f"Build with id '{build_id}' does not exist or you do not have access to it."
             if build is None:
-                raise errors.MissingResourceError(
-                    message=f"Build with id '{build_id}' does not exist or you do not have access to it."
-                )
+                raise errors.MissingResourceError(message=not_found_message)
 
-            if build.environment.environment_kind == models.EnvironmentKind.GLOBAL:
-                authorized = True
-            else:
-                launcher = await session.scalar(
-                    select(schemas.SessionLauncherORM).where(
-                        schemas.SessionLauncherORM.environment_id == build.environment_id
-                    )
-                )
-                if launcher is None:
-                    authorized = False
-                else:
-                    authorized = await self.project_authz.has_permission(
-                        user, ResourceType.project, launcher.project_id, Scope.WRITE
-                    )
+            authorized = await self._get_environment_authorization(
+                session=session, user=user, environment=build.environment, scope=Scope.WRITE
+            )
             if not authorized:
-                raise errors.MissingResourceError(
-                    message=f"Build with id '{build_id}' does not exist or you do not have access to it."
-                )
+                raise errors.MissingResourceError(message=not_found_message)
 
         build_model = build.dump()
 
@@ -1055,7 +1041,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             raise errors.MissingResourceError(message=f"Build with id '{build_id}' does not have logs.")
 
         return await self.shipwright_client.get_image_build_logs(
-            buildrun_name=build_model.k8s_name, user_id=user.id, max_log_lines=max_log_lines
+            buildrun_name=build_model.k8s_name, max_log_lines=max_log_lines
         )
 
     # async def _refresh_build(self, build: schemas.BuildORM, session: AsyncSession, user_id: str) -> None:

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -846,8 +846,9 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
                 raise errors.MissingResourceError(message=not_found_message)
 
             # Check and refresh the status of in-progress builds
-            if user.id is not None:
-                await self._refresh_build(build=build, session=session, user_id=user.id)
+            await self._refresh_build(build=build, session=session)
+            # if user.id is not None:
+            #     await self._refresh_build(build=build, session=session, user_id=user.id)
 
             return build.dump()
 
@@ -884,7 +885,8 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
 
             # Check and refresh the status of in-progress builds
             for build in builds:
-                await self._refresh_build(build=build, session=session, user_id=user.id)
+                await self._refresh_build(build=build, session=session)
+                # await self._refresh_build(build=build, session=session, user_id=user.id)
 
             return [build.dump() for build in builds]
 
@@ -929,7 +931,8 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
                 .order_by(schemas.BuildORM.id.desc())
             )
             async for item in in_progress_builds:
-                await self._refresh_build(build=item, session=session, user_id=user.id)
+                await self._refresh_build(build=item, session=session)
+                # await self._refresh_build(build=item, session=session, user_id=user.id)
                 if item.status == models.BuildStatus.in_progress:
                     raise errors.ConflictError(
                         message=f"Session environment with id '{build.environment_id}' already has a build in progress."
@@ -986,7 +989,8 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
                 raise errors.MissingResourceError(message=not_found_message)
 
             # Check and refresh the status of in-progress builds
-            await self._refresh_build(build=build, session=session, user_id=user.id)
+            await self._refresh_build(build=build, session=session)
+            # await self._refresh_build(build=build, session=session, user_id=user.id)
 
             if build.status == models.BuildStatus.succeeded or build.status == models.BuildStatus.failed:
                 raise errors.ValidationError(
@@ -1054,7 +1058,8 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             buildrun_name=build_model.k8s_name, user_id=user.id, max_log_lines=max_log_lines
         )
 
-    async def _refresh_build(self, build: schemas.BuildORM, session: AsyncSession, user_id: str) -> None:
+    # async def _refresh_build(self, build: schemas.BuildORM, session: AsyncSession, user_id: str) -> None:
+    async def _refresh_build(self, build: schemas.BuildORM, session: AsyncSession) -> None:
         """Refresh the status and environment of a build by querying Shipwright.
 
         Once the build run has completed, the corresponding session launcher's environment
@@ -1070,7 +1075,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
 
         # TODO: consider how we can parallelize calls to `shipwright_client` for refreshes.
         status_update, frontend_var = await self.shipwright_client.update_image_build_status(
-            buildrun_name=build.dump().k8s_name, user_id=user_id
+            buildrun_name=build.dump().k8s_name  # , user_id=user_id
         )
 
         if status_update.update is None:

--- a/components/renku_data_services/session/db.py
+++ b/components/renku_data_services/session/db.py
@@ -847,17 +847,11 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
 
             # Check and refresh the status of in-progress builds
             await self._refresh_build(build=build, session=session)
-            # if user.id is not None:
-            #     await self._refresh_build(build=build, session=session, user_id=user.id)
 
             return build.dump()
 
     async def get_environment_builds(self, user: base_models.APIUser, environment_id: ULID) -> list[models.Build]:
         """Get all builds from a session environment."""
-
-        if not user.is_authenticated or user.id is None:
-            raise errors.UnauthorizedError(message="You do not have the required permissions for this operation.")
-
         async with self.session_maker() as session, session.begin():
             environment = await session.scalar(
                 select(schemas.EnvironmentORM).where(schemas.EnvironmentORM.id == environment_id)
@@ -886,7 +880,6 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             # Check and refresh the status of in-progress builds
             for build in builds:
                 await self._refresh_build(build=build, session=session)
-                # await self._refresh_build(build=build, session=session, user_id=user.id)
 
             return [build.dump() for build in builds]
 
@@ -932,7 +925,6 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             )
             async for item in in_progress_builds:
                 await self._refresh_build(build=item, session=session)
-                # await self._refresh_build(build=item, session=session, user_id=user.id)
                 if item.status == models.BuildStatus.in_progress:
                     raise errors.ConflictError(
                         message=f"Session environment with id '{build.environment_id}' already has a build in progress."
@@ -990,7 +982,6 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
 
             # Check and refresh the status of in-progress builds
             await self._refresh_build(build=build, session=session)
-            # await self._refresh_build(build=build, session=session, user_id=user.id)
 
             if build.status == models.BuildStatus.succeeded or build.status == models.BuildStatus.failed:
                 raise errors.ValidationError(
@@ -1044,7 +1035,6 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
             buildrun_name=build_model.k8s_name, max_log_lines=max_log_lines
         )
 
-    # async def _refresh_build(self, build: schemas.BuildORM, session: AsyncSession, user_id: str) -> None:
     async def _refresh_build(self, build: schemas.BuildORM, session: AsyncSession) -> None:
         """Refresh the status and environment of a build by querying Shipwright.
 
@@ -1061,7 +1051,7 @@ class SessionRepository(SessionEnvironmentRepositoryProtocol):
 
         # TODO: consider how we can parallelize calls to `shipwright_client` for refreshes.
         status_update, frontend_var = await self.shipwright_client.update_image_build_status(
-            buildrun_name=build.dump().k8s_name  # , user_id=user_id
+            buildrun_name=build.dump().k8s_name
         )
 
         if status_update.update is None:

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -83,7 +83,7 @@ class ShipwrightClient:
             yield BuildRun.model_validate(build.manifest.to_dict())
         return
 
-    async def get_build_run(self, name: str, user_id: str) -> BuildRun | None:
+    async def get_build_run(self, name: str) -> BuildRun | None:
         """Get a Shipwright BuildRun."""
         result = await self.client.get(
             K8sObjectMeta(
@@ -91,7 +91,6 @@ class ShipwrightClient:
                 namespace=self.namespace,
                 cluster=self.cluster_id(),
                 gvk=BUILD_RUN_GVK,
-                user_id=user_id,
             )
         )
         if result is None:
@@ -252,11 +251,14 @@ class ShipwrightClient:
             patch = [{"op": "replace", "path": "/metadata/ownerReferences", "value": [owner_reference]}]
             await self.secret_client.patch_secret(secret, patch)
 
+    # async def update_image_build_status(
+    #     self, buildrun_name: str, user_id: str
+    # ) -> tuple[models.ShipwrightBuildStatusUpdate, str | None]:
     async def update_image_build_status(
-        self, buildrun_name: str, user_id: str
+        self, buildrun_name: str
     ) -> tuple[models.ShipwrightBuildStatusUpdate, str | None]:
         """Update the status of a build by pulling the corresponding BuildRun from Shipwright."""
-        k8s_build = await self.get_build_run(name=buildrun_name, user_id=user_id)
+        k8s_build = await self.get_build_run(name=buildrun_name)
 
         if k8s_build is None:
             logger.warning(f"Buildrun {buildrun_name} considered failed because we cannot find it in the cluster.")

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -113,7 +113,7 @@ class ShipwrightClient:
             refresh=True,
         )
         build_resource = await retry_with_exponential_backoff_async(lambda x: x is None)(self.get_build_run)(
-            build_run_name, user_id
+            build_run_name
         )
         if build_resource is None:
             raise CannotStartBuildError(message=f"Cannot create the image build {build_run_name}")
@@ -336,11 +336,9 @@ class ShipwrightClient:
             case _:
                 return models.ShipwrightBuildStatusUpdate(update=None), k8s_build.frontend_variant
 
-    async def get_image_build_logs(
-        self, buildrun_name: str, user_id: str, max_log_lines: int | None = None
-    ) -> dict[str, str]:
+    async def get_image_build_logs(self, buildrun_name: str, max_log_lines: int | None = None) -> dict[str, str]:
         """Get the logs from a Shipwright BuildRun."""
-        buildrun = await self.get_build_run(name=buildrun_name, user_id=user_id)
+        buildrun = await self.get_build_run(name=buildrun_name)
         if not buildrun:
             raise errors.MissingResourceError(message=f"Cannot find buildrun {buildrun_name} to retrieve logs.")
         status = buildrun.status

--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -251,9 +251,6 @@ class ShipwrightClient:
             patch = [{"op": "replace", "path": "/metadata/ownerReferences", "value": [owner_reference]}]
             await self.secret_client.patch_secret(secret, patch)
 
-    # async def update_image_build_status(
-    #     self, buildrun_name: str, user_id: str
-    # ) -> tuple[models.ShipwrightBuildStatusUpdate, str | None]:
     async def update_image_build_status(
         self, buildrun_name: str
     ) -> tuple[models.ShipwrightBuildStatusUpdate, str | None]:


### PR DESCRIPTION
Closes #1338.

Updated permissions:

| API Endpoint | `db.py` method | Description | Required Permission |
| --- | --- | --- | --- |
| `GET /builds/<build_id>` | `get_build()` | Get a single build item | Project Read |
| `GET /environments/<environment_id>/builds` | `get_environment_builds()` | List the build history for a launcher | Project Read |
| `POST /environments/<environment_id>/builds` | `start_build()` | Rebuild (build a new image for the launcher) | Project Write |
| `PATCH /builds/<build_id>` | `update_build()` | Cancel a build | Project Write |
| `GET /builds/<build_id>/logs` | `get_build_logs()` | Get a build's logs | Project Write |
| - | `_refresh_build()` | Refresh build status | Project Read (checked before calling) |

/deploy extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user