### PR TITLE
feat: add session type to some metrics

### DIFF
--- a/bases/renku_data_services/data_tasks/task_defs.py
+++ b/bases/renku_data_services/data_tasks/task_defs.py
@@ -67,7 +67,6 @@ async def send_metrics_to_posthog(dm: DependencyManager) -> None:
 
             processed_ids = []
             async for metric in metrics:
-                logger.warning(f"metrics: {metric}")
                 try:
                     if metric.event == MetricsEvent.identify_user.value:
                         posthog.identify(

--- a/bases/renku_data_services/data_tasks/task_defs.py
+++ b/bases/renku_data_services/data_tasks/task_defs.py
@@ -67,6 +67,7 @@ async def send_metrics_to_posthog(dm: DependencyManager) -> None:
 
             processed_ids = []
             async for metric in metrics:
+                logger.warning(f"metrics: {metric}")
                 try:
                     if metric.event == MetricsEvent.identify_user.value:
                         posthog.identify(

--- a/components/renku_data_services/base_models/metrics.py
+++ b/components/renku_data_services/base_models/metrics.py
@@ -3,10 +3,13 @@
 from dataclasses import dataclass
 from enum import StrEnum
 from hashlib import sha1
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from renku_data_services.base_models.core import APIUser
 from renku_data_services.users.models import UserInfo
+
+if TYPE_CHECKING:
+    from renku_data_services.notebooks.models import LauncherType
 
 
 class MetricsEvent(StrEnum):
@@ -96,7 +99,11 @@ class MetricsService(Protocol):
         ...
 
     async def session_launcher_created(
-        self, user: APIUser, environment_kind: str, environment_image_source: str
+        self,
+        user: APIUser,
+        environment_kind: str,
+        environment_image_source: str,
+        session_type: "LauncherType",
     ) -> None:
         """Send session launcher created event to metrics."""
         ...

--- a/components/renku_data_services/k8s/models.py
+++ b/components/renku_data_services/k8s/models.py
@@ -405,6 +405,16 @@ class GVK:
             version=version,
         )
 
+    def __eq__(self, value: object) -> bool:
+        """Override equality to be case-insensitive."""
+        if not isinstance(value, GVK):
+            return False
+        return (
+            self.kind.casefold() == value.kind.casefold()
+            and self.version.casefold() == value.version.casefold()
+            and (self.group.casefold() if self.group else None) == (value.group.casefold() if value.group else None)
+        )
+
 
 @dataclass
 class APIObjectInCluster:

--- a/components/renku_data_services/k8s/models.py
+++ b/components/renku_data_services/k8s/models.py
@@ -415,6 +415,10 @@ class GVK:
             and (self.group.casefold() if self.group else None) == (value.group.casefold() if value.group else None)
         )
 
+    def __hash__(self) -> int:
+        """Override hash to be case-insensitive."""
+        return hash((self.kind.casefold(), self.version.casefold(), self.group.casefold() if self.group else None))
+
 
 @dataclass
 class APIObjectInCluster:

