### PR TITLE
fix: generate one service account per build run

### DIFF
--- a/components/renku_data_services/session/k8s_client.py
+++ b/components/renku_data_services/session/k8s_client.py
@@ -235,6 +235,7 @@ class ShipwrightClient:
                     )
                 ),
                 retention=retention,
+                serviceAccount=".generate",
             ),
         )
 


### PR DESCRIPTION
See: https://shipwright.io/docs/build/buildrun#defining-the-serviceaccount

Generate one service account per build run so that we fully isolate docker push credentials.

/deploy #notest extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user,dataService.imageBuilders.privateRepositoryBuilds.enabled=true