### PR TITLE
fix: streamline rclone configuration handling

### DIFF
--- a/bases/renku_data_services/data_api/main.py
+++ b/bases/renku_data_services/data_api/main.py
@@ -30,7 +30,7 @@ from renku_data_services.errors.errors import (
 from renku_data_services.migrations.core import run_migrations_for_app
 from renku_data_services.search.reprovision import SearchReprovision
 from renku_data_services.solr.solr_migrate import SchemaMigrator
-from renku_data_services.storage.rclone import RCloneValidator
+from renku_data_services.storage.rclone import RCloneValidator, RenkuRCloneValidator
 from renku_data_services.utils.middleware import validate_null_byte
 
 if TYPE_CHECKING:
@@ -178,6 +178,8 @@ def create_app() -> Sanic:
     async def setup_rclone_validator(app: Sanic) -> None:
         validator = RCloneValidator()
         app.ext.dependency(validator)
+        renku_validator = RenkuRCloneValidator()
+        app.ext.dependency(renku_validator)
 
     @app.after_server_start
     async def ready(app: Sanic) -> None:

--- a/components/renku_data_services/data_connectors/blueprints.py
+++ b/components/renku_data_services/data_connectors/blueprints.py
@@ -56,7 +56,7 @@ from renku_data_services.data_connectors.deposits.zenodo import ZenodoAPIClient
 from renku_data_services.k8s.client_interfaces import K8sClient, SecretClient
 from renku_data_services.k8s.clients import DepositUploadJobClient
 from renku_data_services.notebooks.data_sources import DataSourceRepository
-from renku_data_services.storage.rclone import RCloneValidator
+from renku_data_services.storage.rclone import RenkuRCloneValidator
 
 
 @dataclass(kw_only=True)
@@ -89,7 +89,7 @@ class DataConnectorsBP(CustomBlueprint):
             user: base_models.APIUser,
             pagination: PaginationRequest,
             query: apispec.DataConnectorsGetQuery,
-            validator: RCloneValidator,
+            validator: RenkuRCloneValidator,
         ) -> tuple[list[dict[str, Any]], int]:
             ns_segments = query.namespace.split("/")
             ns: None | NamespacePath | ProjectPath
