### PR TITLE
fix: solr splitting project name

### DIFF
--- a/bases/renku_data_services/data_tasks/task_defs.py
+++ b/bases/renku_data_services/data_tasks/task_defs.py
@@ -41,7 +41,7 @@ async def update_search(dm: DependencyManager) -> None:
     """Update the SOLR with data from the search staging table."""
     while True:
         async with DefaultSolrClient(dm.config.solr) as client:
-            await search_core.update_solr(dm.search_updates_repo, client, 20)
+            await search_core.update_solr(dm.search_updates_repo, client, 20, dm.config.solr)
         await asyncio.sleep(1)
 
 

--- a/bases/renku_data_services/data_tasks/task_defs.py
+++ b/bases/renku_data_services/data_tasks/task_defs.py
@@ -41,7 +41,7 @@ async def update_search(dm: DependencyManager) -> None:
     """Update the SOLR with data from the search staging table."""
     while True:
         async with DefaultSolrClient(dm.config.solr) as client:
-            await search_core.update_solr(dm.search_updates_repo, client, 20, dm.config.solr)
+            await search_core.update_solr(dm.search_updates_repo, client, 20)
         await asyncio.sleep(1)
 
 

--- a/bases/renku_data_services/data_tasks/task_defs.py
+++ b/bases/renku_data_services/data_tasks/task_defs.py
@@ -31,7 +31,9 @@ from renku_data_services.k8s.models import K8sObject, K8sObjectFilter
 from renku_data_services.namespace.models import NamespaceKind
 from renku_data_services.notebooks.constants import AMALTHEA_SESSION_GVK
 from renku_data_services.notifications.models import UnsavedAlert
+from renku_data_services.solr.entity_schema import all_migrations
 from renku_data_services.solr.solr_client import DefaultSolrClient
+from renku_data_services.solr.solr_migrate import SchemaMigrator
 from renku_data_services.utils.core import get_effective_quota
 
 logger = logging.getLogger(__name__)
@@ -39,6 +41,9 @@ logger = logging.getLogger(__name__)
 
 async def update_search(dm: DependencyManager) -> None:
     """Update the SOLR with data from the search staging table."""
+    migrator = SchemaMigrator(dm.config.solr)
+    logger.info("Running/waiting for solr schema migration")
+    await migrator.migrate(all_migrations)
     while True:
         async with DefaultSolrClient(dm.config.solr) as client:
             await search_core.update_solr(dm.search_updates_repo, client, 20)

--- a/components/renku_data_services/search/core.py
+++ b/components/renku_data_services/search/core.py
@@ -49,13 +49,12 @@ async def update_solr(
     search_updates_repo: SearchUpdatesRepo,
     solr_client: SolrClient,
     batch_size: int,
-    solr_config: SolrClientConfig,
     schema_version: Literal["latest"] | int = "latest",
 ) -> list[Exception]:
     """Selects entries from the search staging table and updates SOLR."""
     counter = 0
     output: list[Exception] = []
-    migrator = SchemaMigrator(solr_config)
+    migrator = SchemaMigrator(solr_client.config)
     while True:
         schema_ready = await migrator.schema_version_is(schema_version)
         if not schema_ready:
@@ -106,7 +105,7 @@ async def _renku_query(
     authz_client: AuthzClient, ctx: Context, uq: SolrUserQuery, limit: int, offset: int
 ) -> SolrQuery:
     """Create the final solr query embedding the given user query."""
-    logger.debug(f"Searching as user: {ctx.role or "anonymous"}")
+    logger.debug(f"Searching as user: {ctx.role or 'anonymous'}")
     role_constraint: list[str] = [st.public_only()]
     match ctx.role:
         case AdminRole():

--- a/components/renku_data_services/search/core.py
+++ b/components/renku_data_services/search/core.py
@@ -39,17 +39,23 @@ from renku_data_services.solr.solr_client import (
     SolrQuery,
     SubQuery,
 )
+from renku_data_services.solr.solr_migrate import SchemaMigrator
 
 logger = logging.getLogger(__name__)
 
 
 async def update_solr(
-    search_updates_repo: SearchUpdatesRepo, solr_client: SolrClient, batch_size: int
+    search_updates_repo: SearchUpdatesRepo, solr_client: SolrClient, batch_size: int, solr_config: SolrClientConfig
 ) -> list[Exception]:
     """Selects entries from the search staging table and updates SOLR."""
     counter = 0
     output: list[Exception] = []
+    migrator = SchemaMigrator(solr_config)
     while True:
+        schema_ready = await migrator.schema_is_ready()
+        if not schema_ready:
+            await asyncio.sleep(2)
+            continue
         entries = await search_updates_repo.select_next(batch_size)
         if entries == []:
             break

--- a/components/renku_data_services/search/core.py
+++ b/components/renku_data_services/search/core.py
@@ -3,7 +3,6 @@
 import asyncio
 from collections.abc import Iterable
 from datetime import UTC, datetime
