### PR TITLE
Fix: reuse DB session in `get_resource_pool_users` to avoid connection-pool deadlock

### DIFF
--- a/components/renku_data_services/crc/db.py
+++ b/components/renku_data_services/crc/db.py
@@ -1053,6 +1053,7 @@ class MemberRepository(_Base):
         self.group_repo = group_repo
         self.project_repo = project_repo
 
+    @with_db_transaction
     @_only_admins
     async def get_resource_pool_users(
         self,
@@ -1060,70 +1061,73 @@ class MemberRepository(_Base):
         api_user: base_models.APIUser,
         resource_pool_id: int,
         keycloak_id: Optional[str] = None,
+        session: AsyncSession | None = None,
     ) -> Repository2Users:
         """Get users of a specific resource pool using Authzed as the source of truth."""
-        async with self.session_maker() as session:
-            rp = await session.scalar(
-                select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == resource_pool_id)
-            )
-            if rp is None:
-                raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} does not exist")
+        if session is None:
+            raise errors.ProgrammingError(message="A session must be set to query the database")
 
-            specific_user: base_models.User | None = None
-            if keycloak_id is not None:
-                specific_user_res = (
-                    await session.execute(select(schemas.UserORM).where(schemas.UserORM.keycloak_id == keycloak_id))
-                ).scalar_one_or_none()
-                specific_user = None if not specific_user_res else specific_user_res.dump()
+        rp = await session.scalar(select(schemas.ResourcePoolORM).where(schemas.ResourcePoolORM.id == resource_pool_id))
+        if rp is None:
+            raise errors.MissingResourceError(message=f"Resource pool with id {resource_pool_id} does not exist")
 
-            if rp.default:
-                # Default pools use the no_default_access flag; preserve this behaviour
-                # so that update_resource_pool_users can find disallowed users.
-                disallowed_stmt = select(schemas.UserORM).where(schemas.UserORM.no_default_access == true())
-                if keycloak_id:
-                    disallowed_stmt = disallowed_stmt.where(schemas.UserORM.keycloak_id == keycloak_id)
-                disallowed_res = await session.execute(disallowed_stmt)
-                disallowed = [user.dump() for user in disallowed_res.scalars().all()]
-                allowed: list[base_models.User] = []
-                if specific_user and specific_user not in disallowed:
-                    allowed = [specific_user]
-                return Repository2Users(rp.id, allowed, disallowed)
+        specific_user: base_models.User | None = None
+        if keycloak_id is not None:
+            specific_user_res = (
+                await session.execute(select(schemas.UserORM).where(schemas.UserORM.keycloak_id == keycloak_id))
+            ).scalar_one_or_none()
+            specific_user = None if not specific_user_res else specific_user_res.dump()
 
-            if rp.public and not rp.default:
-                allowed = []
-                if specific_user:
-                    allowed = [specific_user]
-                return Repository2Users(rp.id, allowed, [])
-
-            # Non-default, non-public pools: resolve from Authzed.
-            user_ids = await self.authz.users_with_permission(
-                api_user, ResourceType.resource_pool, resource_pool_id, Scope.READ
-            )
-
-            # Filter out platform admins; they have access via resource_pool_platform->is_admin
-            # but should not appear in the user list.
-            admin_ids = set(await self.authz._get_admin_user_ids())
-            user_ids = [uid for uid in user_ids if uid not in admin_ids]
-
+        if rp.default:
+            # Default pools use the no_default_access flag; preserve this behaviour
+            # so that update_resource_pool_users can find disallowed users.
+            disallowed_stmt = select(schemas.UserORM).where(schemas.UserORM.no_default_access == true())
             if keycloak_id:
-                if keycloak_id not in user_ids:
-                    return Repository2Users(resource_pool_id, allowed=[], disallowed=[])
-                user = await self.kc_user_repo.get_user(id=keycloak_id)
-                if user is None:
-                    raise errors.MissingResourceError(message=f"The user with id {keycloak_id} cannot be found.")
-                return Repository2Users(
-                    resource_pool_id,
-                    allowed=[base_models.User(keycloak_id=keycloak_id, no_default_access=False)],
-                    disallowed=[],
-                )
+                disallowed_stmt = disallowed_stmt.where(schemas.UserORM.keycloak_id == keycloak_id)
+            disallowed_res = await session.execute(disallowed_stmt)
+            disallowed = [user.dump() for user in disallowed_res.scalars().all()]
+            allowed: list[base_models.User] = []
+            if specific_user and specific_user not in disallowed:
+                allowed = [specific_user]
+            return Repository2Users(rp.id, allowed, disallowed)
 
+        if rp.public and not rp.default:
             allowed = []
