### PR TITLE
fix: flaky test failing with 403

### DIFF
--- a/components/renku_data_services/db_config/config.py
+++ b/components/renku_data_services/db_config/config.py
@@ -3,7 +3,7 @@
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
@@ -54,14 +54,27 @@ class DBConfig:
 
     @property
     def async_session_maker(self) -> Callable[..., AsyncSession]:
-        """The asynchronous DB engine."""
-        if not DBConfig._async_engine:
-            DBConfig._async_engine = create_async_engine(
-                self.conn_url(),
-                pool_size=self.pool_size,
-                max_overflow=0,
-            )
-        return async_sessionmaker(DBConfig._async_engine, expire_on_commit=False)
+        """A callable that opens a new async DB session bound to the current engine.
+
+        The engine is resolved lazily on every call rather than being bound when this
+        property is read. This means callers that capture the returned callable (e.g. the
+        repositories built once at app-construction time) always talk to whatever engine is
+        current: disposing the engine via ``dispose_connection`` and pointing ``self`` at a
+        different database (as the test suite does per test) is picked up transparently,
+        without rebuilding those callers.
+        """
+        db = self
+
+        def make_session(*args: Any, **kwargs: Any) -> AsyncSession:
+            if DBConfig._async_engine is None:
+                DBConfig._async_engine = create_async_engine(
+                    db.conn_url(),
+                    pool_size=db.pool_size,
+                    max_overflow=0,
+                )
+            return async_sessionmaker(DBConfig._async_engine, expire_on_commit=False)(*args, **kwargs)
+
+        return make_session
 
     @staticmethod
     async def dispose_connection() -> None:

--- a/test/bases/renku_data_services/data_api/test_migrations.py
+++ b/test/bases/renku_data_services/data_api/test_migrations.py
@@ -68,7 +68,7 @@ async def test_upgrade_downgrade_cycle(
     # NOTE: The engine has to be disposed otherwise it caches the postgres types (i.e. enums)
     # from previous migrations and then trying to create a project below fails with the message
     # cache postgres lookup failed for type XXXX.
-    await app_manager_instance.config.db.current._async_engine.dispose()
+    await app_manager_instance.config.db.dispose_connection()
     await app_manager_instance.kc_user_repo.initialize(app_manager_instance.kc_api)
     await app_manager_instance.group_repo.generate_user_namespaces()
     _, res = await sanic_client_no_migrations.post("/api/data/projects", headers=admin_headers, json=payload)

--- a/test/bases/renku_data_services/data_api/test_secret.py
+++ b/test/bases/renku_data_services/data_api/test_secret.py
@@ -1,17 +1,24 @@
 """Tests for secrets blueprints."""
 
+import os
+import secrets
 import time
 from base64 import b64decode
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
 import pytest
+import pytest_asyncio
 from cryptography.hazmat.primitives.asymmetric import rsa
+from pytest_postgresql.janitor import DatabaseJanitor
 from sanic_testing.testing import SanicASGITestClient
 from ulid import ULID
 
 from renku_data_services.base_models.core import InternalServiceAdmin, ServiceAdminId
+from renku_data_services.db_config.config import DBConfig
 from renku_data_services.k8s.constants import DEFAULT_K8S_CLUSTER
 from renku_data_services.k8s.models import GVK, K8sObjectMeta, K8sSecret
 from renku_data_services.secrets.models import Secret, SecretKind
@@ -26,6 +33,46 @@ from renku_data_services.utils.cryptography import (
     generate_random_encryption_key,
 )
 from test.utils import KindCluster
+
+
+@pytest_asyncio.fixture
+async def db_config(monkeypatch, worker_id, authz_setup) -> AsyncGenerator[DBConfig, None]:
+    db_name = "R_" + str(ULID()).lower() + "_" + worker_id
+    user = os.getenv("DB_USER", "renku")
+    host = os.getenv("DB_HOST", "127.0.0.1")
+    port = os.getenv("DB_PORT", "5432")
+    password = os.getenv("DB_PASSWORD", "renku")  # nosec: B105
+
+    monkeypatch.setenv("DUMMY_STORES", "true")
+    monkeypatch.setenv("DB_NAME", db_name)
+    with DatabaseJanitor(
+        user=user,
+        host=host,
+        port=port,
+        dbname=db_name,
+        version="16.2",
+        password=password,
+        template_dbname="renku_template",
+    ):
+        yield DBConfig.from_env()
+        await DBConfig.dispose_connection()
+
+
+@pytest_asyncio.fixture
+async def secrets_storage_app_manager(
+    db_config: DBConfig, secrets_key_pair, monkeypatch, tmp_path, kubeconfig_path: Path
+) -> AsyncGenerator[SecretsDependencyManager, None]:
+    encryption_key_path = tmp_path / "encryption-key"
+    encryption_key_path.write_bytes(secrets.token_bytes(32))
+
+    monkeypatch.setenv("ENCRYPTION_KEY_PATH", encryption_key_path.as_posix())
+    monkeypatch.setenv("DUMMY_STORES", "true")
+    monkeypatch.setenv("DB_NAME", db_config.db_name)
+    monkeypatch.setenv("MAX_PINNED_PROJECTS", "5")
+    monkeypatch.setenv("K8S_CONFIGS_ROOT", kubeconfig_path.parent.absolute().as_posix())
+
+    dm = SecretsDependencyManager.from_env()
+    yield dm
 
 
 @pytest.fixture

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -881,8 +881,8 @@ async def test_post_session_launcher_with_advanced_environment_build(
         assert error.get("message") == "no_git_repo"
 
 
-@pytest.mark.xdist_group("sessions")
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_post_session_launcher_unauthorized(
     sanic_client: SanicASGITestClient,
     valid_resource_pool_payload: dict[str, Any],

--- a/test/bases/renku_data_services/data_api/test_sessions.py
+++ b/test/bases/renku_data_services/data_api/test_sessions.py
@@ -881,6 +881,7 @@ async def test_post_session_launcher_with_advanced_environment_build(
         assert error.get("message") == "no_git_repo"
 
 
+@pytest.mark.xdist_group("sessions")
 @pytest.mark.asyncio
 async def test_post_session_launcher_unauthorized(
     sanic_client: SanicASGITestClient,
@@ -988,6 +989,7 @@ async def test_patch_session_launcher(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_patch_session_launcher_environment(
     sanic_client: SanicASGITestClient,
     valid_resource_pool_payload: dict[str, Any],
@@ -1433,6 +1435,7 @@ async def test_patch_session_launcher_invalid_env_variables(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_patch_session_launcher_reset_fields(
     sanic_client: SanicASGITestClient,
     valid_resource_pool_payload: dict[str, Any],
@@ -1485,6 +1488,7 @@ async def test_patch_session_launcher_reset_fields(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_patch_session_launcher_keeps_unset_values(
     sanic_client,
     user_headers,

--- a/test/components/renku_data_services/connected_services/test_db.py
+++ b/test/components/renku_data_services/connected_services/test_db.py
@@ -242,6 +242,7 @@ async def test_get_provider_for_image_unsupported_provider(app_manager_instance)
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_oauth_connect_adds_user_to_rp(
     app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
 ) -> None:
@@ -436,6 +437,7 @@ async def test_two_users_connect_same_integration_both_get_access(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("sessions")
 async def test_user_disconnect_only_affects_their_rp_access(
     app_manager_instance: DependencyManager, admin_user: APIUser, cluster: any
 ) -> None:

--- a/test/components/renku_data_services/k8s/test_k8s_adapter.py
+++ b/test/components/renku_data_services/k8s/test_k8s_adapter.py
@@ -75,6 +75,7 @@ async def test_delete_quota(quota: models.UnsavedQuota, quota_repo: QuotaReposit
     assert no_quota is None
 
 
+@settings(deadline=None, max_examples=5)
 @given(old_quota=quota_strat_w_id, new_quota=quota_strat)
 @pytest.mark.xdist_group("sessions")
 async def test_update_quota(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import os
-import secrets
 import socket
 import stat
 import subprocess
@@ -30,7 +29,6 @@ from renku_data_services.authz.config import AuthzConfig
 from renku_data_services.data_api.dependencies import DependencyManager
 from renku_data_services.data_connectors.doi.models import DOIMetadata, SchemaOrgDataset
 from renku_data_services.db_config.config import DBConfig
-from renku_data_services.secrets_storage_api.dependencies import DependencyManager as SecretsDependencyManager
 from renku_data_services.session import constants
 from renku_data_services.solr import entity_schema
 from renku_data_services.solr.solr_client import SolrClientConfig
@@ -124,29 +122,6 @@ async def authz_setup(monkeysession) -> AsyncGenerator[None, None]:
 
 
 @pytest_asyncio.fixture
-async def db_config(monkeypatch, worker_id, authz_setup) -> AsyncGenerator[DBConfig, None]:
-    db_name = "R_" + str(ULID()).lower() + "_" + worker_id
-    user = os.getenv("DB_USER", "renku")
-    host = os.getenv("DB_HOST", "127.0.0.1")
-    port = os.getenv("DB_PORT", "5432")
-    password = os.getenv("DB_PASSWORD", "renku")  # nosec: B105
-
-    monkeypatch.setenv("DUMMY_STORES", "true")
-    monkeypatch.setenv("DB_NAME", db_name)
-    with DatabaseJanitor(
-        user=user,
-        host=host,
-        port=port,
-        dbname=db_name,
-        version="16.2",
-        password=password,
-        template_dbname="renku_template",
-    ):
-        yield DBConfig.from_env()
-        await DBConfig.dispose_connection()
-
-
-@pytest_asyncio.fixture
 async def db_instance(monkeysession, worker_id, app_manager, event_loop) -> AsyncGenerator[DBConfig, None]:
     db_name = "R_" + str(ULID()).lower() + "_" + worker_id
     user = os.getenv("DB_USER", "renku")
@@ -182,7 +157,7 @@ async def db_instance(monkeysession, worker_id, app_manager, event_loop) -> Asyn
 @pytest_asyncio.fixture
 async def authz_instance(app_manager: TestDependencyManager, monkeypatch) -> AsyncGenerator[AuthzConfig]:
     monkeypatch.setenv("AUTHZ_DB_KEY", f"renku-{uuid4().hex}")
-    # As with the database, the app holds a single AuthzConfig for the whole session. Mutate its
+    # As with the database above, the app holds a single AuthzConfig for the whole session. Mutate its
     # key in place so the (non-caching) authz clients used by the repositories pick up this
     # test's key; restore the previous key on teardown.
     authz_config = app_manager.config.authz_config
@@ -273,23 +248,6 @@ async def app_manager(
 async def app_manager_instance(app_manager, db_instance, authz_instance) -> AsyncGenerator[DependencyManager, None]:
     app_manager.metrics.reset_mock()
     yield app_manager
-
-
-@pytest_asyncio.fixture
-async def secrets_storage_app_manager(
-    db_config: DBConfig, secrets_key_pair, monkeypatch, tmp_path, kubeconfig_path: Path
-) -> AsyncGenerator[SecretsDependencyManager, None]:
-    encryption_key_path = tmp_path / "encryption-key"
-    encryption_key_path.write_bytes(secrets.token_bytes(32))
-
-    monkeypatch.setenv("ENCRYPTION_KEY_PATH", encryption_key_path.as_posix())
-    monkeypatch.setenv("DUMMY_STORES", "true")
-    monkeypatch.setenv("DB_NAME", db_config.db_name)
-    monkeypatch.setenv("MAX_PINNED_PROJECTS", "5")
-    monkeypatch.setenv("K8S_CONFIGS_ROOT", kubeconfig_path.parent.absolute().as_posix())
-
-    dm = SecretsDependencyManager.from_env()
-    yield dm
 
 
 @pytest_asyncio.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -165,18 +165,31 @@ async def db_instance(monkeysession, worker_id, app_manager, event_loop) -> Asyn
         password=password,
         template_dbname="renku_template",
     ):
-        db = DBConfig.from_env()
-        app_manager.config.db.push(db)
+        # The app (and every repository it built) is constructed once per session and holds a
+        # single, long-lived DBConfig. Point that instance at this test's fresh database in
+        # place rather than swapping the object, so the session factory captured by the
+        # repositories sees the change. Disposing the connection clears the cached engine so the
+        # next session is opened against this database; we restore and dispose again on teardown.
+        db = app_manager.config.db
+        previous_db_name = db.db_name
+        db.db_name = db_name
+        await DBConfig.dispose_connection()
         yield db
-        await app_manager.config.db.pop()
+        db.db_name = previous_db_name
+        await DBConfig.dispose_connection()
 
 
 @pytest_asyncio.fixture
 async def authz_instance(app_manager: TestDependencyManager, monkeypatch) -> AsyncGenerator[AuthzConfig]:
     monkeypatch.setenv("AUTHZ_DB_KEY", f"renku-{uuid4().hex}")
-    app_manager.config.authz_config.push(AuthzConfig.from_env())
-    yield app_manager.config.authz_config
-    app_manager.config.authz_config.pop()
+    # As with the database, the app holds a single AuthzConfig for the whole session. Mutate its
+    # key in place so the (non-caching) authz clients used by the repositories pick up this
+    # test's key; restore the previous key on teardown.
+    authz_config = app_manager.config.authz_config
+    previous_key = authz_config.key
+    authz_config.key = AuthzConfig.from_env().key
+    yield authz_config
+    authz_config.key = previous_key
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/test/utils.py
+++ b/test/utils.py
@@ -5,22 +5,20 @@ import json
 import os
 import subprocess
 import typing
-from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Self
+from typing import Any
 from unittest.mock import MagicMock
 
 import yaml
-from authzed.api.v1 import AsyncClient, SyncClient
+from authzed.api.v1 import AsyncClient
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 from kubernetes import watch
 from kubernetes.client import V1ObjectMeta
 from sanic import Request
 from sanic_testing.testing import ASGI_HOST, ASGI_PORT, SanicASGITestClient, TestingResponse
-from sqlalchemy.ext.asyncio import AsyncSession
 
 import renku_data_services.base_models as base_models
 from renku_data_services.authn.api.core import ScopeVerifier
@@ -82,107 +80,6 @@ from renku_data_services.users.db import UserPreferencesRepository
 from renku_data_services.users.db import UserRepo as KcUserRepo
 from renku_data_services.users.dummy_kc_api import DummyKeycloakAPI
 from renku_data_services.users.kc_api import IKeycloakAPI
-
-
-class StackSessionMaker:
-    def __init__(self, parent: DBConfigStack) -> None:
-        self.parent = parent
-
-    def __call__(self, *args: Any, **kwargs: Any) -> AsyncSession:
-        return self.parent.current.async_session_maker()
-
-
-class DBConfigStack:
-    stack: list[DBConfig] = list()
-
-    @property
-    def current(self) -> DBConfig:
-        return self.stack[-1]
-
-    @property
-    def password(self) -> str:
-        return self.current.password
-
-    @property
-    def host(self) -> str:
-        return self.current.host
-
-    @property
-    def user(self) -> str:
-        return self.current.user
-
-    @property
-    def port(self) -> str:
-        return self.current.port
-
-    @property
-    def db_name(self) -> str:
-        return self.current.db_name
-
-    def conn_url(self, async_client: bool = True) -> str:
-        return self.current.conn_url(async_client)
-
-    @property
-    def async_session_maker(self) -> Callable[..., AsyncSession]:
-        return StackSessionMaker(self)
-
-    @classmethod
-    def from_env(cls) -> Self:
-        db = DBConfig.from_env()
-        this = cls()
-        this.push(db)
-        return this
-
-    def push(self, config: DBConfig) -> None:
-        self.stack.append(config)
-
-    async def pop(self) -> DBConfig:
-        config = self.stack.pop()
-        await DBConfig.dispose_connection()
-        return config
-
-
-class AuthzConfigStack:
-    stack: list[AuthzConfig] = list()
-
-    @property
-    def host(self) -> str:
-        return self.current.host
-
-    @property
-    def grpc_port(self) -> int:
-        return self.current.grpc_port
-
-    @property
-    def key(self) -> str:
-        return self.current.key
-
-    @property
-    def no_tls_connection(self) -> bool:
-        return self.current.no_tls_connection
-
-    @property
-    def current(self) -> AuthzConfig:
-        return self.stack[-1]
-
-    @classmethod
-    def from_env(cls) -> Self:
-        config = AuthzConfig.from_env()
-        this = cls()
-        this.push(config)
-        return this
-
-    def authz_client(self) -> SyncClient:
-        return self.current.authz_client()
-
-    def authz_async_client(self) -> AsyncClient:
-        return self.current.authz_async_client()
-
-    def push(self, config: AuthzConfig):
-        self.stack.append(config)
-
-    def pop(self) -> AuthzConfig:
-        return self.stack.pop()
 
 
 @dataclass
@@ -256,13 +153,13 @@ class TestDependencyManager(DependencyManager):
         cls, dummy_users: list[user_preferences_models.UnsavedUserInfo], prefix: str = ""
     ) -> DependencyManager:
         """Create a config from environment variables."""
-        db = DBConfigStack.from_env()
+        db = DBConfig.from_env()
         config = Config.from_env(db)
         user_store: base_models.UserStore
         authenticator: base_models.Authenticator
         gitlab_authenticator: base_models.Authenticator
         gitlab_client: base_models.GitlabAPIProtocol
-        config.authz_config = AuthzConfigStack.from_env()
+        config.authz_config = AuthzConfig.from_env()
         nb_authz = NonCachingAuthz(config.authz_config)
         # Monkey patching authz to non caching authz in rp_repo.
         config.nb_config.k8s_v2_client._NotebookK8sClient__rp_repo.authz = nb_authz


### PR DESCRIPTION
/deploy 

We have failures in 2-3 tests sometimes like this:

```
=================================== FAILURES ===================================
_____________ test_post_data_connector_project_link_already_exists _____________
[gw1] linux -- Python 3.13.14 /poetry_cache/virtualenvs/renku-data-services-xS3fZVNL-py3.13/bin/python
sanic_client = <test.utils.SanicReusableASGITestClient object at 0x7f7e38b31a90>
create_data_connector = <function create_data_connector.<locals>.create_data_connector_helper at 0x7f7e3429ed40>
create_project = <function create_project.<locals>.create_project_helper at 0x7f7e2e25e660>
user_headers = {'Authorization': '***"is_admin": false, "id": "user", "name": "User Doe", "first_name": "User", "last_name": "Doe", "email": "user.doe@gmail.com", "full_name": "User Doe"}'}
    @pytest.mark.asyncio
    async def test_post_data_connector_project_link_already_exists(
        sanic_client: SanicASGITestClient, create_data_connector, create_project, user_headers
    ) -> None:
>       data_connector = await create_data_connector("Data connector 1")
test/bases/renku_data_services/data_api/test_data_connectors.py:1132:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
name = 'Data connector 1'
user = UserInfo(id='user', first_name='User', last_name='Doe', email='user.doe@gmail.com', namespace=UserNamespace(id=ULID(01...r'>, created_by='user', path=user.doe, underlying_resource_id='user', latest_slug=None, name=None, creation_date=None))
headers = {'Authorization': '***"is_admin": false, "id": "user", "name": "User Doe", "first_name": "User", "last_name": "Doe", "email": "user.doe@gmail.com", "full_name": "User Doe"}'}
payload = {}
dc_payload = {'description': 'A data connector', 'keywords': ['keyword 1', 'keyword.2', 'keyword-3', 'KEYWORD_4'], 'name': 'Data connector 1', 'namespace': 'user.doe', ...}
_ = <Request: POST /api/data/data_connectors>
response = <Response [403 Forbidden]>, @py_assert1 = 403, @py_assert4 = 201
@py_assert3 = False
@py_format6 = '403\n{403 = <Response [403 Forbidden]>.status_code\n} == 201'
    async def create_data_connector_helper(
        name: str, user: UserInfo | None = None, headers: dict[str, str] | None = None, **payload
    ) -> dict[str, Any]:
        user = user or regular_user
        headers = headers or user_headers
        dc_payload = {
            "name": name,
            "description": "A data connector",
            "visibility": "private",
            "namespace": user.namespace.path.serialize(),
            "storage": {
                "configuration": {
                    "type": "s3",
                    "provider": "AWS",
                    "region": "us-east-1",
                },
                "source_path": "bucket/my-folder",
                "target_path": "my/target",
            },
            "keywords": ["keyword 1", "keyword.2", "keyword-3", "KEYWORD_4"],
        }
        dc_payload.update(payload)

        _, response = await sanic_client.post("/api/data/data_connectors", headers=headers, json=dc_payload)

>       assert response.status_code == 201, response.text
E       AssertionError: {"error":{"code":1403,"message":"The data connector cannot be created because you do not have sufficient permissions with the namespace user.doe"}}
E       assert 403 == 201
E        +  where 403 = <Response [403 Forbidden]>.status_code
test/bases/renku_data_services/data_api/conftest.py:633: AssertionError
---------------------------- Captured stderr setup -----------------------------
```

This occurs randomly and I cannot generate it locally. But in the CI tests it occurs often - sometimes requiring tests to rerun multiple times.