-from typing import Literal
 
 from authzed.api.v1 import (
     AsyncClient as AuthzClient,
@@ -40,7 +39,6 @@ from renku_data_services.solr.solr_client import (
     SolrQuery,
     SubQuery,
 )
-from renku_data_services.solr.solr_migrate import SchemaMigrator
 
 logger = logging.getLogger(__name__)
 
@@ -49,17 +47,11 @@ async def update_solr(
     search_updates_repo: SearchUpdatesRepo,
     solr_client: SolrClient,
     batch_size: int,
-    schema_version: Literal["latest"] | int = "latest",
 ) -> list[Exception]:
     """Selects entries from the search staging table and updates SOLR."""
     counter = 0
     output: list[Exception] = []
-    migrator = SchemaMigrator(solr_client.config)
     while True:
-        schema_ready = await migrator.schema_version_is(schema_version)
-        if not schema_ready:
-            await asyncio.sleep(2)
-            continue
         entries = await search_updates_repo.select_next(batch_size)
         if entries == []:
             break

--- a/components/renku_data_services/search/core.py
+++ b/components/renku_data_services/search/core.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Iterable
 from datetime import UTC, datetime
+from typing import Literal
 
 from authzed.api.v1 import (
     AsyncClient as AuthzClient,
@@ -45,14 +46,18 @@ logger = logging.getLogger(__name__)
 
 
 async def update_solr(
-    search_updates_repo: SearchUpdatesRepo, solr_client: SolrClient, batch_size: int, solr_config: SolrClientConfig
+    search_updates_repo: SearchUpdatesRepo,
+    solr_client: SolrClient,
+    batch_size: int,
+    solr_config: SolrClientConfig,
+    schema_version: Literal["latest"] | int = "latest",
 ) -> list[Exception]:
     """Selects entries from the search staging table and updates SOLR."""
     counter = 0
     output: list[Exception] = []
     migrator = SchemaMigrator(solr_config)
     while True:
-        schema_ready = await migrator.schema_is_ready()
+        schema_ready = await migrator.schema_version_is(schema_version)
         if not schema_ready:
             await asyncio.sleep(2)
             continue

--- a/components/renku_data_services/search/reprovision.py
+++ b/components/renku_data_services/search/reprovision.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import AsyncGenerator, Callable
 from datetime import datetime, timedelta
+from typing import Literal
 
 from renku_data_services.app_config import logging
 from renku_data_services.base_api.pagination import PaginationRequest
@@ -49,22 +50,27 @@ class SearchReprovision:
         self._data_connector_repo = data_connector_repo
         self._migrator = SchemaMigrator(solr_config)
 
-    async def run_reprovision(self, admin: APIUser, migrate_solr_schema: bool = True) -> int:
-        """Start a reprovisioning if not already running."""
-        migration_timeout = timedelta(minutes=2)
+    async def _wait_schema_version(
+        self, version: Literal["latest"] | int = "latest", timeout: timedelta = timedelta(minutes=2)
+    ) -> None:
         start = datetime.now()
         while True:
-            schema_ready = await self._migrator.schema_is_ready()
+            schema_ready = await self._migrator.schema_version_is(version)
             if schema_ready:
                 break
-            if datetime.now() - start > migration_timeout:
+            if datetime.now() - start > timeout:
                 raise errors.ProgrammingError(
                     message="Reproviosioning could not start because a solr schema migration "
-                    f"is needed first and is taking longer than {migration_timeout}"
+                    f"is needed first and is taking longer than {timeout}"
                 )
             await asyncio.sleep(5)
+
+    async def run_reprovision(
+        self, admin: APIUser, migrate_solr_schema: bool = True, schema_version: Literal["latest"] | int = "latest"
+    ) -> int:
+        """Start a reprovisioning if not already running."""
         reprovision = await self.acquire_reprovision()
-        return await self.init_reprovision(admin, reprovision, migrate_solr_schema)
+        return await self.init_reprovision(admin, reprovision, migrate_solr_schema, schema_version)
 
     async def acquire_reprovision(self) -> Reprovisioning:
         """Acquire a reprovisioning slot. Throws if already taken."""
@@ -93,7 +99,11 @@ class SearchReprovision:
                 yield dc
 
     async def init_reprovision(
-        self, admin: APIUser, reprovisioning: Reprovisioning, migrate_solr_schema: bool = True
+        self,
+        admin: APIUser,
+        reprovisioning: Reprovisioning,
+        migrate_solr_schema: bool = True,
+        schema_version: Literal["latest"] | int = "latest",
     ) -> int:
         """Initiates reprovisioning by inserting documents into the staging table.
 
@@ -110,6 +120,9 @@ class SearchReprovision:
         def log_counter(c: int) -> None:
             if c % 50 == 0:
                 logger.info(f"Inserted {c}. entities into staging table...")
+
+        if not migrate_solr_schema:
+            await self._wait_schema_version(schema_version)
 
         migrator = SchemaMigrator(self._solr_config)
         counter = 0
@@ -135,7 +148,11 @@ class SearchReprovision:
                         )
 
             if migrate_solr_schema:
-                await migrator.migrate(entity_schema.all_migrations)
+                if schema_version == "latest":
+                    migrations = entity_schema.all_migrations
+                else:
+                    migrations = [i for i in entity_schema.all_migrations if i.version <= schema_version]
+                await migrator.migrate(migrations)
 
             all_users = self._user_repo.get_all_users(requested_by=admin)
             counter = await self.__update_entities(all_users, "user", started, counter, log_counter)

--- a/components/renku_data_services/search/reprovision.py
+++ b/components/renku_data_services/search/reprovision.py
@@ -1,13 +1,15 @@
 """Code for reprovisioning the search index."""
 
+import asyncio
 from collections.abc import AsyncGenerator, Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from renku_data_services.app_config import logging
 from renku_data_services.base_api.pagination import PaginationRequest
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.data_connectors.db import DataConnectorRepository
 from renku_data_services.data_connectors.models import DataConnector, GlobalDataConnector
+from renku_data_services.errors import errors
 from renku_data_services.errors.errors import ForbiddenError
 from renku_data_services.message_queue.db import ReprovisioningRepository
 from renku_data_services.message_queue.models import Reprovisioning
@@ -45,9 +47,22 @@ class SearchReprovision:
         self._group_repo = group_repo
         self._project_repo = project_repo
         self._data_connector_repo = data_connector_repo
+        self._migrator = SchemaMigrator(solr_config)
 
     async def run_reprovision(self, admin: APIUser, migrate_solr_schema: bool = True) -> int:
         """Start a reprovisioning if not already running."""
+        migration_timeout = timedelta(minutes=2)
+        start = datetime.now()
+        while True:
+            schema_ready = await self._migrator.schema_is_ready()
+            if schema_ready:
+                break
+            if datetime.now() - start > migration_timeout:
+                raise errors.ProgrammingError(
+                    message="Reproviosioning could not start because a solr schema migration "
+                    f"is needed first and is taking longer than {migration_timeout}"
+                )
+            await asyncio.sleep(5)
         reprovision = await self.acquire_reprovision()
         return await self.init_reprovision(admin, reprovision, migrate_solr_schema)
 

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -186,10 +186,28 @@ def public_only() -> SolrToken:
 
 
 def content_all(text: str) -> SolrToken:
-    """Search the content_all field with fuzzy searching each term."""
-    terms: list[SolrToken] = list(map(lambda s: SolrToken(__escape_query(s) + "~"), re.split("\\s+", text)))
-    terms_str = "(" + " ".join(terms) + ")"
-    return SolrToken(f"{Fields.content_all}:{terms_str}")
+    """Search free text across several fields, weighting better matches higher.
+
+    The text is fuzzy-matched against the broad ``content_all`` field and, with a
+    higher boost, against ``name``. A single-word query is additionally matched
+    *exactly* (no fuzzy) against ``slug`` with the highest boost. ``slug`` is an
+    untokenized ``StrField``, so that clause is what reliably matches hyphenated
+    values such as "test-project": the tokenized fields split those on the hyphen
+    and the fuzzy operator bypasses the analyzer, so only the slug clause sees the
+    value whole. Scores from all matching clauses are summed, so name/slug hits
+    rank above generic content matches. The boost factors below are tunable knobs.
+    """
+    words = [w for w in re.split(r"\s+", text) if w != ""]
+    fuzzy = " ".join(f"{__escape_query(w)}~" for w in words)
+    clauses = [
+        f"{Fields.content_all}:({fuzzy})",
+        f"{Fields.name}:({fuzzy})^10",
+    ]
+    # A slug is a single, untokenized, lowercased token, so only a whitespace-free
+    # query can match it exactly. Lowercase the term since slugs are always lowercase.
+    if len(words) == 1:
+        clauses.append(f"{Fields.slug}:{__escape_query(words[0].lower())}^20")
+    return SolrToken("(" + " OR ".join(clauses) + ")")
 
 
 def created_by_exists() -> SolrToken:

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -207,7 +207,7 @@ def content_all(text: str) -> SolrToken:
         # untokenized (it keeps spaces), and its query analyzer lowercases, so we
         # only need to escape the text (escaping the spaces keeps it one term).
         # Build it from `words` so runs of whitespace collapse to single spaces.
-        f"{Fields.name_keyword}:{__escape_query(' '.join(words))}^30",
+        f"{Fields.name_keyword}:{__escape_query(text.strip())}^30",
     ]
     # A slug is a single, untokenized, lowercased token, so only a whitespace-free
     # query can match it exactly. Lowercase the term since slugs are always lowercase.

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -196,7 +196,7 @@ def content_all(text: str) -> SolrToken:
     ranks it first, regardless of spaces, hyphens or underscores. A single-word
     query is additionally matched exactly against the untokenized ``slug``. Scores
     from all matching clauses are summed, so name/title hits rank above generic
-    content matches. The boost factors below are tunable knobs.
+    content matches.
     """
     words = [w for w in re.split(r"\s+", text) if w != ""]
     fuzzy = " ".join(f"{__escape_query(w)}~" for w in words)
@@ -205,8 +205,8 @@ def content_all(text: str) -> SolrToken:
         f"{Fields.name}:({fuzzy})^2",
         # Exact, case-insensitive match of the whole title. nameKeyword is
         # untokenized (it keeps spaces), and its query analyzer lowercases, so we
-        # only need to escape the text (escaping the spaces keeps it one term).
-        # Build it from `words` so runs of whitespace collapse to single spaces.
+        # only need to escape the text. If we use words we will lose the spaces.
+        # But we want the spaces so that we can have a strong score on exact name matches.
         f"{Fields.name_keyword}:{__escape_query(text.strip())}^10",
     ]
     # A slug is a single, untokenized, lowercased token, so only a whitespace-free

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -189,19 +189,25 @@ def content_all(text: str) -> SolrToken:
     """Search free text across several fields, weighting better matches higher.
 
     The text is fuzzy-matched against the broad ``content_all`` field and, with a
-    higher boost, against ``name``. A single-word query is additionally matched
-    *exactly* (no fuzzy) against ``slug`` with the highest boost. ``slug`` is an
-    untokenized ``StrField``, so that clause is what reliably matches hyphenated
-    values such as "test-project": the tokenized fields split those on the hyphen
-    and the fuzzy operator bypasses the analyzer, so only the slug clause sees the
-    value whole. Scores from all matching clauses are summed, so name/slug hits
-    rank above generic content matches. The boost factors below are tunable knobs.
+    higher boost, against ``name``. The whole text is also matched *exactly* (no
+    fuzzy) against ``nameKeyword`` with the highest boost: that field is a
+    ``keyword`` type that keeps the entire title -- including spaces -- as a single,
+    case-insensitive token, so typing a project's exact title reliably matches and
+    ranks it first, regardless of spaces, hyphens or underscores. A single-word
+    query is additionally matched exactly against the untokenized ``slug``. Scores
+    from all matching clauses are summed, so name/title hits rank above generic
+    content matches. The boost factors below are tunable knobs.
     """
     words = [w for w in re.split(r"\s+", text) if w != ""]
     fuzzy = " ".join(f"{__escape_query(w)}~" for w in words)
     clauses = [
         f"{Fields.content_all}:({fuzzy})",
         f"{Fields.name}:({fuzzy})^10",
+        # Exact, case-insensitive match of the whole title. nameKeyword is
+        # untokenized (it keeps spaces), and its query analyzer lowercases, so we
+        # only need to escape the text (escaping the spaces keeps it one term).
+        # Build it from `words` so runs of whitespace collapse to single spaces.
+        f"{Fields.name_keyword}:{__escape_query(' '.join(words))}^30",
     ]
     # A slug is a single, untokenized, lowercased token, so only a whitespace-free
     # query can match it exactly. Lowercase the term since slugs are always lowercase.

--- a/components/renku_data_services/search/solr_token.py
+++ b/components/renku_data_services/search/solr_token.py
@@ -202,17 +202,17 @@ def content_all(text: str) -> SolrToken:
     fuzzy = " ".join(f"{__escape_query(w)}~" for w in words)
     clauses = [
         f"{Fields.content_all}:({fuzzy})",
-        f"{Fields.name}:({fuzzy})^10",
+        f"{Fields.name}:({fuzzy})^2",
         # Exact, case-insensitive match of the whole title. nameKeyword is
         # untokenized (it keeps spaces), and its query analyzer lowercases, so we
         # only need to escape the text (escaping the spaces keeps it one term).
         # Build it from `words` so runs of whitespace collapse to single spaces.
-        f"{Fields.name_keyword}:{__escape_query(text.strip())}^30",
+        f"{Fields.name_keyword}:{__escape_query(text.strip())}^10",
     ]
     # A slug is a single, untokenized, lowercased token, so only a whitespace-free
     # query can match it exactly. Lowercase the term since slugs are always lowercase.
     if len(words) == 1:
-        clauses.append(f"{Fields.slug}:{__escape_query(words[0].lower())}^20")
+        clauses.append(f"{Fields.slug}:{__escape_query(words[0].lower())}^5")
     return SolrToken("(" + " OR ".join(clauses) + ")")
 
 

--- a/components/renku_data_services/solr/constants.py
+++ b/components/renku_data_services/solr/constants.py
@@ -1,0 +1,6 @@
+"""Constants for solr."""
+
+from datetime import timedelta
+from typing import Final
+
+SOLR_VERSION_DEFAULT_TIMEOUT: Final[timedelta] = timedelta(minutes=2)

--- a/components/renku_data_services/solr/entity_schema.py
+++ b/components/renku_data_services/solr/entity_schema.py
@@ -31,6 +31,7 @@ class Fields:
     last_name: Final[FieldName] = FieldName("lastName")
     members: Final[FieldName] = FieldName("members")
     name: Final[FieldName] = FieldName("name")
+    name_keyword: Final[FieldName] = FieldName("nameKeyword")
     repositories: Final[FieldName] = FieldName("repositories")
     slug: Final[FieldName] = FieldName("slug")
     visibility: Final[FieldName] = FieldName("visibility")
@@ -85,6 +86,38 @@ class Analyzers:
         filters=[Filters.lowercase],
     )
 