-            for uid in user_ids:
-                user = await self.kc_user_repo.get_user(id=uid)
-                if user is not None:
-                    allowed.append(base_models.User(keycloak_id=user.id, no_default_access=False))
+            if specific_user:
+                allowed = [specific_user]
+            return Repository2Users(rp.id, allowed, [])
 
-            return Repository2Users(resource_pool_id, allowed=allowed, disallowed=[])
+        # Non-default, non-public pools: resolve from Authzed.
+        user_ids = await self.authz.users_with_permission(
+            api_user, ResourceType.resource_pool, resource_pool_id, Scope.READ
+        )
+
+        # Filter out platform admins; they have access via resource_pool_platform->is_admin
+        # but should not appear in the user list.
+        admin_ids = set(await self.authz._get_admin_user_ids())
+        user_ids = [uid for uid in user_ids if uid not in admin_ids]
+
+        if keycloak_id:
+            if keycloak_id not in user_ids:
+                return Repository2Users(resource_pool_id, allowed=[], disallowed=[])
+            user = await self.kc_user_repo.get_user(id=keycloak_id, session=session)
+            if user is None:
+                raise errors.MissingResourceError(message=f"The user with id {keycloak_id} cannot be found.")
+            return Repository2Users(
+                resource_pool_id,
+                allowed=[base_models.User(keycloak_id=keycloak_id, no_default_access=False)],
+                disallowed=[],
+            )
+
+        # Batch-check which Authz-returned users still exist locally, reusing the same session
+        # instead of opening a new DB session per user.
+        existing_users = await self.kc_user_repo.get_users_by_ids(user_ids, session=session)
+        existing_user_ids = {u.id for u in existing_users}
+        allowed = [
+            base_models.User(keycloak_id=uid, no_default_access=False) for uid in user_ids if uid in existing_user_ids
+        ]
+
+        return Repository2Users(resource_pool_id, allowed=allowed, disallowed=[])
 
     async def get_user_resource_pools(
         self,
@@ -1320,7 +1324,7 @@ class MemberRepository(_Base):
                 # NOTE: If the resource pool is default just check if any users are prevented from having
                 # default resource pool access - and remove the restriction.
                 all_existing_users = await self.get_resource_pool_users(
-                    api_user=api_user, resource_pool_id=resource_pool_id
+                    api_user=api_user, resource_pool_id=resource_pool_id, session=session
                 )
                 users_to_modify = [user for user in all_existing_users.disallowed if user.keycloak_id in user_ids]
                 re_allowed_ids = [u.keycloak_id for u in users_to_modify]

--- a/components/renku_data_services/users/db.py
+++ b/components/renku_data_services/users/db.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import secrets
 from abc import abstractmethod
-from collections.abc import AsyncGenerator, Callable, Mapping
+from collections.abc import AsyncGenerator, Callable, Collection, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, Protocol, cast
@@ -132,6 +132,21 @@ class UserRepo(DbUsernameResolver):
         if user.namespace is None:
             raise errors.ProgrammingError(message=f"Cannot find a user namespace for user {id}.")
         return user.namespace.dump_user()
+
+    @with_db_transaction
+    async def get_users_by_ids(self, ids: Collection[str], session: AsyncSession | None = None) -> list[UserInfo]:
+        """Get users by their keycloak IDs."""
+        if not session:
+            raise errors.ProgrammingError(message="A database session is required")
+
+        result = await session.scalars(select(UserORM).where(UserORM.keycloak_id.in_(ids)))
+        users = result.all()
+
+        for user in users:
+            if user.namespace is None:
+                raise errors.ProgrammingError(message=f"Cannot find a user namespace for user {user.keycloak_id}.")
+
+        return [user.dump() for user in users if user.namespace is not None]
 
     async def get_or_create_user(self, requested_by: APIUser, id: str) -> UserInfo | None:
         """Get a specific user from the database and create it potentially if it does not exist.

--- a/components/renku_data_services/users/db.py
+++ b/components/renku_data_services/users/db.py
@@ -120,16 +120,18 @@ class UserRepo(DbUsernameResolver):
         )
         return result.new
 
-    async def get_user(self, id: str) -> UserInfo | None:
+    @with_db_transaction
+    async def get_user(self, id: str, session: AsyncSession | None = None) -> UserInfo | None:
         """Get a specific user from the database."""
-        async with self.session_maker() as session:
-            result = await session.scalars(select(UserORM).where(UserORM.keycloak_id == id))
-            user = result.one_or_none()
-            if user is None:
-                return None
-            if user.namespace is None:
-                raise errors.ProgrammingError(message=f"Cannot find a user namespace for user {id}.")
-            return user.namespace.dump_user()
+        if not session:
+            raise errors.ProgrammingError(message="A database session is required")
+        result = await session.scalars(select(UserORM).where(UserORM.keycloak_id == id))
+        user = result.one_or_none()
+        if user is None:
+            return None
+        if user.namespace is None:
+            raise errors.ProgrammingError(message=f"Cannot find a user namespace for user {id}.")
+        return user.namespace.dump_user()
 
     async def get_or_create_user(self, requested_by: APIUser, id: str) -> UserInfo | None:
         """Get a specific user from the database and create it potentially if it does not exist.

--- a/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
+++ b/test/components/renku_data_services/db/test_sqlalchemy_pool_repo.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -898,6 +899,73 @@ async def test_resource_pool_insert_with_remote_grants_connected_users(
     finally:
         if inserted_rp is not None:
             await app_manager_instance.rp_repo.delete_resource_pool(admin_user, inserted_rp.id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
+async def test_get_resource_pool_users_reuses_session(
+    app_manager_instance: DependencyManager,
+    admin_user: base_models.APIUser,
+    cluster: KindCluster,
+) -> None:
+    """Check number of db sessions for `get_resource_pool_users`.
+    `get_resource_pool_users` must not open a separate DB session per user. Before the fix it
+    called `kc_user_repo.get_user` in a loop while already holding a session, which could exhaust
+    the connection pool and deadlock. After the fix it should issue a single batched query on the
+    same session and never call `kc_user_repo.get_user` for the list branch.
+    """
+    run_migrations_for_app("common")
+    member_repo = app_manager_instance.member_repo
+    pool_repo = app_manager_instance.rp_repo
+    kc_user_repo = app_manager_instance.kc_user_repo
+
+    await kc_user_repo._add_api_user(admin_user)
+
+    rp = models.UnsavedResourcePool(
+        name="test-reuse-session-pool",
+        classes=[],
+        quota=models.UnsavedQuota(cpu=10.0, memory=100, gpu=0),
+        public=False,
+        default=False,
+        platform=models.RuntimePlatform.linux_amd64,
+    )
+    inserted_rp = await create_rp(rp, pool_repo, admin_user)
+
+    # Grant the calling admin platform-wide admin access so they can read resource pool permissions.
+    admin_change = app_manager_instance.authz._add_admin(admin_user.id)
+    await app_manager_instance.authz.client.WriteRelationships(admin_change.apply)
+
+    user_id_1 = "pool-user-1"
+    user_id_2 = "pool-user-2"
+    await kc_user_repo._add_api_user(APIUser(id=user_id_1, full_name="User One"))
+    await kc_user_repo._add_api_user(APIUser(id=user_id_2, full_name="User Two"))
+
+    await member_repo.grant_resource_pool_members(
+        admin_user,
+        inserted_rp.id,
+        [
+            models.ResourcePoolMemberIdentifier(member_type=models.MemberType.USER, member_id=user_id_1),
+            models.ResourcePoolMemberIdentifier(member_type=models.MemberType.USER, member_id=user_id_2),
+        ],
+    )
+
+    original_get_user = kc_user_repo.get_user
+    calls: list[tuple[Any, dict[str, Any]]] = []
+
+    async def tracking_get_user(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        return await original_get_user(*args, **kwargs)
+
+    kc_user_repo.get_user = tracking_get_user
+
+    try:
+        res = await member_repo.get_resource_pool_users(api_user=admin_user, resource_pool_id=inserted_rp.id)
+    finally:
+        kc_user_repo.get_user = original_get_user
+
+    allowed_ids = {u.keycloak_id for u in res.allowed}
+    assert allowed_ids == {user_id_1, user_id_2}
+    assert len(calls) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`GET /resource_pools/{resource_pool_id}/users` could exhaust the SQLAlchemy connection pool and deadlock.

`get_resource_pool_users()` opened a DB session and then, while still holding that session, called `kc_user_repo.get_user()` once per user. Each `get_user()` call opened a *new* DB session. If the pool was already at its limit, every request thread waited for an additional connection that could never be released, causing:

```
TimeoutError: QueuePool limit of size 10 overflow 0 reached, connection timed out, timeout 30.00
```

## Changes

- Wrapped `MemberRepository.get_resource_pool_users()` with `@with_db_transaction` so the method can reuse a single session.
- Added a `session` parameter to `UserRepo.get_user()` and decorated it with `@with_db_transaction`.
- Added `UserRepo.get_users_by_ids()` to fetch multiple users in a single batched query on the same session.
- Replaced the per-user `kc_user_repo.get_user(id=uid)` loop with a single call to `kc_user_repo.get_users_by_ids(user_ids, session=session)`.
- Updated `update_resource_pool_users()` to pass its own session to `get_resource_pool_users()`.
- Added a regression test verifying that listing resource-pool users does not issue per-user `get_user()` calls.

## Result

The endpoint now resolves all user data on the same DB session, eliminating the nested-session pattern that starved the connection pool.

fixes #1373

/deploy