@@ -125,7 +125,7 @@ class DataConnectorsBP(CustomBlueprint):
         @only_authenticated
         @validate(json=apispec.DataConnectorPost)
         async def _post(
-            _: Request, user: base_models.APIUser, body: apispec.DataConnectorPost, validator: RCloneValidator
+            _: Request, user: base_models.APIUser, body: apispec.DataConnectorPost, validator: RenkuRCloneValidator
         ) -> JSONResponse:
             data_connector = await validate_unsaved_data_connector(body, validator=validator)
             result = await self.data_connector_repo.insert_namespaced_data_connector(
@@ -147,7 +147,10 @@ class DataConnectorsBP(CustomBlueprint):
         @only_authenticated
         @validate(json=apispec.GlobalDataConnectorPost)
         async def _post_global(
-            _: Request, user: base_models.APIUser, body: apispec.GlobalDataConnectorPost, validator: RCloneValidator
+            _: Request,
+            user: base_models.APIUser,
+            body: apispec.GlobalDataConnectorPost,
+            validator: RenkuRCloneValidator,
         ) -> JSONResponse:
             data_connector = await prevalidate_unsaved_global_data_connector(body, validator=validator)
             result, inserted = await self.data_connector_repo.insert_global_data_connector(
@@ -167,7 +170,11 @@ class DataConnectorsBP(CustomBlueprint):
         @authenticate(self.authenticator)
         @extract_if_none_match
         async def _get_one(
-            _: Request, user: base_models.APIUser, data_connector_id: ULID, etag: str | None, validator: RCloneValidator
+            _: Request,
+            user: base_models.APIUser,
+            data_connector_id: ULID,
+            etag: str | None,
+            validator: RenkuRCloneValidator,
         ) -> HTTPResponse:
             data_connector = await self.data_connector_repo.get_data_connector(
                 user=user, data_connector_id=data_connector_id
@@ -195,7 +202,7 @@ class DataConnectorsBP(CustomBlueprint):
             user: base_models.APIUser,
             slug: Slug,
             etag: str | None,
-            validator: RCloneValidator,
+            validator: RenkuRCloneValidator,
         ) -> HTTPResponse:
             data_connector = await self.data_connector_repo.get_global_data_connector_by_slug(user=user, slug=slug)
 
@@ -222,7 +229,7 @@ class DataConnectorsBP(CustomBlueprint):
             namespace: str,
             slug: Slug,
             etag: str | None,
-            validator: RCloneValidator,
+            validator: RenkuRCloneValidator,
         ) -> HTTPResponse:
             data_connector = await self.data_connector_repo.get_data_connector_by_slug(
                 user=user,
@@ -253,7 +260,7 @@ class DataConnectorsBP(CustomBlueprint):
             project_slug: Slug,
             dc_slug: Slug,
             etag: str | None,
-            validator: RCloneValidator,
+            validator: RenkuRCloneValidator,
         ) -> HTTPResponse:
             dc_path = DataConnectorInProjectPath.from_strings(
                 ns_slug.value,
@@ -291,7 +298,7 @@ class DataConnectorsBP(CustomBlueprint):
             data_connector_id: ULID,
             body: apispec.DataConnectorPatch,
             etag: str,
-            validator: RCloneValidator,
+            validator: RenkuRCloneValidator,
         ) -> JSONResponse:
             existing_dc = await self.data_connector_repo.get_data_connector(
                 user=user, data_connector_id=data_connector_id
@@ -539,7 +546,7 @@ class DataConnectorsBP(CustomBlueprint):
 
     @staticmethod
     def _dump_data_connector(
-        data_connector: models.DataConnector | models.GlobalDataConnector, validator: RCloneValidator
+        data_connector: models.DataConnector | models.GlobalDataConnector, validator: RenkuRCloneValidator
     ) -> dict[str, Any]:
         """Dumps a data connector for API responses."""
         storage = dump_storage_with_sensitive_fields(data_connector.storage, validator=validator)

--- a/components/renku_data_services/data_connectors/core.py
+++ b/components/renku_data_services/data_connectors/core.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import base64
 import contextlib
-import re
 from collections.abc import AsyncIterator
 from dataclasses import asdict
 from datetime import datetime
-from html.parser import HTMLParser
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
@@ -51,8 +49,12 @@ from renku_data_services.data_connectors import apispec, models
 from renku_data_services.data_connectors.config import DepositConfig
 from renku_data_services.data_connectors.constants import ALLOWED_GLOBAL_DATA_CONNECTOR_PROVIDERS
 from renku_data_services.data_connectors.doi import schema_org
-from renku_data_services.data_connectors.doi.metadata import create_envidat_metadata_url, get_metadata
-from renku_data_services.data_connectors.doi.models import DOI, SchemaOrgDataset
+from renku_data_services.data_connectors.doi.metadata import (
+    DOIProviders,
+    ParsedDOIMetadata,
+    get_metadata,
+)
+from renku_data_services.data_connectors.doi.models import DOI
 from renku_data_services.k8s.client_interfaces import K8sClient
 from renku_data_services.k8s.clients import DepositUploadJobClient
 from renku_data_services.k8s.constants import DEFAULT_K8S_CLUSTER, ClusterId
@@ -60,7 +62,7 @@ from renku_data_services.k8s.models import GVK, K8sObject, K8sObjectMeta
 from renku_data_services.notebooks.data_sources import DataSourceRepository
 from renku_data_services.storage import models as storage_models
 from renku_data_services.storage.constants import ENVIDAT_V1_PROVIDER
-from renku_data_services.storage.rclone import RCloneDOIMetadata, RCloneValidator, convert_rclone_configuration
+from renku_data_services.storage.rclone import RCloneValidator, convert_rclone_configuration
 from renku_data_services.utils.core import get_openbis_pat
 
 if TYPE_CHECKING:
@@ -90,12 +92,9 @@ def dump_storage_with_sensitive_fields(
     return body
 
 
-def _validate_unsaved_storage_url(
-    storage: apispec.CloudStorageUrlV2, validator: RCloneValidator
-) -> models.CloudStorageCore:
+def _convert_unsaved_storage_url(storage: apispec.CloudStorageUrlV2) -> models.CloudStorageCore:
     """Validate the unsaved storage when its configuration is specified as a URL."""
     config, source_path = storage_models.storage_url_parser(storage.storage_url)
-    validator.validate(config)
     return models.CloudStorageCore(
         storage_type=config["type"],
         configuration=config.config,
@@ -105,13 +104,9 @@ def _validate_unsaved_storage_url(
     )
 
 
-def _validate_unsaved_storage_generic(
-    storage: apispec.CloudStorageCorePost, validator: RCloneValidator
-) -> models.CloudStorageCore:
+def _convert_unsaved_storage_generic(storage: apispec.CloudStorageCorePost) -> models.CloudStorageCore:
     """Validate the unsaved storage when its configuration is specified as a URL."""
     configuration = storage.configuration
-    pure_rclone_configuration = convert_rclone_configuration(configuration)
-    validator.validate(pure_rclone_configuration)
     storage_type = configuration.get("type")
     if not isinstance(storage_type, str):
         raise errors.ValidationError()
@@ -125,24 +120,16 @@ def _validate_unsaved_storage_generic(
     )
 
 
-async def _validate_unsaved_storage_doi(
-    storage: apispec.CloudStorageCorePost, validator: RCloneValidator
-) -> tuple[models.CloudStorageCore, DOI]:
+async def _convert_rclone_doi_config(
+    storage: apispec.CloudStorageCorePost, metadata: ParsedDOIMetadata, doi: DOI
+) -> models.CloudStorageCore:
     """Validate the storage configuration of an unsaved data connector."""
-
     configuration: dict[str, Any]
     source_path: str
 
-    doi_str = storage.configuration.get("doi")
-    if not isinstance(doi_str, str):
-        raise errors.ValidationError(message="Cannot find the doi in the storage configuration")
-
-    doi = DOI(doi_str)
-    doi_host = await doi.resolve_host()
-
-    match doi_host:
-        case "envidat.ch" | "www.envidat.ch":
-            converted_storage = await convert_envidat_v1_data_connector_to_s3(storage)
+    match metadata.provider:
+        case DOIProviders.envidat_v1:
+            converted_storage = await convert_envidat_v1_data_connector_to_s3(storage, metadata)
             configuration = converted_storage.configuration
             source_path = converted_storage.source_path or "/"
             storage_type = ENVIDAT_V1_PROVIDER
@@ -152,15 +139,13 @@ async def _validate_unsaved_storage_doi(
             source_path = storage.source_path or "/"
             storage_type = storage.storage_type or "doi"
 
-    validator.validate(configuration)
-
     return models.CloudStorageCore(
         storage_type=storage_type,
         configuration=configuration,
         source_path=source_path,
         target_path=storage.target_path,
         readonly=storage.readonly,
-    ), doi
+    )
 
 
 async def validate_unsaved_data_connector(
@@ -171,14 +156,19 @@ async def validate_unsaved_data_connector(
     keywords = [kw.root for kw in body.keywords] if body.keywords is not None else []
     match body.storage:
         case apispec.CloudStorageCorePost() if body.storage.storage_type != "doi":
-            storage = _validate_unsaved_storage_generic(body.storage, validator=validator)
+            storage = _convert_unsaved_storage_generic(body.storage)
         case apispec.CloudStorageCorePost() if body.storage.storage_type == "doi":
-            storage, _ = await _validate_unsaved_storage_doi(body.storage, validator=validator)
+            doi = _extract_doi(body.storage.configuration)
+            doi_metadata = await get_metadata(doi)
+            if doi_metadata is None:
+                raise errors.ValidationError()
+            storage = await _convert_rclone_doi_config(body.storage, doi_metadata, doi)
         case apispec.CloudStorageUrlV2():
-            storage = _validate_unsaved_storage_url(body.storage, validator=validator)
+            storage = _convert_unsaved_storage_url(body.storage)
         case _:
             raise errors.ValidationError(message="The data connector provided has an unknown payload format.")
 
+    validator.validate(storage.configuration)
     if body.namespace is None:
         raise NotImplementedError("Missing namespace not supported")
 
@@ -205,31 +195,40 @@ async def validate_unsaved_data_connector(
     )
 
 
+def _extract_doi(data: dict[str, Any]) -> DOI:
+    doi_str = data.get("doi")
+    if not isinstance(doi_str, str):
+        raise errors.ValidationError(message="Cannot find the doi in the storage configuration")
+
+    return DOI(doi_str)
+
+
 async def prevalidate_unsaved_global_data_connector(
     body: apispec.GlobalDataConnectorPost, validator: RCloneValidator
 ) -> models.PrevalidatedGlobalDataConnector:
-    """Pre-validate an unsaved data connector."""
+    """Pre-validate an unsaved data connector.
+
+    Deals with putting together the metadata and the proper RClone configuration.
+    """
     # TODO: allow admins to create global data connectors, e.g. s3://giab
     if isinstance(body.storage, apispec.CloudStorageUrlV2):
         raise errors.ValidationError(message="Global data connectors cannot be configured via a URL.")
-    storage, doi = await _validate_unsaved_storage_doi(body.storage, validator=validator)
+
+    doi = _extract_doi(body.storage.configuration)
+    doi_metadata = await get_metadata(doi)
+    if doi_metadata is None:
+        raise errors.ValidationError()
+    storage = await _convert_rclone_doi_config(body.storage, doi_metadata, doi)
+    validator.validate(storage.configuration)
+
     if storage.storage_type not in ALLOWED_GLOBAL_DATA_CONNECTOR_PROVIDERS:
         raise errors.ValidationError(message="Only doi storage type is allowed for global data connectors")
     if not storage.readonly:
         raise errors.ValidationError(message="Global data connectors must be read-only")
 
-    rclone_metadata: RCloneDOIMetadata | None = None
     doi_uri = f"doi:{doi}"
-    if storage.storage_type == "doi":
-        # This means that the storage is most likely supported by Rclone, by calling the get_doi_metadata we confirm
-        rclone_metadata = await validator.get_doi_metadata(configuration=storage.configuration)
-        if not rclone_metadata:
-            raise errors.ValidationError(message="The provided DOI is not supported.")
-        # Override provider in storage config
-        storage.configuration["provider"] = rclone_metadata.provider
 
     slug = base_models.Slug.from_name(doi_uri).value
-    doi_metadata = await doi.metadata()
     return models.PrevalidatedGlobalDataConnector(
         data_connector=models.UnsavedGlobalDataConnector(
             name=doi_uri,
@@ -241,13 +240,13 @@ async def prevalidate_unsaved_global_data_connector(
             keywords=[],
             doi=doi,
             publisher_url=None
-            if doi_metadata is None or doi_metadata.publisher is None
-            else doi_metadata.publisher.url,
+            if doi_metadata is None or doi_metadata.dataset.publisher is None
+            else doi_metadata.dataset.publisher.url,
             publisher_name=None
-            if doi_metadata is None or doi_metadata.publisher is None
-            else doi_metadata.publisher.name,
+            if doi_metadata is None or doi_metadata.dataset.publisher is None
+            else doi_metadata.dataset.publisher.name,
         ),
-        rclone_metadata=rclone_metadata,
+        rclone_metadata=doi_metadata.dataset.to_doi_metadata(),
     )
 
 
@@ -255,7 +254,10 @@ async def validate_unsaved_global_data_connector(
     prevalidated_dc: models.PrevalidatedGlobalDataConnector,
     validator: RCloneValidator,
 ) -> models.UnsavedGlobalDataConnector:
-    """Validate the data connector."""
+    """Validate the data connector.
+
+    Tests the RClone configuration by trying to connect.
+    """
     data_connector = prevalidated_dc.data_connector
     doi = prevalidated_dc.data_connector.doi
 
@@ -271,34 +273,11 @@ async def validate_unsaved_global_data_connector(
             message="The provided storage configuration is not currently working", detail=connection_result.error
         )
 
-    # Fetch DOI metadata
-    metadata = await get_metadata(doi)
-
-    name = data_connector.name
-    description = ""
-    keywords: list[str] = []
-    if metadata is not None:
-        name = metadata.name or name
-        description = _html_to_text(metadata.description or "")
-        keywords = metadata.keywords
-
-    # Fix metadata if needed
-    if len(name) > 99:
-        name = f"{name[:96]}..."
-    if len(description) > 500:
-        description = f"{description[:497]}..."
-    fixed_keywords: list[str] = []
-    for word in keywords:
-        for kw in word.strip().split(","):
-            with contextlib.suppress(PydanticValidationError):
-                fixed_keywords.append(apispec.Keyword.model_validate(kw.strip()).root)
-    keywords = fixed_keywords
-
     # Assign user-friendly target_path if possible
     target_path = data_connector.slug
     target_path_extension: str | None = None
     with contextlib.suppress(errors.ValidationError):
-        target_path_extension = base_models.Slug.from_name(name).value
+        target_path_extension = base_models.Slug.from_name(data_connector.name).value
     # If we were not able to get metadata about the dataset earlier,
     # the slug and the name are essentially both the same and equal to the doi.
     # And if we extend the target_path in this case it just repeats the slug twice.
@@ -317,13 +296,13 @@ async def validate_unsaved_global_data_connector(
     )
 
     return models.UnsavedGlobalDataConnector(
-        name=name,
+        name=data_connector.name,
         slug=data_connector.slug,
         visibility=Visibility.PUBLIC,
         created_by="",
         storage=storage,
-        description=description or None,
-        keywords=keywords,
+        description=data_connector.description,
+        keywords=data_connector.keywords,
         doi=data_connector.doi,
         publisher_name=data_connector.publisher_name,
         publisher_url=data_connector.publisher_url,
@@ -419,40 +398,6 @@ def validate_data_connector_secrets_patch(
     ]
 
 
-def _html_to_text(html: str) -> str:
-    """Returns the text content of an html snippet."""
-    try:
-        f = _HTMLToText()
-        f.feed(html)
-        content = f.text
-
-        # Cleanup whitespace characters
-        content = content.strip()
-        content = content.strip("\n")
-        content = re.sub(" ( )+", " ", content)
-        content = re.sub("\n\n(\n)+", "\n\n", content)
-        content = re.sub("\n( )+", "\n", content)
-
-        return content
-    except Exception:
-        return html
-
-
-class _HTMLToText(HTMLParser):
-    """Parses HTML into text content."""
-
-    def __init__(self, *, convert_charrefs: bool = True) -> None:
-        super().__init__(convert_charrefs=convert_charrefs)
-        self._text = ""
-
-    @property
-    def text(self) -> str:
-        return self._text
-
-    def handle_data(self, data: str) -> None:
-        self._text += data
-
-
 async def openbis_transform_session_token_to_pat(
     unsaved_secrets: list[models.DataConnectorSecretUpdate], openbis_host: str
 ) -> tuple[list[models.DataConnectorSecretUpdate], datetime]:
@@ -505,45 +450,13 @@ def transform_secrets_for_front_end(
 
 
 async def convert_envidat_v1_data_connector_to_s3(
-    payload: apispec.CloudStorageCorePost,
+    payload: apispec.CloudStorageCorePost, metadata: ParsedDOIMetadata
 ) -> apispec.CloudStorageCorePost:
     """Converts a doi-like configuration for Envidat to S3."""
-    config = payload.configuration
-    doi = config.get("doi")
-    if not isinstance(doi, str):
-        if doi is None:
-            raise errors.ValidationError(
-                message="Cannot get configuration for Envidat data connector because "
-                "the doi is missing from the payload."
-            )
-        raise errors.ValidationError(
-            message=f"Cannot get configuration for Envidat data connector because the doi '{doi}' "
-            "in the payload is not a string."
-        )
-    if len(doi) == 0:
-        raise errors.ValidationError(
-            message="Cannot get configuration for Envidat data connector because the doi is a string with zero length."
-        )
-    doi = DOI(doi)
-
     new_config = payload.model_copy(deep=True)
     new_config.configuration = {}
-
-    envidat_url = create_envidat_metadata_url(doi)
-    headers = {"accept": "application/json"}
-
-    clnt = httpx.AsyncClient(follow_redirects=True, timeout=5)
-    async with clnt:
-        res = await clnt.get(envidat_url, headers=headers)
-        if res.status_code != 200:
-            raise errors.ValidationError(
-                message="Cannot get configuration for Envidat data connector because Envidat responded "
-                f"with an unexpected {res.status_code} status code at {res.url}.",
-                detail=f"Response from envidat: {res.text}",
-            )
-    dataset = SchemaOrgDataset.model_validate_json(res.text)
     s3_config = schema_org.get_rclone_config(
-        dataset,
+        metadata.dataset,
         schema_org.DatasetProvider.envidat,
     )
     new_config.configuration = dict(s3_config.rclone_config)

--- a/components/renku_data_services/data_connectors/core.py
+++ b/components/renku_data_services/data_connectors/core.py
@@ -51,7 +51,7 @@ from renku_data_services.data_connectors import apispec, models
 from renku_data_services.data_connectors.config import DepositConfig
 from renku_data_services.data_connectors.constants import ALLOWED_GLOBAL_DATA_CONNECTOR_PROVIDERS
 from renku_data_services.data_connectors.doi import schema_org
-from renku_data_services.data_connectors.doi.metadata import create_envidat_metadata_url, get_dataset_metadata
+from renku_data_services.data_connectors.doi.metadata import create_envidat_metadata_url, get_metadata
 from renku_data_services.data_connectors.doi.models import DOI, SchemaOrgDataset
 from renku_data_services.k8s.client_interfaces import K8sClient
 from renku_data_services.k8s.clients import DepositUploadJobClient
@@ -258,7 +258,6 @@ async def validate_unsaved_global_data_connector(
     """Validate the data connector."""
     data_connector = prevalidated_dc.data_connector
     doi = prevalidated_dc.data_connector.doi
-    rclone_metadata = prevalidated_dc.rclone_metadata
 
     if not doi:
         raise errors.ValidationError(message="Global data connectors require a DOI.")
@@ -273,20 +272,14 @@ async def validate_unsaved_global_data_connector(
         )
 
     # Fetch DOI metadata
-    if rclone_metadata:
-        metadata = await get_dataset_metadata(rclone_metadata.provider, rclone_metadata.metadata_url)
-    elif data_connector.storage.storage_type == ENVIDAT_V1_PROVIDER:
-        metadata_url = create_envidat_metadata_url(doi)
-        metadata = await get_dataset_metadata(ENVIDAT_V1_PROVIDER, metadata_url)
-    else:
-        metadata = None
+    metadata = await get_metadata(doi)
 
     name = data_connector.name
     description = ""
     keywords: list[str] = []
     if metadata is not None:
         name = metadata.name or name
-        description = _html_to_text(metadata.description)
+        description = _html_to_text(metadata.description or "")
         keywords = metadata.keywords
 
     # Fix metadata if needed

--- a/components/renku_data_services/data_connectors/core.py
+++ b/components/renku_data_services/data_connectors/core.py
@@ -60,7 +60,7 @@ from renku_data_services.k8s.models import GVK, K8sObject, K8sObjectMeta
 from renku_data_services.notebooks.data_sources import DataSourceRepository
 from renku_data_services.storage import models as storage_models
 from renku_data_services.storage.constants import ENVIDAT_V1_PROVIDER
-from renku_data_services.storage.rclone import RCloneDOIMetadata, RCloneValidator
+from renku_data_services.storage.rclone import RCloneDOIMetadata, RCloneValidator, convert_rclone_configuration
 from renku_data_services.utils.core import get_openbis_pat
 
 if TYPE_CHECKING:
@@ -90,7 +90,7 @@ def dump_storage_with_sensitive_fields(
     return body
 
 
-def validate_unsaved_storage_url(
+def _validate_unsaved_storage_url(
     storage: apispec.CloudStorageUrlV2, validator: RCloneValidator
 ) -> models.CloudStorageCore:
     """Validate the unsaved storage when its configuration is specified as a URL."""
@@ -105,15 +105,17 @@ def validate_unsaved_storage_url(
     )
 
 
-def validate_unsaved_storage_generic(
+def _validate_unsaved_storage_generic(
     storage: apispec.CloudStorageCorePost, validator: RCloneValidator
 ) -> models.CloudStorageCore:
     """Validate the unsaved storage when its configuration is specified as a URL."""
     configuration = storage.configuration
-    validator.validate(configuration)
+    pure_rclone_configuration = convert_rclone_configuration(configuration)
+    validator.validate(pure_rclone_configuration)
     storage_type = configuration.get("type")
     if not isinstance(storage_type, str):
         raise errors.ValidationError()
+    configuration = convert_rclone_configuration(configuration)
     return models.CloudStorageCore(
         storage_type=storage_type,
         configuration=configuration,
@@ -123,7 +125,7 @@ def validate_unsaved_storage_generic(
     )
 
 
-async def validate_unsaved_storage_doi(
+async def _validate_unsaved_storage_doi(
     storage: apispec.CloudStorageCorePost, validator: RCloneValidator
 ) -> tuple[models.CloudStorageCore, DOI]:
     """Validate the storage configuration of an unsaved data connector."""
@@ -169,11 +171,11 @@ async def validate_unsaved_data_connector(
     keywords = [kw.root for kw in body.keywords] if body.keywords is not None else []
     match body.storage:
         case apispec.CloudStorageCorePost() if body.storage.storage_type != "doi":
-            storage = validate_unsaved_storage_generic(body.storage, validator=validator)
+            storage = _validate_unsaved_storage_generic(body.storage, validator=validator)
         case apispec.CloudStorageCorePost() if body.storage.storage_type == "doi":
-            storage, _ = await validate_unsaved_storage_doi(body.storage, validator=validator)
+            storage, _ = await _validate_unsaved_storage_doi(body.storage, validator=validator)
         case apispec.CloudStorageUrlV2():
-            storage = validate_unsaved_storage_url(body.storage, validator=validator)
+            storage = _validate_unsaved_storage_url(body.storage, validator=validator)
         case _:
             raise errors.ValidationError(message="The data connector provided has an unknown payload format.")
 
@@ -210,7 +212,7 @@ async def prevalidate_unsaved_global_data_connector(
     # TODO: allow admins to create global data connectors, e.g. s3://giab
     if isinstance(body.storage, apispec.CloudStorageUrlV2):
         raise errors.ValidationError(message="Global data connectors cannot be configured via a URL.")
-    storage, doi = await validate_unsaved_storage_doi(body.storage, validator=validator)
+    storage, doi = await _validate_unsaved_storage_doi(body.storage, validator=validator)
     if storage.storage_type not in ALLOWED_GLOBAL_DATA_CONNECTOR_PROVIDERS:
         raise errors.ValidationError(message="Only doi storage type is allowed for global data connectors")
     if not storage.readonly:

--- a/components/renku_data_services/data_connectors/core.py
+++ b/components/renku_data_services/data_connectors/core.py
@@ -94,20 +94,12 @@ def validate_unsaved_storage_url(
     storage: apispec.CloudStorageUrlV2, validator: RCloneValidator
 ) -> models.CloudStorageCore:
     """Validate the unsaved storage when its configuration is specified as a URL."""
-    cloud_storage = storage_models.UnsavedCloudStorage.from_url(
-        project_id="FAKEPROJECTID",
-        name="fake-storage-name",
-        storage_url=storage.storage_url,
-        target_path=storage.target_path,
-        readonly=storage.readonly,
-    )
-    configuration = cloud_storage.configuration.config
-    source_path = cloud_storage.source_path
-    validator.validate(configuration)
+    config, source_path = storage_models.storage_url_parser(storage.storage_url)
+    validator.validate(config)
     return models.CloudStorageCore(
-        storage_type=configuration["type"],
-        configuration=configuration,
-        source_path=source_path,
+        storage_type=config["type"],
+        configuration=models.SingleConfig.validated(config.config),
+        source_path=source_path.as_posix(),
         target_path=storage.target_path,
         readonly=storage.readonly,
     )

--- a/components/renku_data_services/data_connectors/core.py
+++ b/components/renku_data_services/data_connectors/core.py
@@ -98,7 +98,7 @@ def validate_unsaved_storage_url(
     validator.validate(config)
     return models.CloudStorageCore(
         storage_type=config["type"],
-        configuration=models.SingleConfig.validated(config.config),
+        configuration=config.config,
         source_path=source_path.as_posix(),
         target_path=storage.target_path,
         readonly=storage.readonly,

--- a/components/renku_data_services/data_connectors/db.py
+++ b/components/renku_data_services/data_connectors/db.py
@@ -42,7 +42,7 @@ from renku_data_services.search.db import SearchUpdatesRepo
 from renku_data_services.search.decorators import update_search_document
 from renku_data_services.secrets import orm as secrets_schemas
 from renku_data_services.secrets.models import SecretKind
-from renku_data_services.storage.rclone import RCloneValidator
+from renku_data_services.storage.rclone import RenkuRCloneValidator, convert_rclone_configuration
 from renku_data_services.users.db import UserRepo
 from renku_data_services.utils.core import with_db_transaction
 
@@ -326,7 +326,7 @@ class DataConnectorRepository:
             name=data_connector.name,
             visibility=visibility_orm,
             storage_type=data_connector.storage.storage_type,
-            configuration=data_connector.storage.configuration,
+            configuration=convert_rclone_configuration(data_connector.storage.configuration),
             source_path=data_connector.storage.source_path,
             target_path=data_connector.storage.target_path,
             readonly=data_connector.storage.readonly,
@@ -377,7 +377,7 @@ class DataConnectorRepository:
         self,
         user: base_models.APIUser,
         prevalidated_dc: models.PrevalidatedGlobalDataConnector,
-        validator: RCloneValidator | None,
+        validator: RenkuRCloneValidator,
         *,
         session: AsyncSession | None = None,
     ) -> tuple[models.GlobalDataConnector, bool]:
@@ -405,8 +405,6 @@ class DataConnectorRepository:
 
         # Fully validate a global data connector before inserting
         if isinstance(data_connector, models.UnsavedGlobalDataConnector):
-            if validator is None:
-                raise RuntimeError("Could not validate global data connector")
             data_connector = await validate_unsaved_global_data_connector(
                 prevalidated_dc=prevalidated_dc, validator=validator
             )

--- a/components/renku_data_services/data_connectors/doi/metadata.py
+++ b/components/renku_data_services/data_connectors/doi/metadata.py
@@ -3,118 +3,10 @@
 from urllib.parse import urlencode
 
 import httpx
+from pydantic import AnyHttpUrl
 from pydantic import ValidationError as PydanticValidationError
 
 from renku_data_services.data_connectors.doi import models
-from renku_data_services.storage.constants import ENVIDAT_V1_PROVIDER
-
-
-async def get_dataset_metadata(provider: str, metadata_url: str) -> models.DOIMetadata | None:
-    """Retrieve DOI metadata."""
-    if provider == "invenio" or provider == "zenodo":
-        return await _get_dataset_metadata_invenio(metadata_url)
-    if provider == "dataverse":
-        return await _get_dataset_metadata_dataverse(metadata_url)
-    if provider == ENVIDAT_V1_PROVIDER:
-        return await _get_envidat_metadata(metadata_url)
-    return None
-
-
-async def _get_dataset_metadata_invenio(metadata_url: str) -> models.DOIMetadata | None:
-    """Retrieve DOI metadata from the InvenioRDM API."""
-    async with httpx.AsyncClient(timeout=5) as client:
-        try:
-            res = await client.get(url=metadata_url, follow_redirects=True, headers=[("accept", "application/json")])
-            if res.status_code >= 400:
-                return None
-            record = models.InvenioRecord.model_validate_json(res.content)
-        except httpx.HTTPError:
-            return None
-        except PydanticValidationError:
-            return None
-
-    name = ""
-    description = ""
-    keywords = []
-    if record.metadata is not None:
-        name = record.metadata.title or ""
-        description = record.metadata.description or ""
-        keywords = record.metadata.keywords or []
-    return models.DOIMetadata(name=name, description=description, keywords=keywords)
-
-
-async def _get_dataset_metadata_dataverse(metadata_url: str) -> models.DOIMetadata | None:
-    """Retrieve DOI metadata from the Dataverse API."""
-
-    async with httpx.AsyncClient(timeout=5) as client:
-        try:
-            res = await client.get(url=metadata_url, follow_redirects=True, headers=[("accept", "application/json")])
-            if res.status_code >= 400:
-                return None
-            response = models.DataverseDatasetResponse.model_validate_json(res.content)
-        except httpx.HTTPError:
-            return None
-        except PydanticValidationError:
-            return None
-
-    if response.status != "OK":
-        return None
-
-    name = ""
-    description = ""
-    keywords: list[str] = []
-    if (
-        response.data is not None
-        and response.data.latest_version is not None
-        and response.data.latest_version.metadata_blocks is not None
-        and response.data.latest_version.metadata_blocks.citation is not None
-    ):
-        for field in response.data.latest_version.metadata_blocks.citation.fields:
-            if field.type_name == "title" and field.type_class == "primitive" and not field.multiple:
-                name = str(field.value)
-            if (
-                field.type_name == "dsDescription"
-                and field.type_class == "compound"
-                and field.multiple
-                and isinstance(field.value, list)
-                and field.value
-            ):
-                try:
-                    description_field = models.DataverseMetadataBlockCitationField.model_validate(
-                        field.value[0].get("dsDescriptionValue", dict())
-                    )
-                    if (
-                        description_field.type_name == "dsDescriptionValue"
-                        and description_field.type_class == "primitive"
-                        and not description_field.multiple
-                    ):
-                        description = str(description_field.value)
-                except AttributeError:
-                    pass
-                except PydanticValidationError:
-                    pass
-            if (
-                field.type_name == "keyword"
-                and field.type_class == "compound"
-                and field.multiple
-                and isinstance(field.value, list)
-            ):
-                for value in field.value:
-                    try:
-                        kw_field = models.DataverseMetadataBlockCitationField.model_validate(
-                            value.get("keywordValue", dict())
-                        )
-                        if (
-                            kw_field.type_name == "keywordValue"
-                            and kw_field.type_class == "primitive"
-                            and not kw_field.multiple
-                        ):
-                            keywords.append(str(kw_field.value))
-                    except AttributeError:
-                        pass
-                    except PydanticValidationError:
-                        pass
-    return models.DOIMetadata(name=name, description=description, keywords=keywords)
 
 
 def create_envidat_metadata_url(doi: models.DOI) -> str:
@@ -124,7 +16,7 @@ def create_envidat_metadata_url(doi: models.DOI) -> str:
     return f"{url}?{params}"
 
 
-async def _get_envidat_metadata(metadata_url: str) -> models.DOIMetadata | None:
+async def _get_envidat_metadata(metadata_url: str) -> models.SchemaOrgDataset | None:
     """Get metadata about the envidat dataset."""
     clnt = httpx.AsyncClient(follow_redirects=True, timeout=5)
     headers = {"accept": "application/json"}
@@ -139,6 +31,31 @@ async def _get_envidat_metadata(metadata_url: str) -> models.DOIMetadata | None:
         parsed_metadata = models.SchemaOrgDataset.model_validate_json(res.text)
     except PydanticValidationError:
         return None
-    return models.DOIMetadata(
-        name=parsed_metadata.name, description=parsed_metadata.description or "", keywords=parsed_metadata.keywords
-    )
+    return parsed_metadata
+
+
+async def get_metadata(doi: models.DOI) -> models.SchemaOrgDataset | None:
+    """Get metadata for a specific doi."""
+    clnt = httpx.AsyncClient(follow_redirects=True, timeout=5)
+    res = await clnt.get(f"https://doi.org/api/handles/{doi}", follow_redirects=True)
+    if res.status_code != 200:
+        return None
+    handles_data = models.DOIHandles.model_validate_json(res.text)
+
+    match handles_data.url:
+        case None:
+            dataset = await doi.metadata()
+        case AnyHttpUrl(host=None):
+            dataset = await doi.metadata()
+        case AnyHttpUrl(host=host) if host and host.endswith("psi.ch"):
+            raise NotImplementedError()
+        case AnyHttpUrl(host=host) if host and host.endswith("envidat.ch"):
+            dataset = await _get_envidat_metadata(create_envidat_metadata_url(doi))
+        case AnyHttpUrl(host=host) if host and host.endswith("zenodo.org"):
+            dataset = await doi.metadata()
+        case AnyHttpUrl(host="dataverse.harvard.ch"):
+            dataset = await doi.metadata()
+        case _:
+            dataset = await doi.metadata()
+
+    return dataset

--- a/components/renku_data_services/data_connectors/doi/metadata.py
+++ b/components/renku_data_services/data_connectors/doi/metadata.py
@@ -1,12 +1,19 @@
 """Metadata handling for DOIs."""
 
+import contextlib
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from html.parser import HTMLParser
 from urllib.parse import urlencode
 
 import httpx
 from pydantic import AnyHttpUrl
 from pydantic import ValidationError as PydanticValidationError
 
+from renku_data_services.data_connectors import apispec
 from renku_data_services.data_connectors.doi import models
+from renku_data_services.storage.constants import ENVIDAT_V1_PROVIDER
 
 
 def create_envidat_metadata_url(doi: models.DOI) -> str:
@@ -34,13 +41,31 @@ async def _get_envidat_metadata(metadata_url: str) -> models.SchemaOrgDataset | 
     return parsed_metadata
 
 
-async def get_metadata(doi: models.DOI) -> models.SchemaOrgDataset | None:
+class DOIProviders(StrEnum):
+    """List of supported doi providers."""
+
+    doi = "doi"
+    "Supported by Rclone"
+    envidat_v1 = ENVIDAT_V1_PROVIDER
+    "Only supported by Renku"
+
+
+@dataclass
+class ParsedDOIMetadata:
+    """DOI metadata that has been parsed."""
+
+    dataset: models.SchemaOrgDataset
+    provider: DOIProviders
+
+
+async def get_metadata(doi: models.DOI) -> ParsedDOIMetadata | None:
     """Get metadata for a specific doi."""
     clnt = httpx.AsyncClient(follow_redirects=True, timeout=5)
     res = await clnt.get(f"https://doi.org/api/handles/{doi}", follow_redirects=True)
     if res.status_code != 200:
         return None
     handles_data = models.DOIHandles.model_validate_json(res.text)
+    provider = DOIProviders.doi
 
     match handles_data.url:
         case None:
@@ -51,6 +76,7 @@ async def get_metadata(doi: models.DOI) -> models.SchemaOrgDataset | None:
             raise NotImplementedError()
         case AnyHttpUrl(host=host) if host and host.endswith("envidat.ch"):
             dataset = await _get_envidat_metadata(create_envidat_metadata_url(doi))
+            provider = DOIProviders.envidat_v1
         case AnyHttpUrl(host=host) if host and host.endswith("zenodo.org"):
             dataset = await doi.metadata()
         case AnyHttpUrl(host="dataverse.harvard.ch"):
@@ -58,4 +84,60 @@ async def get_metadata(doi: models.DOI) -> models.SchemaOrgDataset | None:
         case _:
             dataset = await doi.metadata()
 
-    return dataset
+    if dataset is None:
+        return None
+    description = _html_to_text(dataset.description or "")
+    keywords = dataset.keywords
+
+    # Fix metadata if needed
+    name = dataset.name
+    if len(name) > 99:
+        name = f"{name[:96]}..."
+    if len(description) > 500:
+        description = f"{description[:497]}..."
+    fixed_keywords: list[str] = []
+    for word in keywords:
+        for kw in word.strip().split(","):
+            with contextlib.suppress(PydanticValidationError):
+                fixed_keywords.append(apispec.Keyword.model_validate(kw.strip()).root)
+    keywords = fixed_keywords
+
+    dataset.name = name
+    dataset.description = description
+    dataset.keywords = keywords
+
+    return ParsedDOIMetadata(dataset=dataset, provider=provider)
+
+
+def _html_to_text(html: str) -> str:
+    """Returns the text content of an html snippet."""
+    try:
+        f = _HTMLToText()
+        f.feed(html)
+        content = f.text
+
+        # Cleanup whitespace characters
+        content = content.strip()
+        content = content.strip("\n")
+        content = re.sub(" ( )+", " ", content)
+        content = re.sub("\n\n(\n)+", "\n\n", content)
+        content = re.sub("\n( )+", "\n", content)
+
+        return content
+    except Exception:
+        return html
+
+
+class _HTMLToText(HTMLParser):
+    """Parses HTML into text content."""
+
+    def __init__(self, *, convert_charrefs: bool = True) -> None:
+        super().__init__(convert_charrefs=convert_charrefs)
+        self._text = ""
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def handle_data(self, data: str) -> None:
+        self._text += data

--- a/components/renku_data_services/data_connectors/doi/models.py
+++ b/components/renku_data_services/data_connectors/doi/models.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Annotated, Literal, Self
 from urllib.parse import urlparse
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, ValidationError
 
 from renku_data_services.errors import errors
 
@@ -89,60 +89,6 @@ class DOIMetadata:
     keywords: list[str]
 
 
-class InvenioRecordMetadata(BaseModel):
-    """Representation of a record's metadata."""
-
-    title: str | None = Field(default=None)
-    description: str | None = Field(default=None)
-    keywords: list[str] | None = Field(default=None)
-
-
-class InvenioRecord(BaseModel):
-    """Schema for the representation of a record from the InvenioRDM API."""
-
-    metadata: InvenioRecordMetadata | None = Field(default=None)
-
-
-class DataverseMetadataBlockCitationField(BaseModel):
-    """A metadata field of citation metadata."""
-
-    type_name: str = Field(alias="typeName")
-    multiple: bool = Field()
-    type_class: str = Field(alias="typeClass")
-    value: Any = Field()  # TODO: can we find better types here?
-
-
-class DataverseMetadataBlockCitation(BaseModel):
-    """Representation of citation metadata."""
-
-    fields: list[DataverseMetadataBlockCitationField] = Field(default_factory=list)
-
-
-class DataverseMetadataBlocks(BaseModel):
-    """Represents metadata of a Dataverse dataset."""
-
-    citation: DataverseMetadataBlockCitation | None = Field()
-
-
-class DataverseDatasetVersion(BaseModel):
-    """Representation of a dataset version."""
-
-    metadata_blocks: DataverseMetadataBlocks | None = Field(alias="metadataBlocks")
-
-
-class DataverseDataset(BaseModel):
-    """Representation of a dataset in Dataverse."""
-
-    latest_version: DataverseDatasetVersion | None = Field(alias="latestVersion")
-
-
-class DataverseDatasetResponse(BaseModel):
-    """DataverseDatasetResponse is returned by the Dataverse dataset API."""
-
-    status: str = Field()
-    data: DataverseDataset | None = Field()
-
-
 class SchemaOrgDistribution(BaseModel):
     """The distribution field of a schema.org dataset."""
 
@@ -160,11 +106,16 @@ class SchemaOrgDataset(BaseModel):
     description: str | None = None
     raw_keywords: str = Field(alias="keywords", default="")
     publisher: SchemaOrgPublisher | None = None
+    provider: SchemaOrgProvider | None = None
 
     @property
     def keywords(self) -> list[str]:
         """Split the single keywords string into a list."""
         return [i.strip() for i in self.raw_keywords.split(",")]
+
+    def to_doi_metadata(self) -> DOIMetadata:
+        """Convert to an alternative metdata representation."""
+        return DOIMetadata(name=self.name, description=self.description or "", keywords=self.keywords)
 
 
 class SchemaOrgPublisher(BaseModel):
@@ -186,3 +137,49 @@ class SchemaOrgPublisher(BaseModel):
         if parsed.scheme not in ["http", "https"]:
             return None
         return self.id.rstrip("/")
+
+
+class SchemaOrgProvider(BaseModel):
+    """The schema.org provider field in a dataset."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: str | None = Field(alias="@type", default=None)
+    name: str
+
+
+class DOIHandles(BaseModel):
+    """The response from the doi handles endpoint."""
+
+    model_config = ConfigDict(extra="ignore")
+    values: list[Annotated[DOIHandlesUrl | DOIHandlesUndefined, Field(union_mode="left_to_right")]]
+
+    @property
+    def url(self) -> AnyHttpUrl | None:
+        """Get the provider url the doi would resolve to."""
+        for i in self.values:
+            if isinstance(i, DOIHandlesUrl):
+                return i.data.value
+        return None
+
+
+class DOIHandlesUrl(BaseModel):
+    """The url from the doi handles endpoint."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["URL"]
+    data: DOIHandlesUrlData
+
+
+class DOIHandlesUndefined(BaseModel):
+    """Can contain arbitrary data from the doi handles endpoint."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: str
+
+
+class DOIHandlesUrlData(BaseModel):
+    """The url from the doi handles endpoint."""
+
+    model_config = ConfigDict(extra="ignore")
+    format: Literal["string"]
+    value: AnyHttpUrl

--- a/components/renku_data_services/data_connectors/doi/models.py
+++ b/components/renku_data_services/data_connectors/doi/models.py
@@ -107,11 +107,20 @@ class SchemaOrgDataset(BaseModel):
     raw_keywords: str = Field(alias="keywords", default="")
     publisher: SchemaOrgPublisher | None = None
     provider: SchemaOrgProvider | None = None
+    _parsed_keywords: list[str] | None = Field(exclude=True, init=False, repr=False)
 
     @property
     def keywords(self) -> list[str]:
         """Split the single keywords string into a list."""
-        return [i.strip() for i in self.raw_keywords.split(",")]
+        if self._parsed_keywords is not None:
+            return self._parsed_keywords
+        self._parsed_keywords = [i.strip() for i in self.raw_keywords.split(",")]
+        return self._parsed_keywords
+
+    @keywords.setter
+    def keywords(self, value: list[str]) -> None:
+        """Set the keywords."""
+        self._parsed_keywords = value
 
     def to_doi_metadata(self) -> DOIMetadata:
         """Convert to an alternative metdata representation."""

--- a/components/renku_data_services/data_connectors/models.py
+++ b/components/renku_data_services/data_connectors/models.py
@@ -18,11 +18,10 @@ from renku_data_services.base_models.core import (
     NamespacePath,
     ProjectPath,
 )
-from renku_data_services.data_connectors.doi.models import DOI
+from renku_data_services.data_connectors.doi.models import DOI, DOIMetadata
 from renku_data_services.k8s.constants import ClusterId
 from renku_data_services.k8s.models import GVK, K8sObjectMeta
 from renku_data_services.namespace.models import GroupNamespace, ProjectNamespace, UserNamespace
-from renku_data_services.storage.rclone import RCloneDOIMetadata
 from renku_data_services.utils.etag import compute_etag_from_fields
 
 if TYPE_CHECKING:
@@ -126,7 +125,7 @@ class PrevalidatedGlobalDataConnector:
     """Global data connector model that is unsaved but has been pre-validated."""
 
     data_connector: UnsavedGlobalDataConnector
-    rclone_metadata: RCloneDOIMetadata | None = None
+    rclone_metadata: DOIMetadata
 
 
 @dataclass(frozen=True, eq=True, kw_only=True)

--- a/components/renku_data_services/notebooks/api/schemas/cloud_storage.py
+++ b/components/renku_data_services/notebooks/api/schemas/cloud_storage.py
@@ -3,8 +3,7 @@
 import json
 from configparser import ConfigParser
 from io import StringIO
-from pathlib import PurePosixPath
-from typing import Any, Final, Optional, Protocol, Self
+from typing import Any, Final, Optional, Protocol
 
 from kubernetes import client
 from marshmallow import EXCLUDE, Schema, ValidationError, fields, validates_schema

--- a/components/renku_data_services/notebooks/api/schemas/cloud_storage.py
+++ b/components/renku_data_services/notebooks/api/schemas/cloud_storage.py
@@ -11,7 +11,6 @@ from marshmallow import EXCLUDE, Schema, ValidationError, fields, validates_sche
 
 from renku_data_services.k8s.models import sanitizer
 from renku_data_services.notebooks.api.classes.cloud_storage import ICloudStorageRequest
-from renku_data_services.storage.models import CloudStorage
 from renku_data_services.storage.rclone import RCloneValidator
 
 
@@ -73,41 +72,6 @@ class RCloneStorage(ICloudStorageRequest):
         self.storage_class = storage_class
         validator = RCloneValidator()
         validator.inject_default_values(self.configuration)
-
-    @classmethod
-    async def storage_from_schema(
-        cls,
-        data: dict[str, Any],
-        work_dir: PurePosixPath,
-        saved_storage: CloudStorage | None,
-        storage_class: str,
-        user_secret_key: str | None = None,
-    ) -> Self:
-        """Create storage object from request."""
-        name = None
-        if saved_storage:
-            configuration = {**saved_storage.configuration.model_dump(), **(data.get("configuration", {}))}
-            readonly = saved_storage.readonly
-            name = saved_storage.name
-        else:
-            source_path = data["source_path"]
-            target_path = data["target_path"]
-            configuration = data["configuration"]
-            readonly = data.get("readonly", True)
-
-        # NOTE: This is used only in Renku v1, there we do not save secrets for storage
-        secrets: dict[str, str] = {}
-        mount_folder = str(work_dir / target_path)
-        return cls(
-            source_path=source_path,
-            configuration=configuration,
-            readonly=readonly,
-            mount_folder=mount_folder,
-            name=name,
-            storage_class=storage_class,
-            secrets=secrets,
-            user_secret_key=user_secret_key,
-        )
 
     def pvc(
         self,

--- a/components/renku_data_services/storage/blueprints.py
+++ b/components/renku_data_services/storage/blueprints.py
@@ -13,7 +13,7 @@ from renku_data_services.base_api.blueprint import BlueprintFactoryResponse, Cus
 from renku_data_services.base_models.validation import validated_json
 from renku_data_services.notebooks.data_sources import DataSourceRepository
 from renku_data_services.storage import apispec
-from renku_data_services.storage.rclone import RCloneValidator
+from renku_data_services.storage.rclone import RenkuRCloneValidator
 
 
 @dataclass(kw_only=True)
@@ -26,7 +26,7 @@ class StorageSchemaBP(CustomBlueprint):
     def get(self) -> BlueprintFactoryResponse:
         """Get cloud storage for a repository."""
 
-        async def _get(_: Request, validator: RCloneValidator) -> JSONResponse:
+        async def _get(_: Request, validator: RenkuRCloneValidator) -> JSONResponse:
             return validated_json(apispec.RCloneSchema, validator.asdict())
 
         return "/storage_schema", ["GET"], _get
@@ -39,7 +39,7 @@ class StorageSchemaBP(CustomBlueprint):
         async def _test_connection(
             request: Request,
             user: base_models.APIUser,
-            validator: RCloneValidator,
+            validator: RenkuRCloneValidator,
             body: apispec.StorageSchemaTestConnectionPostRequest,
         ) -> HTTPResponse:
             validator.validate(body.configuration, keep_sensitive=True)
@@ -57,7 +57,7 @@ class StorageSchemaBP(CustomBlueprint):
 
         @validate(json=apispec.RCloneConfigValidate)
         async def _validate(
-            request: Request, validator: RCloneValidator, body: apispec.RCloneConfigValidate
+            request: Request, validator: RenkuRCloneValidator, body: apispec.RCloneConfigValidate
         ) -> HTTPResponse:
             if body.root is None:
                 raise errors.ValidationError(message="The request body is empty. Please provide a valid JSON object.")
@@ -71,7 +71,7 @@ class StorageSchemaBP(CustomBlueprint):
 
         @validate(json=apispec.StorageSchemaObscurePostRequest)
         async def _obscure(
-            request: Request, validator: RCloneValidator, body: apispec.StorageSchemaObscurePostRequest
+            request: Request, validator: RenkuRCloneValidator, body: apispec.StorageSchemaObscurePostRequest
         ) -> JSONResponse:
             config = await validator.obscure_config(body.configuration)
             return validated_json(apispec.RCloneConfigValidate, config)

--- a/components/renku_data_services/storage/models.py
+++ b/components/renku_data_services/storage/models.py
@@ -1,11 +1,15 @@
 """Models for cloud storage."""
 
+from __future__ import annotations
+
+import configparser
 from collections.abc import Generator, MutableMapping
-from typing import Any
+from copy import deepcopy
+from pathlib import PurePosixPath
+from typing import IO, Any
 from urllib.parse import ParseResult, urlparse
 
 from pydantic import BaseModel, Field, PrivateAttr, model_serializer, model_validator
-from ulid import ULID
 
 from renku_data_services import errors
 from renku_data_services.storage.rclone import RCloneValidator
@@ -51,88 +55,21 @@ class RCloneConfig(BaseModel, MutableMapping):
         yield from self.config.keys()
 
 
-class UnsavedCloudStorage(BaseModel):
-    """Cloud Storage model."""
+def storage_url_parser(storage_url: str) -> tuple[RCloneConfig, PurePosixPath]:
+    """Get Cloud Storage/rclone config from a storage URL.
 
-    project_id: str = Field(pattern=r"^[A-Z0-9]+$")
-    name: str = Field(min_length=3)
-    storage_type: str = Field(pattern=r"^[a-z0-9]+$")
-    configuration: RCloneConfig
-    readonly: bool = Field(default=True)
-
-    source_path: str = Field()
-    """Path inside the cloud storage.
-
-    Note: Since rclone itself doesn't really know about buckets/containers (they're not in the schema),
-    bucket/container/etc. has to be the first part of source path.
+    Example:
+        Supported URLs are:
+        - s3://s3.<region>.amazonaws.com/<bucket>/<path>
+        - s3://<bucket>.s3.<region>.amazonaws.com/<path>
+        - s3://bucket/
+        - http(s)://<endpoint>/<bucket>/<path>
+        - (azure|az)://<account>.dfs.core.windows.net/<container>/<path>
+        - (azure|az)://<account>.blob.core.windows.net/<container>/<path>
+        - (azure|az)://<container>/<path>
     """
 
-    target_path: str = Field(min_length=1)
-    """Path inside the target repository to mount/clone data to."""
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "UnsavedCloudStorage":
-        """Create the model from a plain dictionary."""
-
-        if "project_id" not in data:
-            raise errors.ValidationError(message="'project_id' not set")
-        if "configuration" not in data:
-            raise errors.ValidationError(message="'configuration' not set")
-
-        if "source_path" not in data:
-            raise errors.ValidationError(message="'source_path' not set")
-
-        if "target_path" not in data:
-            raise errors.ValidationError(message="'target_path' not set")
-
-        if "type" not in data["configuration"]:
-            raise errors.ValidationError(message="'type' not set in 'configuration'")
-
-        return cls(
-            project_id=data["project_id"],
-            name=data["name"],
-            configuration=RCloneConfig(config=data["configuration"]),
-            storage_type=data["configuration"]["type"],
-            source_path=data["source_path"],
-            target_path=data["target_path"],
-            readonly=data.get("readonly", True),
-        )
-
-    @classmethod
-    def from_url(
-        cls, storage_url: str, name: str, readonly: bool, project_id: str, target_path: str
-    ) -> "UnsavedCloudStorage":
-        """Get Cloud Storage/rclone config from a storage URL.
-
-        Example:
-            Supported URLs are:
-            - s3://s3.<region>.amazonaws.com/<bucket>/<path>
-            - s3://<bucket>.s3.<region>.amazonaws.com/<path>
-            - s3://bucket/
-            - http(s)://<endpoint>/<bucket>/<path>
-            - (azure|az)://<account>.dfs.core.windows.net/<container>/<path>
-            - (azure|az)://<account>.blob.core.windows.net/<container>/<path>
-            - (azure|az)://<container>/<path>
-        """
-        parsed_url = urlparse(storage_url)
-
-        if parsed_url.scheme is None:
-            raise errors.ValidationError(message="Couldn't parse scheme of 'storage_url'")
-
-        match parsed_url.scheme:
-            case "s3":
-                return UnsavedCloudStorage.from_s3_url(parsed_url, project_id, name, readonly, target_path)
-            case "azure" | "az":
-                return UnsavedCloudStorage.from_azure_url(parsed_url, project_id, name, readonly, target_path)
-            case "http" | "https":
-                return UnsavedCloudStorage._from_ambiguous_url(parsed_url, project_id, name, readonly, target_path)
-            case _:
-                raise errors.ValidationError(message=f"Scheme '{parsed_url.scheme}' is not supported.")
-
-    @classmethod
-    def from_s3_url(
-        cls, storage_url: ParseResult, project_id: str, name: str, readonly: bool, target_path: str
-    ) -> "UnsavedCloudStorage":
+    def from_s3_url(storage_url: ParseResult) -> tuple[RCloneConfig, PurePosixPath]:
         """Get Cloud storage from an S3 URL.
 
         Example:
@@ -163,20 +100,9 @@ class UnsavedCloudStorage(BaseModel):
         else:
             configuration["endpoint"] = storage_url.netloc
 
-        return UnsavedCloudStorage(
-            project_id=project_id,
-            name=name,
-            storage_type="s3",
-            configuration=RCloneConfig(config=configuration),
-            source_path=source_path,
-            target_path=target_path,
-            readonly=readonly,
-        )
+        return RCloneConfig(config=configuration), PurePosixPath(source_path)
 
-    @classmethod
-    def from_azure_url(
-        cls, storage_url: ParseResult, project_id: str, name: str, readonly: bool, target_path: str
-    ) -> "UnsavedCloudStorage":
+    def from_azure_url(storage_url: ParseResult) -> tuple[RCloneConfig, PurePosixPath]:
         """Get Cloud storage from an Azure URL.
 
         Example:
@@ -199,32 +125,30 @@ class UnsavedCloudStorage(BaseModel):
                     raise errors.ValidationError(message="Host cannot contain dots unless it's a core.windows.net URL")
 
                 source_path = f"{storage_url.hostname}{storage_url.path}"
-        return UnsavedCloudStorage(
-            project_id=project_id,
-            name=name,
-            storage_type="azureblob",
-            configuration=RCloneConfig(config=configuration),
-            source_path=source_path,
-            target_path=target_path,
-            readonly=readonly,
-        )
+        return RCloneConfig(config=configuration), PurePosixPath(source_path)
 
-    @classmethod
-    def _from_ambiguous_url(
-        cls, storage_url: ParseResult, project_id: str, name: str, readonly: bool, target_path: str
-    ) -> "UnsavedCloudStorage":
+    def _from_ambiguous_url(storage_url: ParseResult) -> tuple[RCloneConfig, PurePosixPath]:
         """Get cloud storage from an ambiguous storage url."""
         if storage_url.hostname is None:
             raise errors.ValidationError(message="Storage URL must contain a host")
 
         if storage_url.hostname.endswith(".windows.net"):
-            return UnsavedCloudStorage.from_azure_url(storage_url, project_id, name, readonly, target_path)
+            return from_azure_url(storage_url)
 
         # default to S3 for unknown URLs, since these are way more common
-        return UnsavedCloudStorage.from_s3_url(storage_url, project_id, name, readonly, target_path)
+        return from_s3_url(storage_url)
 
+    parsed_url = urlparse(storage_url)
 
-class CloudStorage(UnsavedCloudStorage):
-    """Cloudstorage saved in the database."""
+    if parsed_url.scheme is None:
+        raise errors.ValidationError(message="Couldn't parse scheme of 'storage_url'")
 
-    storage_id: ULID = Field()
+    match parsed_url.scheme:
+        case "s3":
+            return from_s3_url(parsed_url)
+        case "azure" | "az":
+            return from_azure_url(parsed_url)
+        case "http" | "https":
+            return _from_ambiguous_url(parsed_url)
+        case _:
+            raise errors.ValidationError(message=f"Scheme '{parsed_url.scheme}' is not supported.")

--- a/components/renku_data_services/storage/models.py
+++ b/components/renku_data_services/storage/models.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import configparser
 from collections.abc import Generator, MutableMapping
-from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import IO, Any
+from typing import Any
 from urllib.parse import ParseResult, urlparse
 
 from pydantic import BaseModel, Field, PrivateAttr, model_serializer, model_validator
@@ -23,7 +21,7 @@ class RCloneConfig(BaseModel, MutableMapping):
     _validator: RCloneValidator = PrivateAttr(default=RCloneValidator())
 
     @model_validator(mode="after")
-    def check_rclone_schema(self) -> "RCloneConfig":
+    def check_rclone_schema(self) -> RCloneConfig:
         """Validate that the reclone config is valid."""
         self._validator.validate(self.config)
         return self

--- a/components/renku_data_services/storage/rclone.py
+++ b/components/renku_data_services/storage/rclone.py
@@ -154,36 +154,6 @@ class RCloneValidator:
         provider = self.get_provider(configuration)
         return provider.get_private_fields(configuration)
 
-    async def get_doi_metadata(self, configuration: Union[RCloneConfig, dict[str, Any]]) -> RCloneDOIMetadata | None:
-        """Returns the metadata of a DOI remote."""
-        provider = self.get_provider(configuration)
-        if provider.name != "doi":
-            raise errors.ValidationError(message="Configuration is not of type DOI")
-
-        # Obscure configuration and transform if needed
-        obscured_config = await self.obscure_config(configuration)
-
-        with tempfile.NamedTemporaryFile(mode="w+", delete=False, encoding="utf-8") as f:
-            config = "\n".join(f"{k}={v}" for k, v in obscured_config.items())
-            f.write(f"[temp]\n{config}")
-            f.close()
-            proc = await asyncio.create_subprocess_exec(
-                "rclone",
-                "backend",
-                "metadata",
-                "--config",
-                f.name,
-                "temp:",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await proc.communicate()
-            success = proc.returncode == 0
-        if success:
-            metadata = RCloneDOIMetadata.model_validate_json(stdout.decode().strip())
-            return metadata
-        return None
-
     def inject_default_values(self, config: Union[RCloneConfig, dict[str, Any]]) -> Union[RCloneConfig, dict[str, Any]]:
         """Adds default values for required options that are not provided in the config."""
         provider = self.get_provider(config)
@@ -552,12 +522,3 @@ def convert_rclone_configuration(configuration: dict[str, Any]) -> dict[str, Any
     __transform_polybox_switchdriver_config(configuration)
     __transform_envidat_config(configuration)
     return configuration
-
-
-class RCloneDOIMetadata(BaseModel):
-    """Schema for metadata provided by rclone about a DOI remote."""
-
-    doi: str = Field(alias="DOI")
-    url: str = Field(alias="URL")
-    metadata_url: str = Field(alias="metadataURL")
-    provider: str = Field()

--- a/components/renku_data_services/storage/rclone.py
+++ b/components/renku_data_services/storage/rclone.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import tempfile
 from collections.abc import Generator
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, Union, cast
 
@@ -37,18 +38,7 @@ class RCloneValidator:
     def __init__(self) -> None:
         """Initialize with contained schema file."""
         spec = RCloneValidator._get_spec()
-
-        apply_patches(spec)
-
-        self.providers: dict[str, RCloneProviderSchema] = {}
-
-        for provider_config in spec:
-            try:
-                provider_schema = RCloneProviderSchema.model_validate(provider_config)
-                self.providers[provider_schema.prefix] = provider_schema
-            except ValidationError:
-                logger.error("Couldn't load RClone config: %s", provider_config)
-                raise
+        self.providers = RCloneValidator._get_providers(spec)
 
     def validate(self, configuration: Union[RCloneConfig, dict[str, Any]], keep_sensitive: bool = False) -> None:
         """Validates an RClone config."""
@@ -69,21 +59,6 @@ class RCloneValidator:
                 continue
             raise errors.ValidationError(message=f"The '{key}' property is not marked as sensitive.")
 
-    def get_real_configuration(self, configuration: Union[RCloneConfig, dict[str, Any]]) -> dict[str, Any]:
-        """Converts a Renku rclone configuration to a real rclone config."""
-        real_config = dict(configuration)
-
-        if real_config["type"] == "s3" and real_config.get("provider") == "Switch":
-            # Switch is a fake provider we add for users, we need to replace it since rclone itself
-            # doesn't know it
-            real_config["provider"] = "Other"
-        elif configuration["type"] == "openbis":
-            real_config["type"] = "sftp"
-            real_config["port"] = "2222"
-            real_config["user"] = "?"
-            real_config["pass"] = real_config.pop("session_token")
-        return real_config
-
     async def test_connection(
         self,
         configuration: Union[RCloneConfig, dict[str, Any]],
@@ -98,9 +73,7 @@ class RCloneValidator:
             return ConnectionResult(False, str(e))
 
         # Obscure configuration and transform if needed
-        obscured_config = await self.obscure_config(self.get_real_configuration(configuration))
-        transformed_config = self.inject_default_values(self.transform_polybox_switchdriver_config(obscured_config))
-        transformed_config = self.transform_envidat_config(transformed_config)
+        transformed_config = await self.obscure_config(configuration)
 
         # Handle testing with Renku integrations
         if user is not None and data_source_repo is not None:
@@ -126,7 +99,7 @@ class RCloneValidator:
             storage_type = cast(str, configuration.get("type"))
             if storage_type == "sftp":
                 args.extend(["--low-level-retries", "1"])
-            logger.debug(f"Execute: rclone {" ".join(args)}")
+            logger.debug(f"Execute: rclone {' '.join(args)}")
             proc = await asyncio.create_subprocess_exec(
                 "rclone",
                 *args,
@@ -231,61 +204,26 @@ class RCloneValidator:
         return config
 
     @staticmethod
-    def transform_polybox_switchdriver_config(
-        configuration: Union[RCloneConfig, dict[str, Any]],
-    ) -> Union[RCloneConfig, dict[str, Any]]:
-        """Transform the configuration for public access."""
-        storage_type = configuration.get("type")
-
-        # Only process Polybox or SwitchDrive configurations
-        if storage_type not in {"polybox", "switchDrive"}:
-            return configuration
-
-        configuration["type"] = "webdav"
-
-        provider = configuration.get("provider")
-
-        if provider == "personal":
-            configuration["url"] = configuration.get("url") or (
-                "https://polybox.ethz.ch/remote.php/webdav/"
-                if storage_type == "polybox"
-                else "https://drive.switch.ch/remote.php/webdav/"
-            )
-            return configuration
-
-        ## Set url and username when is a shared configuration
-        configuration["url"] = (
-            "https://polybox.ethz.ch/public.php/webdav/"
-            if storage_type == "polybox"
-            else "https://drive.switch.ch/public.php/webdav/"
-        )
-        public_link = configuration.get("public_link")
-
-        if not public_link:
-            raise ValueError("Missing 'public_link' for public access configuration.")
-
-        # Extract the user from the public link
-        configuration["user"] = public_link.split("/")[-1]
-
-        return configuration
-
-    @staticmethod
-    def transform_envidat_config(configuration: RCloneConfig | dict[str, Any]) -> RCloneConfig | dict[str, Any]:
-        """Used to convert the configuration for Envidat into a real configuration."""
-        storage_type = configuration.get("type")
-        if storage_type is None:
-            return configuration
-        if storage_type != ENVIDAT_V1_PROVIDER:
-            return configuration
-        configuration["type"] = "doi"
-        return configuration
-
-    @staticmethod
     def _get_spec() -> Any:
         """Get the rclone spec file."""
         with open(Path(__file__).parent / "rclone_schema.autogenerated.json") as f:
             spec = json.load(f)
         return spec
+
+    @staticmethod
+    def _get_providers(spec: Any) -> dict[str, RCloneProviderSchema]:
+        """Read the spec and parse it into a dict of Providers."""
+        providers: dict[str, RCloneProviderSchema] = {}
+
+        for provider_config in spec:
+            try:
+                provider_schema = RCloneProviderSchema.model_validate(provider_config)
+                providers[provider_schema.prefix] = provider_schema
+            except ValidationError:
+                logger.error("Couldn't load RClone config: %s", provider_config)
+                raise
+
+        return providers
 
 
 class RCloneTriState(BaseModel):
@@ -517,6 +455,103 @@ class RCloneProviderSchema(BaseModel):
             if option.name not in configuration:
                 continue
             yield option
+
+
+class RenkuRCloneValidator(RCloneValidator):
+    """RCloneValidator that is aware of all the Renku-specific providers that are not real RClone providers."""
+
+    @staticmethod
+    def _get_spec() -> Any:
+        """Get the rclone spec file."""
+        spec = RCloneValidator._get_spec()
+        apply_patches(spec)
+        return spec
+
+    async def test_connection(
+        self,
+        configuration: Union[RCloneConfig, dict[str, Any]],
+        source_path: str,
+        user: base_models.APIUser | None = None,
+        data_source_repo: DataSourceRepository | None = None,
+    ) -> ConnectionResult:
+        """Tests connecting with an RClone config."""
+        transformed_config = convert_rclone_configuration(
+            configuration.config if isinstance(configuration, RCloneConfig) else configuration
+        )
+        return await super().test_connection(transformed_config, source_path, user, data_source_repo)
+
+
+def __transform_polybox_switchdriver_config(configuration: Union[RCloneConfig, dict[str, Any]]) -> None:
+    """Transform the configuration for public access."""
+    storage_type = configuration.get("type")
+
+    # Only process Polybox or SwitchDrive configurations
+    if storage_type not in {"polybox", "switchDrive"}:
+        return None
+
+    configuration["type"] = "webdav"
+
+    provider = configuration.get("provider")
+
+    if provider == "personal":
+        configuration["url"] = configuration.get("url") or (
+            "https://polybox.ethz.ch/remote.php/webdav/"
+            if storage_type == "polybox"
+            else "https://drive.switch.ch/remote.php/webdav/"
+        )
+        return None
+
+    ## Set url and username when is a shared configuration
+    configuration["url"] = (
+        "https://polybox.ethz.ch/public.php/webdav/"
+        if storage_type == "polybox"
+        else "https://drive.switch.ch/public.php/webdav/"
+    )
+    public_link = configuration.get("public_link")
+
+    if not public_link:
+        raise ValueError("Missing 'public_link' for public access configuration.")
+
+    # Extract the user from the public link
+    configuration["user"] = public_link.split("/")[-1]
+
+
+def __transform_envidat_config(configuration: RCloneConfig | dict[str, Any]) -> None:
+    """Used to convert the configuration for Envidat into a real configuration."""
+    storage_type = configuration.get("type")
+    if storage_type is None:
+        return None
+    if storage_type != ENVIDAT_V1_PROVIDER:
+        return None
+    configuration["type"] = "doi"
+
+
+def __transform_switch_config(configuration: RCloneConfig | dict[str, Any]) -> None:
+    """Converts a Renku specific Switch S3 config into a regular RClone config."""
+    if configuration["type"] != "s3" or configuration.get("provider") != "Switch":
+        return
+    # Switch is a fake provider we add for users, we need to replace it since rclone itself
+    # doesn't know it
+    configuration["provider"] = "Other"
+
+
+def __transform_openbis_config(configuration: RCloneConfig | dict[str, Any]) -> None:
+    if configuration["type"] != "openbis":
+        return None
+    configuration["type"] = "sftp"
+    configuration["port"] = "2222"
+    configuration["user"] = "?"
+    configuration["pass"] = configuration.pop("session_token")
+
+
+def convert_rclone_configuration(configuration: dict[str, Any]) -> dict[str, Any]:
+    """Converts a Renku-specific RClone configuration into a regular RClone configuration."""
+    configuration = deepcopy(configuration)
+    __transform_switch_config(configuration)
+    __transform_openbis_config(configuration)
+    __transform_polybox_switchdriver_config(configuration)
+    __transform_envidat_config(configuration)
+    return configuration
 
 
 class RCloneDOIMetadata(BaseModel):

--- a/test/components/renku_data_services/data_connectors/test_doi.py
+++ b/test/components/renku_data_services/data_connectors/test_doi.py
@@ -1,7 +1,15 @@
+import json
+from datetime import datetime
+
 import pytest
 
 from renku_data_services.data_connectors.doi.models import DOI
+from renku_data_services.data_connectors.models import CloudStorageCore
+from renku_data_services.data_connectors.orm import DataConnectorORM
 from renku_data_services.errors import errors
+from renku_data_services.namespace.orm import EntitySlugOldORM, EntitySlugORM
+from renku_data_services.storage.models import RCloneConfig
+from renku_data_services.storage.rclone import RCloneValidator
 
 
 @pytest.mark.parametrize(
@@ -40,3 +48,30 @@ def test_valid_doi_parsing(raw_doi: str, expected_value: str) -> None:
 def test_invalid_doi_parsing(raw_doi: str) -> None:
     with pytest.raises(errors.ValidationError):
         DOI(raw_doi)
+
+
+def test_storage_configs() -> None:
+    storage_from_db = DataConnectorORM(
+        name="giab",
+        visibility="private",
+        storage_type="s3",
+        configuration=json.loads('{"type": "s3", "provider": "AWS"}'),
+        source_path="giab",
+        target_path="external_storage/giab",
+        created_by_id="d18366ec-de3a-4275-828b-c1df8e53da86",
+        description=None,
+        keywords=None,
+        readonly=True,
+        creation_date=datetime.fromisoformat("2024-10-22 11:02:10.864+0200"),
+        updated_at=datetime.fromisoformat("2024-10-22 11:02:10.864+0200"),
+        doi=None,
+        publisher_name=None,
+        publisher_url=None,
+        global_slug="test",
+    )
+    dumped = storage_from_db.dump()
+    assert isinstance(dumped.storage, CloudStorageCore)
+    validator = RCloneValidator()
+    validator.validate(dumped.storage.configuration)
+    # How does and when CloudStorageCore get converted to RCloneConfig
+    breakpoint()

--- a/test/components/renku_data_services/data_connectors/test_doi.py
+++ b/test/components/renku_data_services/data_connectors/test_doi.py
@@ -7,8 +7,6 @@ from renku_data_services.data_connectors.doi.models import DOI
 from renku_data_services.data_connectors.models import CloudStorageCore
 from renku_data_services.data_connectors.orm import DataConnectorORM
 from renku_data_services.errors import errors
-from renku_data_services.namespace.orm import EntitySlugOldORM, EntitySlugORM
-from renku_data_services.storage.models import RCloneConfig
 from renku_data_services.storage.rclone import RCloneValidator
 
 


### PR DESCRIPTION
This is very much WIP. I want to do it before we have to handle more complicated multi-remote Rclone configurations for SciCat datasets. But there is nothing in this PR for SciCat, that will come in followup prs.

/deploy

