### PR TITLE
feat: add remote-tunnel label for network policy selection

### DIFF
--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1089,7 +1089,7 @@ async def start_session(
     }
 
     if session_location == SessionLocation.remote:
-        labels["renku.io/reverse-tunnel"] = "allow"
+        labels["renku.io/remote-tunnel"] = "allow"
 
     if user.is_anonymous:
         labels["renku.io/anonymous-session"] = "true"

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1088,6 +1088,9 @@ async def start_session(
         "renku.io/session-type": str(session_type),
     }
 
+    if session_location == SessionLocation.remote:
+        labels["renku.io/reverse-tunnel"] = "allow"
+
     if user.is_anonymous:
         labels["renku.io/anonymous-session"] = "true"
 


### PR DESCRIPTION
## Summary

This PR adds a `renku.io/remote-tunnel: allow` label to amalthea sessions when its `session_location` is remote.

it has a companion PR in renku https://github.com/SwissDataScienceCenter/renku/pull/4485