### PR TITLE
chore: make sure tests can run in parallel

### DIFF
--- a/test/bases/renku_data_services/data_api/test_connected_services.py
+++ b/test/bases/renku_data_services/data_api/test_connected_services.py
@@ -643,6 +643,7 @@ async def test_get_token_with_internal_token(
 # --- Integration Group Connected Services API Tests (E1-E2) ---
 
 
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 @pytest.mark.asyncio
 async def test_oauth_callback_adds_user_to_rp(
     oauth2_test_client: SanicASGITestClient,
@@ -714,6 +715,7 @@ async def test_oauth_callback_adds_user_to_rp(
     assert res.status_code == 204
 
 
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 @pytest.mark.asyncio
 async def test_delete_oauth_connection_removes_rp_access(
     oauth2_test_client: SanicASGITestClient,

--- a/test/bases/renku_data_services/data_api/test_resource_pools.py
+++ b/test/bases/renku_data_services/data_api/test_resource_pools.py
@@ -1867,6 +1867,8 @@ async def test_resource_pools_quota_with_no_usage(
     assert resource_class["usage_hours_total"] == 4.0
 
 
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_resource_pool_members_add_group(
     sanic_client: SanicASGITestClient,
     admin_headers: dict[str, str],
@@ -2011,6 +2013,8 @@ async def test_resource_pools_quota_exceeded(
     assert resource_class["usage_hours_total"] == 2.0
 
 
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_resource_pool_members_add_project(
     sanic_client: SanicASGITestClient,
     admin_headers: dict[str, str],
@@ -2147,6 +2151,8 @@ async def test_resource_pools_quota_with_no_limits(
     assert "usage_hours_total" not in resource_class
 
 
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_resource_pool_members_put_replaces(
     sanic_client: SanicASGITestClient,
     admin_headers: dict[str, str],
@@ -2273,6 +2279,8 @@ async def test_resource_pools_quota_with_no_costs(
     assert "usage_hours_total" not in resource_class
 
 
+@pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_resource_pool_members_delete(
     sanic_client: SanicASGITestClient,
     admin_headers: dict[str, str],

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -253,6 +253,7 @@ async def test_patch_session_environment(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_patch_session_environment_archived(
     sanic_client: SanicASGITestClient,
     admin_headers,
@@ -597,6 +598,7 @@ async def test_post_launcher_invalid_launcher_type(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_post_session_launcher_with_environment_build(
     app_manager: DependencyManager,
     sanic_client,
@@ -693,6 +695,7 @@ async def test_post_session_launcher_with_environment_build(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_post_job_launcher_with_environment_build(
     app_manager: DependencyManager,
     sanic_client,
@@ -795,6 +798,7 @@ async def test_post_job_launcher_with_environment_build(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_post_session_launcher_with_advanced_environment_build(
     app_manager: DependencyManager,
     sanic_client: SanicASGITestClient,
@@ -925,6 +929,7 @@ async def test_delete_session_launcher(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_patch_session_launcher(
     sanic_client: SanicASGITestClient,
     valid_resource_pool_payload: dict[str, Any],
@@ -1136,6 +1141,7 @@ async def test_patch_session_launcher_environment(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_patch_session_launcher_from_code_update_command(
     sanic_client: SanicASGITestClient,
     user_headers,
@@ -1189,6 +1195,7 @@ async def test_patch_session_launcher_from_code_update_command(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_patch_session_launcher_environment_with_build_parameters(
     sanic_client: SanicASGITestClient,
     user_headers,
@@ -1380,6 +1387,7 @@ async def test_patch_session_launcher_environment_with_invalid_build_parameters(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_patch_session_launcher_invalid_env_variables(
     sanic_client: SanicASGITestClient,
     valid_resource_pool_payload: dict[str, Any],
@@ -1521,6 +1529,7 @@ async def test_patch_session_launcher_keeps_unset_values(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_patch_session_launcher_with_advanced_environment_build(
     sanic_client: SanicASGITestClient,
     user_headers: dict[str, str],

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -293,6 +293,7 @@ async def test_oauth_connect_adds_user_to_rp(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_oauth_disconnect_removes_user_from_rp(
     app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
 ) -> None:
@@ -380,6 +381,7 @@ async def test_oauth_connect_with_no_matching_rp_does_nothing(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_two_users_connect_same_integration_both_get_access(
     app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
 ) -> None:
@@ -491,6 +493,7 @@ async def test_user_disconnect_only_affects_their_rp_access(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")  # Needs to run on the same worker as the rest of the sessions tests
 async def test_delete_connection_revokes_rp_access(
     app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
 ) -> None:


### PR DESCRIPTION
Some tests have to be limited to run in series. This includes anything that needs a kind cluster. when they are not added to the group that indicates that this is the case running the tests locally with multiple workers will fail.