+    # Analyzers for the `name` field only. Unlike `text_index`, these use the
+    # whitespace tokenizer so hyphenated values stay intact long enough for the
+    # wordDelimiterGraph filter to split them. That filter then emits the word
+    # parts ("test", "project"), the catenated form ("testproject") and -- via
+    # preserveOriginal -- the whole token ("test-project"), so the name field
+    # matches all of those (including the hyphenated whole, which the fuzzy query
+    # operator can only hit because preserveOriginal keeps it in the index).
+    name_index: Final[Analyzer] = Analyzer(
+        tokenizer=Tokenizers.whitespace,
+        filters=[
+            Filters.word_delimiter_graph(catenate=True, preserve_original=True),
+            Filters.flatten_graph,
+            Filters.lowercase,
+            Filters.stop,
+            Filters.english_minimal_stem,
+            Filters.ascii_folding,
+            Filters.edgeNgram(2, 8, True),
+        ],
+    )
+
+    name_query: Final[Analyzer] = Analyzer(
+        tokenizer=Tokenizers.whitespace,
+        filters=[
+            # No catenate or flattenGraph at query time; the parser handles the graph.
+            Filters.word_delimiter_graph(catenate=False, preserve_original=True),
+            Filters.lowercase,
+            Filters.stop,
+            Filters.english_minimal_stem,
+            Filters.ascii_folding,
+        ],
+    )
+
 
 class FieldTypes:
     """A collection of field types."""