--- a/components/renku_data_services/k8s/watcher/core.py
+++ b/components/renku_data_services/k8s/watcher/core.py
@@ -226,6 +226,9 @@ async def __collect_session_metrics(
         await metrics.session_stopped(user=user, metadata={"session_id": new_obj.meta.name})
         return
     previous_state = previous_obj.manifest.get("status", {}).get("state", None) if previous_obj else None
+    logger.warning(
+        f"Matching statuses: state={new_obj.obj.raw.get("status", {}).get("state")}, previous_state={previous_state}"
+    )
     match new_obj.obj.raw.get("status", {}).get("state"):
         case State.Running.value if previous_state is None or previous_state == State.NotReady.value:
             # session starting

--- a/components/renku_data_services/k8s/watcher/core.py
+++ b/components/renku_data_services/k8s/watcher/core.py
@@ -193,6 +193,9 @@ async def collect_metrics(
 ) -> None:
     """Track product metrics."""
     # Dispatch metric collection by kind
+
+    logger.warning(f"Collecting: {new_obj.meta.gvk} {new_obj.meta.name}: {event_type}")
+
     match new_obj.meta.gvk:
         case gvk if gvk == AMALTHEA_SESSION_GVK:
             await __collect_session_metrics(

--- a/components/renku_data_services/k8s/watcher/core.py
+++ b/components/renku_data_services/k8s/watcher/core.py
@@ -193,9 +193,6 @@ async def collect_metrics(
 ) -> None:
     """Track product metrics."""
     # Dispatch metric collection by kind
-
-    logger.warning(f"Collecting: {new_obj.meta.gvk} {new_obj.meta.name}: {event_type}")
-
     match new_obj.meta.gvk:
         case gvk if gvk == AMALTHEA_SESSION_GVK:
             await __collect_session_metrics(
@@ -226,9 +223,6 @@ async def __collect_session_metrics(
         await metrics.session_stopped(user=user, metadata={"session_id": new_obj.meta.name})
         return
     previous_state = previous_obj.manifest.get("status", {}).get("state", None) if previous_obj else None
-    logger.warning(
-        f"Matching statuses: state={new_obj.obj.raw.get("status", {}).get("state")}, previous_state={previous_state}"
-    )
     match new_obj.obj.raw.get("status", {}).get("state"):
         case State.Running.value if previous_state is None or previous_state == State.NotReady.value:
             # session starting

--- a/components/renku_data_services/k8s/watcher/core.py
+++ b/components/renku_data_services/k8s/watcher/core.py
@@ -20,7 +20,9 @@ from renku_data_services.k8s.constants import DEFAULT_K8S_CLUSTER, ClusterId
 from renku_data_services.k8s.db import K8sDbCache
 from renku_data_services.k8s.models import GVK, APIObjectInCluster, K8sObject, K8sObjectFilter
 from renku_data_services.notebooks.constants import AMALTHEA_SESSION_GVK
+from renku_data_services.notebooks.cr_amalthea_session import SessionType as AmaltheaSessionType
 from renku_data_services.notebooks.crs import State
+from renku_data_services.notebooks.models import SessionType
 
 logger = logging.getLogger(__name__)
 
@@ -227,6 +229,12 @@ async def __collect_session_metrics(
             resource_class_id = int(new_obj.obj.metadata.annotations.get("renku.io/resource_class_id"))
             resource_pool = await rp_repo.get_resource_pool_from_class(k8s_watcher_admin_user, resource_class_id)
             resource_class = await rp_repo.get_resource_class(k8s_watcher_admin_user, resource_class_id)
+            session_type_raw: str | None = new_obj.obj.spec.get("sessionType")
+            session_type = (
+                SessionType.from_amalthea(AmaltheaSessionType.from_str(session_type_raw))
+                if session_type_raw
+                else SessionType.interactive
+            )
 
             await metrics.session_started(
                 user=user,
@@ -239,6 +247,7 @@ async def __collect_session_metrics(
                     "resource_pool_id": resource_pool.id or "",
                     "resource_class_name": f"{resource_pool.name}.{resource_class.name}",
                     "session_id": new_obj.meta.name,
+                    "session_type": session_type.value.lower(),
                 },
             )
         case State.Running.value | State.NotReady.value if previous_state == State.Hibernated.value:

--- a/components/renku_data_services/metrics/core.py
+++ b/components/renku_data_services/metrics/core.py
@@ -4,6 +4,7 @@ from renku_data_services.base_models.core import APIUser, AuthenticatedAPIUser
 from renku_data_services.base_models.metrics import MetricsEvent, MetricsMetadata, MetricsService, UserIdentity
 from renku_data_services.metrics.db import MetricsRepository
 from renku_data_services.metrics.utils import anonymize_user_id
+from renku_data_services.notebooks.models import LauncherType
 from renku_data_services.users.models import UserInfo
 
 
@@ -82,13 +83,21 @@ class StagingMetricsService(MetricsService):
         await self._store_event(MetricsEvent.session_stopped, user, metadata)
 
     async def session_launcher_created(
-        self, user: APIUser, environment_kind: str, environment_image_source: str
+        self,
+        user: APIUser,
+        environment_kind: str,
+        environment_image_source: str,
+        session_type: LauncherType,
     ) -> None:
         """Store session launcher created event in staging table."""
         await self._store_event(
             MetricsEvent.session_launcher_created,
             user,
-            {"environment_kind": environment_kind, "environment_image_source": environment_image_source},
+            {
+                "environment_kind": environment_kind,
+                "environment_image_source": environment_image_source,
+                "session_type": session_type.value.lower(),
+            },
         )
 
     async def project_created(self, user: APIUser, metadata: MetricsMetadata) -> None:

--- a/components/renku_data_services/notebooks/core_sessions.py
+++ b/components/renku_data_services/notebooks/core_sessions.py
@@ -1212,6 +1212,7 @@ async def start_session(
             "resource_pool_id": resource_pool.id or "",
             "resource_class_name": f"{resource_pool.name}.{resource_class.name}",
             "session_id": server_name,
+            "session_type": session_type.value.lower(),
         },
     )
     return session, True

--- a/components/renku_data_services/session/blueprints.py
+++ b/components/renku_data_services/session/blueprints.py
@@ -134,6 +134,7 @@ class SessionLaunchersBP(CustomBlueprint):
                 user,
                 environment_kind=launcher.environment.environment_kind.value,
                 environment_image_source=launcher.environment.environment_image_source.value,
+                session_type=launcher.launcher_type,
             )
             return validated_json(apispec.SessionLauncher, launcher, status=201)
 

--- a/test/bases/renku_data_services/data_api/test_metrics.py
+++ b/test/bases/renku_data_services/data_api/test_metrics.py
@@ -46,4 +46,8 @@ async def test_metrics_are_stored(sanic_metrics_client, app_manager, create_proj
     session_launcher_created = events[1]
     assert re.match(r"^[0-7][0-9A-HJKMNP-TV-Z]{25}$", str(session_launcher_created.id))
     assert session_launcher_created.event == "session_launcher_created"
-    assert session_launcher_created.metadata_ == {"environment_image_source": "image", "environment_kind": "CUSTOM"}
+    assert session_launcher_created.metadata_ == {
+        "environment_image_source": "image",
+        "environment_kind": "CUSTOM",
+        "session_type": "interactive",
+    }


### PR DESCRIPTION
Update session metrics to include a new `session_type` field used to differentiate interactive sessions and offline jobs.

Also, fixes a bug introduced in #1368 where session events were not sent because of case-sensitive matching with the `GVK` dataclass.

/deploy #notest renku-ui=main extra-values=posthog.enabled=true,posthog.apiKey=phc_7hCT82FJG1oPBUN43wDyU93uSyymE0Iwo2fW4qb02pa,posthog.environment=renku-ci-ds-1372,posthog.host=https://eu.i.posthog.com