### PR TITLE
feat: Use an HTTP readiness probe for remote interactive sessions

### DIFF
--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1127,7 +1127,7 @@ async def start_session(
                 stripURLPath=environment.strip_path_prefix,
                 env=env,
                 remoteSecretRef=remote_secret.ref() if remote_secret else None,
-                readinessProbe=ReadinessProbe(type=Type.none) if session_type.is_non_interactive else ReadinessProbe(),
+                readinessProbe=_get_readiness_probe(session_type, session_location),
             ),
             ingress=ingress_config.get_k8s_ingress() if session_type.is_interactive else None,
             extraContainers=session_extras.containers,

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1454,6 +1454,20 @@ async def patch_session(
     return await nb_config.k8s_v2_client.patch_session(session_id, user.id, patch_serialized)
 
 
+def _get_readiness_probe(session_type: SessionType, session_location: SessionLocation) -> ReadinessProbe:
+    """Return the readiness probe for a session based on type and location.
+
+    - Non-interactive sessions get no probe (Type.none).
+    - Interactive remote sessions (firecrest/runai) use an HTTP probe.
+    - Interactive local sessions use the default TCP probe.
+    """
+    if session_type.is_non_interactive:
+        return ReadinessProbe(type=Type.none)
+    if session_location == SessionLocation.remote:
+        return ReadinessProbe(type=Type.http)
+    return ReadinessProbe(type=Type.tcp)
+
+
 class _NamedResource(Protocol):
     """Represents a resource with a name."""
 

--- a/test/bases/renku_data_services/data_api/test_notebooks.py
+++ b/test/bases/renku_data_services/data_api/test_notebooks.py
@@ -329,6 +329,7 @@ async def test_not_found_server(
 
     assert res.status_code == 404, res.text
 
+
 @pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 @pytest.mark.sessions
 @pytest.mark.asyncio

--- a/test/bases/renku_data_services/data_api/test_notebooks.py
+++ b/test/bases/renku_data_services/data_api/test_notebooks.py
@@ -12,7 +12,13 @@ from sanic_testing.testing import SanicASGITestClient
 
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.data_api.dependencies import DependencyManager
-from renku_data_services.notebooks.crs import AmaltheaSessionSpec, AmaltheaSessionV1Alpha1, Resources, Session
+from renku_data_services.notebooks.crs import (
+    AmaltheaSessionSpec,
+    AmaltheaSessionV1Alpha1,
+    Resources,
+    Session,
+    Type,
+)
 
 
 @pytest.fixture
@@ -322,3 +328,70 @@ async def test_not_found_server(
     _, res = await sanic_client.get(f"/api/data/sessions/{server_name}", headers=authenticated_user_headers)
 
     assert res.status_code == 404, res.text
+
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
+@pytest.mark.sessions
+@pytest.mark.asyncio
+async def test_start_server_remote_readiness_probe(
+    sanic_client: SanicASGITestClient,
+    authenticated_user_headers,
+    notebooks_fixtures,
+    create_session_launcher,
+    create_project,
+    renku_image,
+    create_resource_pool,
+    app_manager_instance: DependencyManager,
+    regular_user_api_user: APIUser,
+    admin_headers: dict[str, str],
+):
+    """Remote interactive sessions should use an HTTP readiness probe."""
+    # Create an OAuth2 provider required for a remote resource pool.
+    provider_payload = {
+        "id": "test-provider-for-remote-session-notebooks",
+        "kind": "gitlab",
+        "client_id": "test-client-id",
+        "display_name": "Test Provider",
+        "scope": "api",
+        "url": "https://example.org",
+    }
+    _, res = await sanic_client.post("/api/data/oauth2/providers", headers=admin_headers, json=provider_payload)
+    assert res.status_code == 201, res.text
+
+    # Create a private resource pool and patch it to be remote.
+    rp = await create_resource_pool(admin=True, public=False)
+    patch = {
+        "remote": {
+            "kind": "firecrest",
+            "provider_id": provider_payload["id"],
+            "api_url": "https://example.org",
+            "system_name": "my-system",
+        },
+    }
+    _, res = await sanic_client.patch(f"/api/data/resource_pools/{rp['id']}", headers=admin_headers, json=patch)
+    assert res.status_code == 200, res.text
+
+    proj = await create_project(sanic_client, "proj1")
+    env = {
+        "environment_kind": "CUSTOM",
+        "name": "Test",
+        "container_image": renku_image,
+        "environment_image_source": "image",
+    }
+    launcher = await create_session_launcher("launcher_name", proj["id"], **{"environment": env})
+    data = {"launcher_id": launcher["id"], "resource_class_id": rp["classes"][0]["id"]}
+    cookies = {app_manager_instance.config.nb_config.session_id_cookie_name: "session_id"}
+
+    # Use admin headers so the user can access the private remote pool.
+    _, res = await sanic_client.post("/api/data/sessions/", json=data, headers=admin_headers, cookies=cookies)
+    assert res.status_code == 201, res.text
+
+    server_name: str = res.json["name"]
+
+    # Fetch the created session from k8s and verify the readiness probe.
+    # NOTE: The session is created under the admin user's namespace (safe_username="admin").
+    session = await app_manager_instance.config.nb_config.k8s_v2_client.get_session(server_name, "admin")
+    assert session.spec.session.readinessProbe.type == Type.http
+
+    # Cleanup.
+    _, res = await sanic_client.delete(f"/api/data/sessions/{server_name}", headers=admin_headers)
+    assert res.status_code == 204, res.text

--- a/test/components/renku_data_services/notebooks/test_core_sessions_readiness_probe.py
+++ b/test/components/renku_data_services/notebooks/test_core_sessions_readiness_probe.py
@@ -1,0 +1,25 @@
+"""Tests for readiness probe behaviour in core_sessions."""
+
+from renku_data_services.notebooks.core_sessions import _get_readiness_probe
+from renku_data_services.notebooks.crs import SessionLocation, Type
+from renku_data_services.notebooks.models import SessionType
+
+
+class TestGetReadinessProbe:
+    """Unit tests for _get_readiness_probe helper."""
+
+    def test_non_interactive_always_none(self) -> None:
+        """Non-interactive sessions should have no readiness probe regardless of location."""
+        for location in (SessionLocation.local, SessionLocation.remote):
+            probe = _get_readiness_probe(SessionType.non_interactive, location)
+            assert probe.type == Type.none, f"Expected none for {location}"
+
+    def test_interactive_local_uses_tcp(self) -> None:
+        """Interactive local sessions should keep the default TCP readiness probe."""
+        probe = _get_readiness_probe(SessionType.interactive, SessionLocation.local)
+        assert probe.type == Type.tcp
+
+    def test_interactive_remote_uses_http(self) -> None:
+        """Interactive remote sessions should use an HTTP readiness probe."""
+        probe = _get_readiness_probe(SessionType.interactive, SessionLocation.remote)
+        assert probe.type == Type.http


### PR DESCRIPTION
## Summary

This PR makes remote interactive sessions (FirecREST/Slurm and RunAI) report Kubernetes readiness based on whether the session is *actually serving its frontend*, rather than merely on whether the tunnel has connected. It does so by selecting the readiness probe type per session based on both session type and location, sending an `http` probe for remote interactive sessions, `tcp` for local interactive sessions, and `none` for non-interactive sessions.

This change pairs with https://github.com/SwissDataScienceCenter/amalthea/pull/1135, which forwards `readinessProbe`, `port`, and `urlPath` into the remote session controller sidecar so its `/ready` endpoint actually evaluates these probe types.

## Motivation and Context

For remote sessions managed via FirecREST / RunAI, the controller pod was reporting ready immediately as soon as the tunnel connected, even if the IDE on the remote compute node had not actually started yet. As a result, a session could appear "ready" in the UI while the remote process was not yet serving the frontend, causing service routing to send users to a session that isn't usable.

We want the Kubernetes readiness state to reflect real, user-facing session availability so that routing only begins once the session is genuinely reachable. The Amalthea sidecar's `/ready` handler now interprets the probe type; `none` returns 200 immediately, `tcp` dials the local tunnel endpoint, and `http` performs an HTTP GET against the session's port and URL path. This PR is responsible for selecting the correct type per session.

## Changes

- Introduced a `_get_readiness_probe(session_type, session_location)` helper in `core_sessions.py` that centralizes readiness-probe selection:
  - Non-interactive sessions: `Type.none` (no probe), regardless of location.
  - Interactive **remote** sessions (FirecREST/RunAI): `Type.http`.
  - Interactive **local** sessions: `Type.tcp` (the existing default behavior).
- Updated `start_session` to call `_get_readiness_probe(...)` instead of the previous inline `Type.none` / default branch, so probe selection now accounts for session location.
- Added unit tests (`test_core_sessions_readiness_probe.py`) covering all three branches of the helper.
- Added an integration test (`test_start_server_remote_readiness_probe`) that provisions a remote (FirecREST) resource pool, starts a session, and asserts the created session's `readinessProbe.type == Type.http`.

## Notes

- **Depends on https://github.com/SwissDataScienceCenter/amalthea/pull/1135**, without it, the remote controller sidecar will not act on the `http`/`tcp` probe types. That PR requires no CRD changes, since `readinessProbe`, `port`, and `urlPath` already exist on the AmaltheaSession CRD.
- The behavior is **backward compatible**: in Amalthea, an empty/unknown probe type or a port of `0` falls back to the previous behavior of returning `200 OK`, so existing remote sessions continue to behave exactly as before until they're created with these values.
- Local sessions are unaffected in practice; they retain the default TCP probe via Kubernetes container probes.