@@ -97,6 +130,14 @@ class FieldTypes:
         .with_index_analyzer(Analyzers.text_index)
         .with_query_analyzer(Analyzers.text_query)
     )
+    text_name: Final[FieldType] = (
+        FieldType.text(TypeName("SearchTextName"))
+        .with_index_analyzer(Analyzers.name_index)
+        .with_query_analyzer(Analyzers.name_query)
+    )
+    """Like `text`, but splits hyphenated/camelCase tokens into parts while also
+    keeping the whole and catenated forms. Used only for the `name` field."""
+
     text_all: Final[FieldType] = (
         FieldType.text(TypeName("SearchTextAll"))
         .with_index_analyzer(Analyzers.text_index)
@@ -186,6 +227,19 @@ all_migrations: Final[list[SchemaMigration]] = [
         version=14,
         commands=[
             ReplaceCommand(Field.of(Fields.keywords, FieldTypes.keyword).make_multi_valued()),
+        ],
+        requires_reindex=True,
+    ),
+    SchemaMigration(
+        version=15,
+        commands=[
+            AddCommand(FieldTypes.text_name),
+            ReplaceCommand(Field.of(Fields.name, FieldTypes.text_name)),
+            # An untokenized, case-insensitive copy of the name (FieldTypes.keyword
+            # keeps the whole value including spaces as a single token) so an exact
+            # title can be matched/boosted regardless of spaces or other separators.
+            AddCommand(Field.of(Fields.name_keyword, FieldTypes.keyword)),
+            AddCommand(CopyFieldRule(source=Fields.name, dest=Fields.name_keyword)),
         ],
         requires_reindex=True,
     ),

--- a/components/renku_data_services/solr/solr_client.py
+++ b/components/renku_data_services/solr/solr_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
@@ -624,12 +624,18 @@ class SolrClient(AbstractAsyncContextManager, ABC):
         """Delete data that matches the `query`."""
         ...
 
+    @property
+    @abstractmethod
+    def config(self) -> SolrClientConfig:
+        """Get the config for the client."""
+        ...
+
 
 class DefaultSolrClient(SolrClient):
     """Default implementation of the solr client."""
 
     def __init__(self, cfg: SolrClientConfig):
-        self.config = cfg
+        self.__config = cfg
         url_parsed = list(urlparse(cfg.base_url))
         url_parsed[2] = urljoin(url_parsed[2], f"/solr/{cfg.core}")
         burl = urlunparse(url_parsed)
@@ -638,6 +644,11 @@ class DefaultSolrClient(SolrClient):
 
     def __repr__(self) -> str:
         return f"DefaultSolrClient(delegate={self.delegate}, config={self.config})"
+
+    @property
+    def config(self) -> SolrClientConfig:
+        """The client config."""
+        return self.__config
 
     async def __aenter__(self) -> Self:
         await self.delegate.__aenter__()
@@ -770,9 +781,14 @@ class DefaultSolrAdminClient(SolrAdminClient):
     """
 
     def __init__(self, cfg: SolrClientConfig):
-        self.config = cfg
+        self.__config = cfg
         bauth = BasicAuth(username=cfg.user.username, password=cfg.user.password) if cfg.user is not None else None
         self.delegate = AsyncClient(auth=bauth, base_url=self.config.base_url, timeout=cfg.timeout)
+
+    @property
+    def config(self) -> SolrClientConfig:
+        """The client config."""
+        return self.__config
 
     async def __aenter__(self) -> Self:
         await self.delegate.__aenter__()

--- a/components/renku_data_services/solr/solr_client.py
+++ b/components/renku_data_services/solr/solr_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field

--- a/components/renku_data_services/solr/solr_migrate.py
+++ b/components/renku_data_services/solr/solr_migrate.py
@@ -1,7 +1,7 @@
 """Manage solr schema migrations."""
 
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import pydantic
 from pydantic import AliasChoices, BaseModel
@@ -175,7 +175,7 @@ class SchemaMigrator:
             else:
                 return doc.current_schema_version_l
 
-    async def schema_is_ready(self) -> bool:
+    async def schema_version_is(self, version: Literal["latest"] | int = "latest") -> bool:
         """Checks if all migrations have been completed."""
         from renku_data_services.solr.entity_schema import all_migrations
 
@@ -184,7 +184,8 @@ class SchemaMigrator:
             if doc is None:
                 return False
             else:
-                return doc.current_schema_version_l == all_migrations[-1].version
+                target_version = all_migrations[-1].version if version == "latest" else version
+                return doc.current_schema_version_l == target_version
 
     async def __current_version0(self, client: DefaultSolrClient) -> VersionDoc | None:
         """Return the current schema version document."""

--- a/components/renku_data_services/solr/solr_migrate.py
+++ b/components/renku_data_services/solr/solr_migrate.py
@@ -175,6 +175,17 @@ class SchemaMigrator:
             else:
                 return doc.current_schema_version_l
 
+    async def schema_is_ready(self) -> bool:
+        """Checks if all migrations have been completed."""
+        from renku_data_services.solr.entity_schema import all_migrations
+
+        async with DefaultSolrClient(self.__config) as client:
+            doc = await self.__current_version0(client)
+            if doc is None:
+                return False
+            else:
+                return doc.current_schema_version_l == all_migrations[-1].version
+
     async def __current_version0(self, client: DefaultSolrClient) -> VersionDoc | None:
         """Return the current schema version document."""
         resp = await client.get_raw(self.__docId)

--- a/components/renku_data_services/solr/solr_migrate.py
+++ b/components/renku_data_services/solr/solr_migrate.py
@@ -1,12 +1,16 @@
 """Manage solr schema migrations."""
 
+import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any, Literal, Self
 
 import pydantic
 from pydantic import AliasChoices, BaseModel
 
 from renku_data_services.app_config import logging
+from renku_data_services.errors import errors
+from renku_data_services.solr.constants import SOLR_VERSION_DEFAULT_TIMEOUT
 from renku_data_services.solr.solr_client import (
     DefaultSolrAdminClient,
     DefaultSolrClient,
@@ -176,7 +180,7 @@ class SchemaMigrator:
                 return doc.current_schema_version_l
 
     async def schema_version_is(self, version: Literal["latest"] | int = "latest") -> bool:
-        """Checks if all migrations have been completed."""
+        """Checks if the current migration in solr is >= the version passed in the function have been completed."""
         from renku_data_services.solr.entity_schema import all_migrations
 
         async with DefaultSolrClient(self.__config) as client:
@@ -185,7 +189,23 @@ class SchemaMigrator:
                 return False
             else:
                 target_version = all_migrations[-1].version if version == "latest" else version
-                return doc.current_schema_version_l == target_version
+                return doc.current_schema_version_l >= target_version
+
+    async def wait_for_schema_version(
+        self, version: Literal["latest"] | int = "latest", timeout: timedelta = SOLR_VERSION_DEFAULT_TIMEOUT
+    ) -> None:
+        """Waits for the schema in Solr to reach or pass the indicated version."""
+        start = datetime.now()
+        while True:
+            reached_version = await self.schema_version_is(version)
+            if reached_version:
+                break
+            if datetime.now() - start > timeout:
+                raise errors.ProgrammingError(
+                    message=f"Waiting for the Solr schema version to reach {version} "
+                    f"has timed out after {timeout.total_seconds} seconds."
+                )
+            await asyncio.sleep(2)
 
     async def __current_version0(self, client: DefaultSolrClient) -> VersionDoc | None:
         """Return the current schema version document."""
@@ -200,7 +220,11 @@ class SchemaMigrator:
                 return VersionDoc.model_validate(docs[0])
 
     async def migrate(self, migrations: list[SchemaMigration]) -> MigrateResult:
-        """Run all given migrations, skipping those that have been done before."""
+        """Run all given migrations, skipping those that have been done before.
+
+        If you call this but a migration is already underway then it will wait until
+        the migrations are all complete.
+        """
         async with DefaultSolrClient(self.__config) as client:
             initial_doc = await self.__current_version0(client)
             if initial_doc is None:
@@ -213,6 +237,9 @@ class SchemaMigrator:
 
             if initial_doc.migration_running_b:
                 logger.info("A solr migration is already running")
+                if len(migrations) == 0:
+                    return MigrateResult.empty()
+                await self.wait_for_schema_version(version=migrations[-1].version)
                 return MigrateResult.empty()
             else:
                 initial_doc.migration_running_b = True

--- a/components/renku_data_services/solr/solr_schema.py
+++ b/components/renku_data_services/solr/solr_schema.py
@@ -81,6 +81,34 @@ class Filters:
     classic = Filter(name="classic")
     ngram = Filter(name="nGram")
 
+    # Flattens the token graph produced by wordDelimiterGraph so it can be indexed.
+    # Must follow wordDelimiterGraph and is only valid in an *index* analyzer.
+    flatten_graph = Filter(name="flattenGraph")
+
+    @classmethod
+    def word_delimiter_graph(
+        cls, catenate: bool = True, preserve_original: bool = True, split_on_case_change: bool = True
+    ) -> Filter:
+        """Create a wordDelimiterGraph filter.
+
+        It splits tokens on intra-word delimiters (e.g. the hyphen in "test-project"
+        into "test" and "project"), and can additionally emit the catenated form
+        ("testproject") and keep the original token ("test-project") via
+        `preserve_original`. See
+        https://solr.apache.org/guide/solr/latest/indexing-guide/filters.html#word-delimiter-graph-filter
+        """
+        return Filter(
+            name="wordDelimiterGraph",
+            settings={
+                "generateWordParts": "1",
+                "generateNumberParts": "1",
+                "catenateWords": "1" if catenate else "0",
+                "catenateNumbers": "1" if catenate else "0",
+                "preserveOriginal": "1" if preserve_original else "0",
+                "splitOnCaseChange": "1" if split_on_case_change else "0",
+            },
+        )
+
     @classmethod
     def edgeNgram(cls, min_gram_size: int = 3, maxGramSize: int = 6, preserve_original: bool = True) -> Filter:
         """Create a edgeNGram filter with the given settings."""

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -292,7 +292,6 @@ class SearchReprovisionCall(Protocol):
         app_manager_instance: DependencyManager,
         migrate_solr_schema: bool = True,
         clear_index: bool = False,
-        schema_version: Literal["latest"] | int = "latest",
     ) -> None: ...
 
 
@@ -307,7 +306,7 @@ async def search_reprovision(search_push_updates) -> SearchReprovisionCall:
         schema_version: Literal["latest"] | int = "latest",
     ) -> None:
         await app_manager_instance.search_reprovisioning.run_reprovision(admin, migrate_solr_schema, schema_version)
-        await search_push_updates(app_manager_instance, clear_index=clear_index, schema_version=schema_version)
+        await search_push_updates(app_manager_instance, clear_index=clear_index)
 
     return search_reprovision_helper
 
@@ -317,7 +316,6 @@ async def search_push_updates():
     async def search_push_updates_helper(
         app_manager_instance: DependencyManager,
         clear_index: bool = False,
-        schema_version: Literal["latest"] | int = "latest",
     ) -> None:
         async with DefaultSolrClient(app_manager_instance.config.solr) as client:
             if clear_index:
@@ -330,7 +328,6 @@ async def search_push_updates():
                 app_manager_instance.search_updates_repo,
                 client,
                 10,
-                schema_version,
             )
             assert len(responses) == 0, responses
 

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -313,7 +313,9 @@ async def search_push_updates():
                 async with DefaultSolrAdminClient(app_manager_instance.config.solr) as admin_client:
                     res = await admin_client.reload(None)
                     assert res.status_code == 200, res.text
-            responses = await search_core.update_solr(app_manager_instance.search_updates_repo, client, 10)
+            responses = await search_core.update_solr(
+                app_manager_instance.search_updates_repo, client, 10, app_manager_instance.config.solr
+            )
             assert len(responses) == 0, responses
 
     return search_push_updates_helper

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -330,7 +330,6 @@ async def search_push_updates():
                 app_manager_instance.search_updates_repo,
                 client,
                 10,
-                app_manager_instance.config.solr,
                 schema_version,
             )
             assert len(responses) == 0, responses

--- a/test/bases/renku_data_services/data_api/conftest.py
+++ b/test/bases/renku_data_services/data_api/conftest.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import AsyncGenerator, Callable
 from copy import deepcopy
 from datetime import timedelta
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 import pytest
 import pytest_asyncio
@@ -287,7 +287,13 @@ async def sanic_client_with_solr(sanic_client: SanicASGITestClient, app_manager)
 class SearchReprovisionCall(Protocol):
     """The type for the `search_reprovision` fixture."""
 
-    async def __call__(self, app_manager_instance: DependencyManager, migrate_solr_schema: bool = True) -> None: ...
+    async def __call__(
+        self,
+        app_manager_instance: DependencyManager,
+        migrate_solr_schema: bool = True,
+        clear_index: bool = False,
+        schema_version: Literal["latest"] | int = "latest",
+    ) -> None: ...
 
 
 @pytest_asyncio.fixture
@@ -295,17 +301,24 @@ async def search_reprovision(search_push_updates) -> SearchReprovisionCall:
     admin = InternalServiceAdmin(id=ServiceAdminId.search_reprovision)
 
     async def search_reprovision_helper(
-        app_manager_instance: DependencyManager, migrate_solr_schema: bool = True, clear_index: bool = False
+        app_manager_instance: DependencyManager,
+        migrate_solr_schema: bool = True,
+        clear_index: bool = False,
+        schema_version: Literal["latest"] | int = "latest",
     ) -> None:
-        await app_manager_instance.search_reprovisioning.run_reprovision(admin, migrate_solr_schema)
-        await search_push_updates(app_manager_instance, clear_index=clear_index)
+        await app_manager_instance.search_reprovisioning.run_reprovision(admin, migrate_solr_schema, schema_version)
+        await search_push_updates(app_manager_instance, clear_index=clear_index, schema_version=schema_version)
 
     return search_reprovision_helper
 
 
 @pytest_asyncio.fixture
 async def search_push_updates():
-    async def search_push_updates_helper(app_manager_instance: DependencyManager, clear_index: bool = False) -> None:
+    async def search_push_updates_helper(
+        app_manager_instance: DependencyManager,
+        clear_index: bool = False,
+        schema_version: Literal["latest"] | int = "latest",
+    ) -> None:
         async with DefaultSolrClient(app_manager_instance.config.solr) as client:
             if clear_index:
                 res = await client.delete("_type:*")
@@ -314,7 +327,11 @@ async def search_push_updates():
                     res = await admin_client.reload(None)
                     assert res.status_code == 200, res.text
             responses = await search_core.update_solr(
-                app_manager_instance.search_updates_repo, client, 10, app_manager_instance.config.solr
+                app_manager_instance.search_updates_repo,
+                client,
+                10,
+                app_manager_instance.config.solr,
+                schema_version,
             )
             assert len(responses) == 0, responses
 

--- a/test/bases/renku_data_services/data_api/test_search.py
+++ b/test/bases/renku_data_services/data_api/test_search.py
@@ -219,7 +219,7 @@ async def test_projects(
     sanic_client_with_solr: SanicASGITestClient,
     app_manager_instance: TestDependencyManager,
 ) -> None:
-    """More occurrences of a word should push results up."""
+    """Test different behaviours of the search scoring for projects."""
     p1 = await create_project_model(
         sanic_client_with_solr, "Project Bike Z", visibility="public", description="a bike with a bike"
     )
@@ -228,8 +228,15 @@ async def test_projects(
     p3 = await create_project_model(sanic_client_with_solr, "Project Bike R", visibility="public", description="a bike")
     await search_reprovision(app_manager_instance)
 
+    # More occurrences of a word should push results up
     result = await search_query(sanic_client_with_solr, "bike")
     assert_search_result(result, [p1, p3, p2], check_order=True)
+
+    # An exact match on the name should be the top result
+    result = await search_query(sanic_client_with_solr, "Project Bike A type:project")
+    assert result.items and len(result.items) == 3
+    assert isinstance(result.items[0].root, SearchProject)
+    assert result.items[0].root.id == p2.id
 
 
 # TODO: figure out how to run search tests fully parallel

--- a/test/bases/renku_data_services/data_api/test_search_migrations.py
+++ b/test/bases/renku_data_services/data_api/test_search_migrations.py
@@ -84,6 +84,7 @@ def get_solr_schemas() -> Callable[[int | None], list[SchemaMigration]]:
     [
         (12, 13),
         (13, 14),
+        (14, 15),
     ],
 )
 @pytest.mark.xdist_group("search")
@@ -133,7 +134,7 @@ async def test_search_schema_upgrade(
         keywords=["test-keyword"],
     )
 
-    await search_reprovision(app_manager, migrate_solr_schema=False)
+    await search_reprovision(app_manager, migrate_solr_schema=False, schema_version=start_solr_version)
     result = await search_query(sanic_client, "type:project", user=wout)
     assert_search_result(result, [p1, p3])
     res = await solr_migrator.migrate(get_solr_schemas(end_solr_version))

--- a/test/components/renku_data_services/search/test_core.py
+++ b/test/components/renku_data_services/search/test_core.py
@@ -41,7 +41,7 @@ async def test_update_solr(app_manager_instance, solr_search):
         before = await client.query(SolrQuery.query_all_fields("_type:*"))
         assert len(before.response.docs) == 0
 
-        await core.update_solr(repo, client, 10, app_manager_instance.config.solr)
+        await core.update_solr(repo, client, 10)
 
         result = await client.query(SolrQuery.query_all_fields("_type:*"))
         assert len(result.response.docs) == 2
@@ -50,7 +50,7 @@ async def test_update_solr(app_manager_instance, solr_search):
 
         user = UserInfo(id="user234", first_name="Greg", last_name="Larrsson", namespace=user_namespace)
         await repo.upsert(user, started_at=None)
-        await core.update_solr(repo, client, 10, app_manager_instance.config.solr)
+        await core.update_solr(repo, client, 10)
         entities = await repo.select_next(10)
         assert len(entities) == 0
         doc = await client.get("user234")
@@ -75,7 +75,7 @@ async def test_update_no_solr(app_manager_instance):
 
     async with DefaultSolrClient(solr_config) as client:
         try:
-            await core.update_solr(repo, client, 10, app_manager_instance.config.solr)
+            await core.update_solr(repo, client, 10)
             raise Exception("Not expected to succeed")
         except Exception as _:
             entities = await repo.select_next(10)

--- a/test/components/renku_data_services/search/test_core.py
+++ b/test/components/renku_data_services/search/test_core.py
@@ -11,7 +11,9 @@ from renku_data_services.namespace.models import UserNamespace
 from renku_data_services.search.db import SearchUpdatesRepo
 from renku_data_services.search.orm import RecordState, SearchUpdatesORM
 from renku_data_services.solr.entity_documents import User
+from renku_data_services.solr.entity_schema import all_migrations
 from renku_data_services.solr.solr_client import DefaultSolrClient, SolrClientConfig, SolrQuery
+from renku_data_services.solr.solr_migrate import SchemaMigrator
 from renku_data_services.users.models import UserInfo
 
 user_namespace = UserNamespace(
@@ -25,6 +27,8 @@ user_namespace = UserNamespace(
 @pytest.mark.asyncio
 async def test_update_solr(app_manager_instance, solr_search):
     run_migrations_for_app("common")
+    schema_migrator = SchemaMigrator(app_manager_instance.config.solr)
+    await schema_migrator.migrate(all_migrations)
     repo = SearchUpdatesRepo(app_manager_instance.config.db.async_session_maker)
 
     user = UserInfo(id="user123", first_name="Tadej", last_name="Pogacar", namespace=user_namespace)
@@ -37,7 +41,7 @@ async def test_update_solr(app_manager_instance, solr_search):
         before = await client.query(SolrQuery.query_all_fields("_type:*"))
         assert len(before.response.docs) == 0
 
-        await core.update_solr(repo, client, 10)
+        await core.update_solr(repo, client, 10, app_manager_instance.config.solr)
 
         result = await client.query(SolrQuery.query_all_fields("_type:*"))
         assert len(result.response.docs) == 2
@@ -46,7 +50,7 @@ async def test_update_solr(app_manager_instance, solr_search):
 
         user = UserInfo(id="user234", first_name="Greg", last_name="Larrsson", namespace=user_namespace)
         await repo.upsert(user, started_at=None)
-        await core.update_solr(repo, client, 10)
+        await core.update_solr(repo, client, 10, app_manager_instance.config.solr)
         entities = await repo.select_next(10)
         assert len(entities) == 0
         doc = await client.get("user234")
@@ -57,6 +61,8 @@ async def test_update_solr(app_manager_instance, solr_search):
 @pytest.mark.asyncio
 async def test_update_no_solr(app_manager_instance):
     run_migrations_for_app("common")
+    schema_migrator = SchemaMigrator(app_manager_instance.config.solr)
+    await schema_migrator.migrate(all_migrations)
     repo = SearchUpdatesRepo(app_manager_instance.config.db.async_session_maker)
 
     user = UserInfo(id="user123", first_name="Tadej", last_name="Pogacar", namespace=user_namespace)
@@ -69,7 +75,7 @@ async def test_update_no_solr(app_manager_instance):
 
     async with DefaultSolrClient(solr_config) as client:
         try:
-            await core.update_solr(repo, client, 10)
+            await core.update_solr(repo, client, 10, app_manager_instance.config.solr)
             raise Exception("Not expected to succeed")
         except Exception as _:
             entities = await repo.select_next(10)

--- a/test/components/renku_data_services/search/test_solr_token.py
+++ b/test/components/renku_data_services/search/test_solr_token.py
@@ -140,4 +140,6 @@ def test_content_all() -> None:
         "nameKeyword:Test\\-Project^30 OR slug:test\\-project^20)"
     )
     assert st.content_all("ab cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ cd^30)"
-    assert st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ cd^30)"
+    assert (
+        st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ \\ \\ \\ cd^30)"
+    )

--- a/test/components/renku_data_services/search/test_solr_token.py
+++ b/test/components/renku_data_services/search/test_solr_token.py
@@ -130,7 +130,8 @@ def test_created_by_exists() -> None:
 
 
 def test_content_all() -> None:
-    assert st.content_all("abc") == "content_all:(abc~)"
-    assert st.content_all("a+b+c") == "content_all:(a\\+b\\+c~)"
-    assert st.content_all("ab cd") == "content_all:(ab~ cd~)"
-    assert st.content_all("ab    cd") == "content_all:(ab~ cd~)"
+    assert st.content_all("abc") == "(content_all:(abc~) OR name:(abc~)^10 OR slug:abc^20)"
+    assert st.content_all("a+b+c") == "(content_all:(a\\+b\\+c~) OR name:(a\\+b\\+c~)^10 OR slug:a\\+b\\+c^20)"
+    assert st.content_all("Test-Project") == "(content_all:(Test\\-Project~) OR name:(Test\\-Project~)^10 OR slug:test\\-project^20)"
+    assert st.content_all("ab cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10)"
+    assert st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10)"

--- a/test/components/renku_data_services/search/test_solr_token.py
+++ b/test/components/renku_data_services/search/test_solr_token.py
@@ -130,8 +130,14 @@ def test_created_by_exists() -> None:
 
 
 def test_content_all() -> None:
-    assert st.content_all("abc") == "(content_all:(abc~) OR name:(abc~)^10 OR slug:abc^20)"
-    assert st.content_all("a+b+c") == "(content_all:(a\\+b\\+c~) OR name:(a\\+b\\+c~)^10 OR slug:a\\+b\\+c^20)"
-    assert st.content_all("Test-Project") == "(content_all:(Test\\-Project~) OR name:(Test\\-Project~)^10 OR slug:test\\-project^20)"
-    assert st.content_all("ab cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10)"
-    assert st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10)"
+    assert st.content_all("abc") == "(content_all:(abc~) OR name:(abc~)^10 OR nameKeyword:abc^30 OR slug:abc^20)"
+    assert (
+        st.content_all("a+b+c")
+        == "(content_all:(a\\+b\\+c~) OR name:(a\\+b\\+c~)^10 OR nameKeyword:a\\+b\\+c^30 OR slug:a\\+b\\+c^20)"
+    )
+    assert (
+        st.content_all("Test-Project")
+        == "(content_all:(Test\\-Project~) OR name:(Test\\-Project~)^10 OR nameKeyword:Test\\-Project^30 OR slug:test\\-project^20)"
+    )
+    assert st.content_all("ab cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ cd^30)"
+    assert st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ cd^30)"

--- a/test/components/renku_data_services/search/test_solr_token.py
+++ b/test/components/renku_data_services/search/test_solr_token.py
@@ -130,16 +130,16 @@ def test_created_by_exists() -> None:
 
 
 def test_content_all() -> None:
-    assert st.content_all("abc") == "(content_all:(abc~) OR name:(abc~)^10 OR nameKeyword:abc^30 OR slug:abc^20)"
+    assert st.content_all("abc") == "(content_all:(abc~) OR name:(abc~)^2 OR nameKeyword:abc^10 OR slug:abc^5)"
     assert (
         st.content_all("a+b+c")
-        == "(content_all:(a\\+b\\+c~) OR name:(a\\+b\\+c~)^10 OR nameKeyword:a\\+b\\+c^30 OR slug:a\\+b\\+c^20)"
+        == "(content_all:(a\\+b\\+c~) OR name:(a\\+b\\+c~)^2 OR nameKeyword:a\\+b\\+c^10 OR slug:a\\+b\\+c^5)"
     )
     assert (
-        st.content_all("Test-Project") == "(content_all:(Test\\-Project~) OR name:(Test\\-Project~)^10 OR "
-        "nameKeyword:Test\\-Project^30 OR slug:test\\-project^20)"
+        st.content_all("Test-Project") == "(content_all:(Test\\-Project~) OR name:(Test\\-Project~)^2 OR "
+        "nameKeyword:Test\\-Project^10 OR slug:test\\-project^5)"
     )
-    assert st.content_all("ab cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ cd^30)"
+    assert st.content_all("ab cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^2 OR nameKeyword:ab\\ cd^10)"
     assert (
-        st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ \\ \\ \\ cd^30)"
+        st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^2 OR nameKeyword:ab\\ \\ \\ \\ cd^10)"
     )

--- a/test/components/renku_data_services/search/test_solr_token.py
+++ b/test/components/renku_data_services/search/test_solr_token.py
@@ -136,8 +136,8 @@ def test_content_all() -> None:
         == "(content_all:(a\\+b\\+c~) OR name:(a\\+b\\+c~)^10 OR nameKeyword:a\\+b\\+c^30 OR slug:a\\+b\\+c^20)"
     )
     assert (
-        st.content_all("Test-Project")
-        == "(content_all:(Test\\-Project~) OR name:(Test\\-Project~)^10 OR nameKeyword:Test\\-Project^30 OR slug:test\\-project^20)"
+        st.content_all("Test-Project") == "(content_all:(Test\\-Project~) OR name:(Test\\-Project~)^10 OR "
+        "nameKeyword:Test\\-Project^30 OR slug:test\\-project^20)"
     )
     assert st.content_all("ab cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ cd^30)"
     assert st.content_all("ab    cd") == "(content_all:(ab~ cd~) OR name:(ab~ cd~)^10 OR nameKeyword:ab\\ cd^30)"


### PR DESCRIPTION
/deploy

This fixes the basic problem of:
- create a project with name "test-project"
- type `test-project` in the search 
- there will be no results

It is because the name is tokenized in a way that splits on `-`, `_` and other characters.

What this does is:
- adds a new field which retains the name unchanged - other than lowercased
- add a migration so the new field is there
- modify the query for solr so that some matches significantly boost the match score:
  - fuzzy match on the name
  - full match on the unchanged name
  - full match on the slug (which is also not tokenized)